### PR TITLE
decrease time delays for async specs

### DIFF
--- a/Tests/SwifterSwiftTests/SwifterSwiftTests.swift
+++ b/Tests/SwifterSwiftTests/SwifterSwiftTests.swift
@@ -30,7 +30,7 @@ class SwifterSwiftTests: XCTestCase {
 		var value = 0
 		let done = expectation(description: "Execute block after delay")
 
-		SwifterSwift.delay(milliseconds: 500, queue: DispatchQueue.main, completion: {
+		SwifterSwift.delay(milliseconds: 50, queue: DispatchQueue.main, completion: {
 			value = 1
 			done.fulfill()
 		})
@@ -50,14 +50,14 @@ class SwifterSwiftTests: XCTestCase {
 			value += 1
 		}
 
-		let debouncedIncrementor = SwifterSwift.debounce(millisecondsDelay: 200, action: {
+		let debouncedIncrementor = SwifterSwift.debounce(millisecondsDelay: 20, action: {
 			incrementor()
 		})
 
 		for i in 1...10 {
 			debouncedIncrementor()
 			if i == 10 {
-				SwifterSwift.delay(milliseconds: 300, completion: {
+				SwifterSwift.delay(milliseconds: 30, completion: {
 					done.fulfill()
 				})
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Two specs I recently added were notably slower then rest of the suite. With decreased delays they work the same but faster.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
