### PR TITLE
Added isValidSchemedUrl to StringExtensions

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -100,11 +100,19 @@ public extension String {
 		let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
 		return emailTest.evaluate(with: self)
 	}
-	
+    
 	/// SwifterSwift: Check if string is a valid URL.
 	public var isValidUrl: Bool {
 		return URL(string: self) != nil
 	}
+    
+        /// SwifterSwift: Check if string is a valid schemed URL.
+        public var isValidSchemedUrl: Bool {
+                guard let url = URL(string: self) else {
+                    return false
+                }
+                return url.scheme != nil
+        }
 	
 	/// SwifterSwift: Check if string is a valid https URL.
 	public var isValidHttpsUrl: Bool {

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -106,6 +106,12 @@ class StringExtensionsTests: XCTestCase {
 		XCTAssert("ftp://google.com".isValidUrl)
 	}
 	
+        func testIsValidSchemedUrl() {
+                XCTAssert("https://google.com".isValidSchemedUrl)
+                XCTAssert("ftp://google.com".isValidSchemedUrl)
+                XCTAssertFalse("google.com".isValidSchemedUrl)
+        }
+    
 	func testIsValidHttpsUrl() {
 		XCTAssert("https://google.com".isValidHttpsUrl)
 		XCTAssertFalse("http://google.com".isValidHttpsUrl)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added isValidSchemedUrl property to StringExtensions.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
