### PR TITLE
[#81] add watchOS target

### DIFF
--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |spec|
   spec.social_media_url = "http://twitter.com/omaralbeik"
   spec.screenshot  = 'https://raw.githubusercontent.com/omaralbeik/SwifterSwift/master/logo.png'
 
-  spec.platforms = { :ios => "8.0", :tvos => "9.0" }
+  spec.platforms = { :ios => "8.0", :tvos => "9.0", :watchos => "3.0" }
   spec.requires_arc = true
   spec.source = { git: "https://github.com/omaralbeik/SwifterSwift.git", tag: "v#{spec.version}" }
   spec.source_files = "Source/**/*.swift"

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -57,6 +57,25 @@
 		07445BCC1E11D1EF000E9A85 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BC01E11D1EF000E9A85 /* StringExtensionsTests.swift */; };
 		07445BCD1E11D1EF000E9A85 /* SwifterSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BC11E11D1EF000E9A85 /* SwifterSwiftTests.swift */; };
 		077805591E11D0FD000A21C6 /* SwifterSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0778054F1E11D0FC000A21C6 /* SwifterSwift.framework */; };
+		6E4933561E25093B00210167 /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A6F1E11DDDD0021AB84 /* ArrayExtensions.swift */; };
+		6E4933571E25093B00210167 /* BoolExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A701E11DDDD0021AB84 /* BoolExtensions.swift */; };
+		6E4933581E25093B00210167 /* CharacterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A711E11DDDD0021AB84 /* CharacterExtensions.swift */; };
+		6E4933591E25093B00210167 /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A721E11DDDD0021AB84 /* CollectionExtensions.swift */; };
+		6E49335A1E25093B00210167 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A731E11DDDD0021AB84 /* DataExtensions.swift */; };
+		6E49335B1E25093B00210167 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A741E11DDDD0021AB84 /* DateExtensions.swift */; };
+		6E49335C1E25093B00210167 /* DictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A751E11DDDD0021AB84 /* DictionaryExtensions.swift */; };
+		6E49335D1E25093B00210167 /* DoubleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A761E11DDDD0021AB84 /* DoubleExtensions.swift */; };
+		6E49335E1E25093B00210167 /* FloatExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A771E11DDDD0021AB84 /* FloatExtensions.swift */; };
+		6E49335F1E25093B00210167 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A781E11DDDD0021AB84 /* IntExtensions.swift */; };
+		6E4933601E25093B00210167 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A791E11DDDD0021AB84 /* StringExtensions.swift */; };
+		6E4933621E25094100210167 /* CGFloatExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A7C1E11DDDD0021AB84 /* CGFloatExtensions.swift */; };
+		6E4933631E25094100210167 /* CGPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A7D1E11DDDD0021AB84 /* CGPointExtensions.swift */; };
+		6E4933641E25094100210167 /* CGSizeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A7E1E11DDDD0021AB84 /* CGSizeExtensions.swift */; };
+		6E4933651E25094100210167 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A7F1E11DDDD0021AB84 /* NSAttributedStringExtensions.swift */; };
+		6E49336A1E25094100210167 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A841E11DDDD0021AB84 /* UIColorExtensions.swift */; };
+		6E49336B1E25094100210167 /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A851E11DDDD0021AB84 /* UIImageExtensions.swift */; };
+		6E4933731E25094100210167 /* UISliderExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A8D1E11DDDD0021AB84 /* UISliderExtensions.swift */; };
+		6E4933741E25094100210167 /* UISwitchExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A8E1E11DDDD0021AB84 /* UISwitchExtensions.swift */; };
 		6EBD19E71E23E444002186D3 /* SwifterSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EBD19DE1E23E444002186D3 /* SwifterSwift.framework */; };
 		6EBD19F51E23E49B002186D3 /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BB61E11D1EF000E9A85 /* ArrayExtensionsTests.swift */; };
 		6EBD19F61E23E49E002186D3 /* CGFloatExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BB71E11D1EF000E9A85 /* CGFloatExtensionsTests.swift */; };
@@ -180,6 +199,7 @@
 		07445BC11E11D1EF000E9A85 /* SwifterSwiftTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterSwiftTests.swift; sourceTree = "<group>"; };
 		0778054F1E11D0FC000A21C6 /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		077805581E11D0FD000A21C6 /* SwifterSwift iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6E49334E1E2508C000210167 /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EBD19DE1E23E444002186D3 /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EBD19E61E23E444002186D3 /* SwifterSwift tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -197,6 +217,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				077805591E11D0FD000A21C6 /* SwifterSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6E49334A1E2508C000210167 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,6 +334,7 @@
 				077805581E11D0FD000A21C6 /* SwifterSwift iOSTests.xctest */,
 				6EBD19DE1E23E444002186D3 /* SwifterSwift.framework */,
 				6EBD19E61E23E444002186D3 /* SwifterSwift tvOSTests.xctest */,
+				6E49334E1E2508C000210167 /* SwifterSwift.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -329,6 +357,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				072F7ABD1E11DDDD0021AB84 /* SwifterSwift.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6E49334B1E2508C000210167 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -378,6 +413,24 @@
 			productName = SwifterSwiftTests;
 			productReference = 077805581E11D0FD000A21C6 /* SwifterSwift iOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6E49334D1E2508C000210167 /* SwifterSwift watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6E4933551E2508C100210167 /* Build configuration list for PBXNativeTarget "SwifterSwift watchOS" */;
