### PR TITLE
Added isValidUrl to StringExtensions

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -108,18 +108,18 @@ public extension String {
 	
 	/// SwifterSwift: Check if string is a valid https URL.
 	public var isValidHttpsUrl: Bool {
-		guard let url = URL(string: self), url.scheme == "https" else {
+		guard let url = URL(string: self) else {
 			return false
 		}
-		return true
+		return url.scheme == "https"
 	}
 	
 	/// SwifterSwift: Check if string is a valid http URL.
 	public var isValidHttpUrl: Bool {
-		guard let url = URL(string: self), url.scheme == "http" else {
+		guard let url = URL(string: self) else {
 			return false
 		}
-		return true
+		return url.scheme == "http"
 	}
 	
 	/// SwifterSwift: Check if string contains only numbers.

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -100,29 +100,26 @@ public extension String {
 		let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
 		return emailTest.evaluate(with: self)
 	}
-    
-        /// SwifterSwift: Check if string is a valid URL.
-        public var isValidUrl: Bool {
-            guard let candidateURL = NSURL(string: self), candidateURL.scheme != nil, candidateURL.host != nil else {
-                return false
-            }
-            return true
-        }
 	
-	/// SwifterSwift: Check if string is https URL.
-	public var isHttpsUrl: Bool {
-		guard start(with: "https://".lowercased()) else {
-			return false
-		}
+	/// SwifterSwift: Check if string is a valid URL.
+	public var isValidUrl: Bool {
 		return URL(string: self) != nil
 	}
 	
-	/// SwifterSwift: Check if string is http URL.
-	public var isHttpUrl: Bool {
-		guard start(with: "http://".lowercased()) else {
+	/// SwifterSwift: Check if string is a valid https URL.
+	public var isValidHttpsUrl: Bool {
+		guard let url = URL(string: self), url.scheme == "https" else {
 			return false
 		}
-		return URL(string: self) != nil
+		return true
+	}
+	
+	/// SwifterSwift: Check if string is a valid http URL.
+	public var isValidHttpUrl: Bool {
+		guard let url = URL(string: self), url.scheme == "http" else {
+			return false
+		}
+		return true
 	}
 	
 	/// SwifterSwift: Check if string contains only numbers.

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -100,6 +100,14 @@ public extension String {
 		let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
 		return emailTest.evaluate(with: self)
 	}
+    
+        /// SwifterSwift: Check if string is a valid URL.
+        public var isValidUrl: Bool {
+            guard let candidateURL = NSURL(string: self), candidateURL.scheme != nil, candidateURL.host != nil else {
+                return false
+            }
+            return true
+        }
 	
 	/// SwifterSwift: Check if string is https URL.
 	public var isHttpsUrl: Bool {

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -102,6 +102,14 @@ class StringExtensionsTests: XCTestCase {
 		XCTAssert("omaralbeikgmail.com".isEmail == false, "Couldn't get correct value for \(#function) function")
 	}
 	
+        func testIsValidUrl() {
+                XCTAssert("https://google.com".isValidUrl == true, "Couldn't get correct value for \(#function) function")
+                XCTAssert("http://google.com".isValidUrl == true, "Couldn't get correct value for \(#function) function")
+                XCTAssert("ftp://google.com".isValidUrl == true, "Couldn't get correct value for \(#function) function")
+                XCTAssert("https:/google.com".isValidUrl == false, "Couldn't get correct value for \(#function) function")
+                XCTAssert("google.com".isValidUrl == false, "Couldn't get correct value for \(#function) function")
+        }
+    
 	func testIsHttpsUrl() {
 		XCTAssert("https://google.com".isHttpsUrl == true, "Couldn't get correct value for \(#function) function")
 		XCTAssert("http://google.com".isHttpsUrl == false, "Couldn't get correct value for \(#function) function")

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -102,23 +102,24 @@ class StringExtensionsTests: XCTestCase {
 		XCTAssert("omaralbeikgmail.com".isEmail == false, "Couldn't get correct value for \(#function) function")
 	}
 	
-        func testIsValidUrl() {
-                XCTAssert("https://google.com".isValidUrl == true, "Couldn't get correct value for \(#function) function")
-                XCTAssert("http://google.com".isValidUrl == true, "Couldn't get correct value for \(#function) function")
-                XCTAssert("ftp://google.com".isValidUrl == true, "Couldn't get correct value for \(#function) function")
-                XCTAssert("https:/google.com".isValidUrl == false, "Couldn't get correct value for \(#function) function")
-                XCTAssert("google.com".isValidUrl == false, "Couldn't get correct value for \(#function) function")
-        }
-    
-	func testIsHttpsUrl() {
-		XCTAssert("https://google.com".isHttpsUrl == true, "Couldn't get correct value for \(#function) function")
-		XCTAssert("http://google.com".isHttpsUrl == false, "Couldn't get correct value for \(#function) function")
-		XCTAssert("google.com".isHttpsUrl == false, "Couldn't get correct value for \(#function) function")
+	func testIsValidUrl() {
+		let error = "Couldn't get correct value for \(#function) function"
+		XCTAssertTrue("https://google.com".isValidUrl, error)
+		XCTAssertTrue("http://google.com".isValidUrl, error)
+		XCTAssertTrue("ftp://google.com".isValidUrl, error)
 	}
 	
-	func testIsHttpUrl() {
-		XCTAssert("http://google.com".isHttpUrl == true, "Couldn't get correct value for \(#function) function")
-		XCTAssert("google.com".isHttpUrl == false, "Couldn't get correct value for \(#function) function")
+	func testIsValidHttpsUrl() {
+		let error = "Couldn't get correct value for \(#function) function"
+		XCTAssertTrue("https://google.com".isValidHttpsUrl, error)
+		XCTAssertFalse("http://google.com".isValidHttpsUrl, error)
+		XCTAssertFalse("google.com".isValidHttpsUrl, error)
+	}
+	
+	func testIsValidHttpUrl() {
+		let error = "Couldn't get correct value for \(#function) function"
+		XCTAssertTrue("http://google.com".isValidHttpUrl, error)
+		XCTAssertFalse("google.com".isValidHttpUrl, error)
 	}
 	
 	func testIsNumeric() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added isValidUrl property to StringExtensions.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.