### PR TITLE
Add NSAttributedStringExtensionsTests (SwifterSwift iOSTests target o…

### DIFF
--- a/Source/Extensions/UI/NSAttributedStringExtensions.swift
+++ b/Source/Extensions/UI/NSAttributedStringExtensions.swift
@@ -8,83 +8,62 @@
 
 #if !os(macOS)
 
-import UIKit
-
-
 // MARK: - Properties
 public extension NSAttributedString {
-	
+
 	#if os(iOS)
-	/// SwifterSwift: Bold string
-	public var bold: NSAttributedString {
-		guard let copy = self.mutableCopy() as? NSMutableAttributedString else {
-			return self
-		}
-		let range = (self.string as NSString).range(of: self.string)
-		copy.addAttributes([NSFontAttributeName: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)], range: range)
-		return copy
+	/// SwifterSwift: Bolded string
+	public var bolded: NSAttributedString {
+		return applying(attributes: [NSFontAttributeName: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)])
 	}
 	#endif
 	
 	/// SwifterSwift: Underlined string
-	public var underline: NSAttributedString {
-		guard let copy = self.mutableCopy() as? NSMutableAttributedString else {
-			return self
-		}
-		let range = (self.string as NSString).range(of: self.string)
-		copy.addAttributes([NSUnderlineStyleAttributeName: NSUnderlineStyle.styleSingle.rawValue], range: range)
-		return copy
+	public var underlined: NSAttributedString {
+		return applying(attributes: [NSUnderlineStyleAttributeName: NSUnderlineStyle.styleSingle.rawValue])
 	}
-	
+
 	#if os(iOS)
-	/// SwifterSwift: Italic string
-	public var italic: NSAttributedString {
-		guard let copy = self.mutableCopy() as? NSMutableAttributedString else {
-			return self
-		}
-		let range = (self.string as NSString).range(of: self.string)
-		copy.addAttributes([NSFontAttributeName: UIFont.italicSystemFont(ofSize: UIFont.systemFontSize)], range: range)
-		return copy
+	/// SwifterSwift: Italicized string
+	public var italicized: NSAttributedString {
+		return applying(attributes: [NSFontAttributeName: UIFont.italicSystemFont(ofSize: UIFont.systemFontSize)])
 	}
 	#endif
 	
-	/// SwifterSwift: Strikethrough string
-	public var strikethrough: NSAttributedString {
-		guard let copy = self.mutableCopy() as? NSMutableAttributedString else {
-			return self
-		}
-		let range = (self.string as NSString).range(of: self.string)
-		let attributes = [
-			NSStrikethroughStyleAttributeName: NSNumber(value: NSUnderlineStyle.styleSingle.rawValue as Int)]
-		copy.addAttributes(attributes, range: range)
-		return copy
+	/// SwifterSwift: Struckthrough string
+	public var struckthrough: NSAttributedString {
+		return applying(attributes: [NSStrikethroughStyleAttributeName: NSNumber(value: NSUnderlineStyle.styleSingle.rawValue as Int)])
 	}
-	
 }
-
 
 // MARK: - Methods
 public extension NSAttributedString {
-	
+
+	/// SwifterSwift: Applies given attributes to the new instance
+	/// of NSAttributedString initialized with self object
+	///
+	/// - Parameter attributes: Dictionary of attributes
+	/// - Returns: NSAttributedString with applied attributes
+	fileprivate func applying(attributes: [String: Any]) -> NSAttributedString {
+		let copy = NSMutableAttributedString(attributedString: self)
+		let range = (self.string as NSString).range(of: self.string)
+		copy.addAttributes(attributes, range: range)
+
+		return copy
+	}
+
 	/// SwifterSwift: Add color to NSAttributedString.
 	///
 	/// - Parameter color: text color.
 	/// - Returns: a NSAttributedString colored with given color.
 	public func colored(with color: UIColor) -> NSAttributedString {
-		guard let copy = self.mutableCopy() as? NSMutableAttributedString else {
-			return self
-		}
-		let range = (self.string as NSString).range(of: self.string)
-		copy.addAttributes([NSForegroundColorAttributeName: color], range: range)
-		return copy
+		return applying(attributes: [NSForegroundColorAttributeName: color])
 	}
-	
 }
-
 
 // MARK: - Operators
 public extension NSAttributedString {
-	
+
 	/// SwifterSwift: Add a NSAttributedString to another NSAttributedString
 	///
 	/// - Parameters:
@@ -95,7 +74,6 @@ public extension NSAttributedString {
 		ns.append(rhs)
 		lhs = ns
 	}
-	
 }
 
 #endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		6EF946D71E263D9A0061AEFC /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072F7A941E11DDDD0021AB84 /* UIViewExtensions.swift */; };
 		6EF946D81E263DC80061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF946D91E263DCA0061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9FD870C1E3A001000ADBD19 /* NSAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FD870B1E3A001000ADBD19 /* NSAttributedStringTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -223,7 +224,7 @@
 		072F7A7C1E11DDDD0021AB84 /* CGFloatExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatExtensions.swift; sourceTree = "<group>"; };
 		072F7A7D1E11DDDD0021AB84 /* CGPointExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGPointExtensions.swift; sourceTree = "<group>"; };
 		072F7A7E1E11DDDD0021AB84 /* CGSizeExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGSizeExtensions.swift; sourceTree = "<group>"; };
-		072F7A7F1E11DDDD0021AB84 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
+		072F7A7F1E11DDDD0021AB84 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringExtensions.swift; path = UI/NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
 		072F7A801E11DDDD0021AB84 /* UIAlertControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensions.swift; sourceTree = "<group>"; };
 		072F7A811E11DDDD0021AB84 /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
 		072F7A821E11DDDD0021AB84 /* UIButtonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensions.swift; sourceTree = "<group>"; };
@@ -268,6 +269,7 @@
 		6EBD19E61E23E444002186D3 /* SwifterSwift tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946901E263C4D0061AEFC /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946981E263C4E0061AEFC /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9FD870B1E3A001000ADBD19 /* NSAttributedStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringTests.swift; path = UIExtensionsTests/NSAttributedStringTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -339,6 +341,7 @@
 				072F7A761E11DDDD0021AB84 /* DoubleExtensions.swift */,
 				072F7A771E11DDDD0021AB84 /* FloatExtensions.swift */,
 				072F7A781E11DDDD0021AB84 /* IntExtensions.swift */,
+				072F7A7F1E11DDDD0021AB84 /* NSAttributedStringExtensions.swift */,
 				072F7A791E11DDDD0021AB84 /* StringExtensions.swift */,
 				072F7A7A1E11DDDD0021AB84 /* SwifterSwift.swift */,
 				072F7A7B1E11DDDD0021AB84 /* UI */,
@@ -353,7 +356,6 @@
 				072F7A7C1E11DDDD0021AB84 /* CGFloatExtensions.swift */,
 				072F7A7D1E11DDDD0021AB84 /* CGPointExtensions.swift */,
 				072F7A7E1E11DDDD0021AB84 /* CGSizeExtensions.swift */,
-				072F7A7F1E11DDDD0021AB84 /* NSAttributedStringExtensions.swift */,
 				072F7A801E11DDDD0021AB84 /* UIAlertControllerExtensions.swift */,
 				072F7A811E11DDDD0021AB84 /* UIBarButtonItemExtensions.swift */,
 				072F7A821E11DDDD0021AB84 /* UIButtonExtensions.swift */,
@@ -394,6 +396,7 @@
 				07445BBC1E11D1EF000E9A85 /* DoubleExtensionsTests.swift */,
 				07445BBD1E11D1EF000E9A85 /* FloatExtensionsTests.swift */,
 				07445BBF1E11D1EF000E9A85 /* IntExtensionsTests.swift */,
+				C9FD870B1E3A001000ADBD19 /* NSAttributedStringTests.swift */,
 				07445BC01E11D1EF000E9A85 /* StringExtensionsTests.swift */,
 				07445BC11E11D1EF000E9A85 /* SwifterSwiftTests.swift */,
 			);
@@ -771,6 +774,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07445BC61E11D1EF000E9A85 /* DateExtensionsTests.swift in Sources */,
+				C9FD870C1E3A001000ADBD19 /* NSAttributedStringTests.swift in Sources */,
 				07445BC31E11D1EF000E9A85 /* CGFloatExtensionsTests.swift in Sources */,
 				07445BC81E11D1EF000E9A85 /* DoubleExtensionsTests.swift in Sources */,
 				07445BCB1E11D1EF000E9A85 /* IntExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/UIExtensionsTests/NSAttributedStringTests.swift
+++ b/Tests/SwifterSwiftTests/UIExtensionsTests/NSAttributedStringTests.swift
@@ -1,0 +1,109 @@
+//
+//  NSAttributedStringTests.swift
+//  SwifterSwift
+//
+//  Created by Ewelina on 26/01/2017.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import XCTest
+@testable import SwifterSwift
+
+class NSAttributedStringTests: XCTestCase {
+	// MARK: - Properties
+	func testBolded() {
+		let string = NSAttributedString(string: "Bolded")
+		let out = string.bolded
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
+
+		let filterClosure: (String, Any) -> Bool = {key, value in
+			return (key == NSFontAttributeName && ((value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize)))
+		}
+
+		let filteredAttributes = attributes.filter { filterClosure($0, $1) }
+		XCTAssertEqual(filteredAttributes.count, 1)
+	}
+
+	func testUnderlined() {
+		let string = NSAttributedString(string: "Underlined")
+		let out = string.underlined
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let filteredAttributes = attributes.filter { (key, value) -> Bool in
+			return (key == NSUnderlineStyleAttributeName && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue)
+		}
+
+		XCTAssertEqual(filteredAttributes.count, 1)
+	}
+
+	func testItalicized() {
+		let string = NSAttributedString(string: "Italicized")
+		let out = string.italicized
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let filteredAttributes = attributes.filter { (key, value) -> Bool in
+			return (key == NSFontAttributeName && (value as? UIFont) == .italicSystemFont(ofSize: UIFont.systemFontSize))
+		}
+
+		XCTAssertEqual(filteredAttributes.count, 1)
+	}
+
+	func testStruckthrough() {
+		let string = NSAttributedString(string: "Struck through")
+		let out = string.struckthrough
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let filteredAttributes = attributes.filter { (key, value) -> Bool in
+			return (key == NSStrikethroughStyleAttributeName && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue)
+		}
+
+		XCTAssertEqual(filteredAttributes.count, 1)
+	}
+
+	// MARK: - Methods
+	func testColored() {
+		let string = NSAttributedString(string: "Colored")
+		var out = string.colored(with: .red)
+		var attributes = out.attributes(at: 0, effectiveRange: nil)
+		let filteredAttributes = attributes.filter { (key, value) -> Bool in
+			return (key == NSForegroundColorAttributeName && (value as? UIColor) == .red)
+		}
+
+		XCTAssertEqual(filteredAttributes.count, 1)
+
+		out = out.colored(with: .blue)
+		attributes = out.attributes(at: 0, effectiveRange: nil)
+		XCTAssertEqual(attributes[NSForegroundColorAttributeName] as? UIColor, UIColor.blue)
+		XCTAssertNotEqual(attributes[NSForegroundColorAttributeName] as? UIColor, .red)
+	}
+
+	// MARK: - Operators
+	func testAppending() {
+		var string = NSAttributedString(string: "Test").italicized.underlined.struckthrough
+		string += NSAttributedString(string: " Appending").bolded
+
+		XCTAssertEqual(string.string, "Test Appending")
+
+		var attributes = string.attributes(at: 0, effectiveRange: nil)
+		var filteredAttributes = attributes.filter { (key, value) -> Bool in
+			var valid = false
+			if key == NSFontAttributeName, let value = value as? UIFont, value == .italicSystemFont(ofSize: UIFont.systemFontSize) {
+				valid = true
+			}
+			if key == NSUnderlineStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+				valid = true
+			}
+			if key == NSStrikethroughStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+				valid = true
+			}
+
+			return valid
+		}
+
+		XCTAssertEqual(filteredAttributes.count, 3)
+
+		attributes = string.attributes(at: 5, effectiveRange: nil)
+		filteredAttributes = attributes.filter { (key, value) -> Bool in
+			return (key == NSFontAttributeName && (value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize))
+		}
+
+		XCTAssertEqual(filteredAttributes.count, 1)
+	}
+}


### PR DESCRIPTION
…nly). Apply the “ed/ing” rule to the function/property names in NSAttributedStringExtensions implementation.

- NSAttributedStringExtensions.swift moved up to the Extensions directory, since this is not a part of UIKit framework.
- Changed parameter/function naming convention to match Swift 3 API Guidelines (http://devstreaming.apple.com/videos/wwdc/2016/403hb0ie2m86hvs7yyn/403/403_swift_api_design_guidelines.pdf)
- Added tests for NSAttributedStringExtensions (linked to the SwifterSwift iOSTests target only)


## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [ ] New extensions are written in Swift 3.
- [ ] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.