### PR TITLE
Added isValidUrl to StringExtensions

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -100,6 +100,14 @@ public extension String {
 		let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
 		return emailTest.evaluate(with: self)
 	}
+    
+        /// SwifterSwift: Check if string is a valid URL.
+        public var isValidUrl: Bool {
+            guard let candidateURL = NSURL(string: self), candidateURL.scheme != nil, candidateURL.host != nil else {
+                return false
+            }
+            return true
+        }
 	
 	/// SwifterSwift: Check if string is https URL.
 	public var isHttpsUrl: Bool {

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -102,6 +102,14 @@ class StringExtensionsTests: XCTestCase {
 		XCTAssert("omaralbeikgmail.com".isEmail == false, "Couldn't get correct value for \(#function) function")
 	}
 	
+        func testIsValidUrl() {
+                XCTAssert("https://google.com".isValidURL == true, "Couldn't get correct value for \(#function) function")
+                XCTAssert("http://google.com".isValidURL == true, "Couldn't get correct value for \(#function) function")
+                XCTAssert("ftp://google.com".isValidURL == true, "Couldn't get correct value for \(#function) function")
+                XCTAssert("https:/google.com".isValidURL == false, "Couldn't get correct value for \(#function) function")
+                XCTAssert("google.com".isValidURL == false, "Couldn't get correct value for \(#function) function")
+        }
+    
 	func testIsHttpsUrl() {
 		XCTAssert("https://google.com".isHttpsUrl == true, "Couldn't get correct value for \(#function) function")
 		XCTAssert("http://google.com".isHttpsUrl == false, "Couldn't get correct value for \(#function) function")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added isValidUrl property to StringExtensions.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