+			buildPhases = (
+				6E4933491E2508C000210167 /* Sources */,
+				6E49334A1E2508C000210167 /* Frameworks */,
+				6E49334B1E2508C000210167 /* Headers */,
+				6E49334C1E2508C000210167 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwifterSwift watchOS";
+			productName = "SwifterSwift watchOS";
+			productReference = 6E49334E1E2508C000210167 /* SwifterSwift.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		6EBD19DD1E23E444002186D3 /* SwifterSwift tvOS */ = {
 			isa = PBXNativeTarget;
@@ -433,6 +486,10 @@
 						CreatedOnToolsVersion = 8.2.1;
 						ProvisioningStyle = Automatic;
 					};
+					6E49334D1E2508C000210167 = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+					};
 					6EBD19DD1E23E444002186D3 = {
 						CreatedOnToolsVersion = 8.2.1;
 						ProvisioningStyle = Automatic;
@@ -459,6 +516,7 @@
 				077805571E11D0FD000A21C6 /* SwifterSwift iOSTests */,
 				6EBD19DD1E23E444002186D3 /* SwifterSwift tvOS */,
 				6EBD19E51E23E444002186D3 /* SwifterSwift tvOSTests */,
+				6E49334D1E2508C000210167 /* SwifterSwift watchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -472,6 +530,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		077805561E11D0FD000A21C6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6E49334C1E2508C000210167 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -556,6 +621,32 @@
 				07445BC91E11D1EF000E9A85 /* FloatExtensionsTests.swift in Sources */,
 				07445BCC1E11D1EF000E9A85 /* StringExtensionsTests.swift in Sources */,
 				07445BC71E11D1EF000E9A85 /* DictionaryExtensionsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6E4933491E2508C000210167 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6E49336B1E25094100210167 /* UIImageExtensions.swift in Sources */,
+				6E4933561E25093B00210167 /* ArrayExtensions.swift in Sources */,
+				6E4933651E25094100210167 /* NSAttributedStringExtensions.swift in Sources */,
+				6E49335C1E25093B00210167 /* DictionaryExtensions.swift in Sources */,
+				6E49335E1E25093B00210167 /* FloatExtensions.swift in Sources */,
+				6E4933591E25093B00210167 /* CollectionExtensions.swift in Sources */,
+				6E4933571E25093B00210167 /* BoolExtensions.swift in Sources */,
+				6E49335F1E25093B00210167 /* IntExtensions.swift in Sources */,
+				6E4933601E25093B00210167 /* StringExtensions.swift in Sources */,
+				6E4933621E25094100210167 /* CGFloatExtensions.swift in Sources */,
+				6E49335D1E25093B00210167 /* DoubleExtensions.swift in Sources */,
+				6E49335A1E25093B00210167 /* DataExtensions.swift in Sources */,
+				6E4933641E25094100210167 /* CGSizeExtensions.swift in Sources */,
+				6E4933631E25094100210167 /* CGPointExtensions.swift in Sources */,
+				6E4933731E25094100210167 /* UISliderExtensions.swift in Sources */,
+				6E49336A1E25094100210167 /* UIColorExtensions.swift in Sources */,
+				6E4933741E25094100210167 /* UISwitchExtensions.swift in Sources */,
+				6E4933581E25093B00210167 /* CharacterExtensions.swift in Sources */,
+				6E49335B1E25093B00210167 /* DateExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -798,6 +889,50 @@
 			};
 			name = Release;
 		};
+		6E4933531E2508C100210167 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.omaralbeik.SwifterSwift;
+				PRODUCT_NAME = SwifterSwift;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.1;
+			};
+			name = Debug;
+		};
+		6E4933541E2508C100210167 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.omaralbeik.SwifterSwift;
+				PRODUCT_NAME = SwifterSwift;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.1;
+			};
+			name = Release;
+		};
 		6EBD19EF1E23E444002186D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -809,7 +944,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.omaralbeik.SwifterSwift-tvOS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.omaralbeik.SwifterSwift;
 				PRODUCT_NAME = SwifterSwift;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -830,7 +965,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.omaralbeik.SwifterSwift-tvOS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.omaralbeik.SwifterSwift;
 				PRODUCT_NAME = SwifterSwift;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -894,6 +1029,15 @@
 			buildConfigurations = (
 				077805671E11D0FD000A21C6 /* Debug */,
 				077805681E11D0FD000A21C6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6E4933551E2508C100210167 /* Build configuration list for PBXNativeTarget "SwifterSwift watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6E4933531E2508C100210167 /* Debug */,
+				6E4933541E2508C100210167 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift watchOS.xcscheme
+++ b/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6E49334D1E2508C000210167"
+               BuildableName = "SwifterSwift.framework"
+               BlueprintName = "SwifterSwift watchOS"
+               ReferencedContainer = "container:SwifterSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6E49334D1E2508C000210167"
+            BuildableName = "SwifterSwift.framework"
+            BlueprintName = "SwifterSwift watchOS"
+            ReferencedContainer = "container:SwifterSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6E49334D1E2508C000210167"
+            BuildableName = "SwifterSwift.framework"
+            BlueprintName = "SwifterSwift watchOS"
+            ReferencedContainer = "container:SwifterSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Looks like currently there is no way to test watchOS targets. What is recommended is to test the code in iOS target what we already do. I just did not include files with code not compatible with watchOS into the target.

I tested it with Carthage and imported into a dummy watchOS app. I managed to import framework module but looks like types are not extended because I cannot use any of the SwifterSwift methods. Could you take a look at it? Maybe some lib linking setting that I forgot to tick or sth.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
