### PR TITLE
allow delayed execution to be cancelled

### DIFF
--- a/Source/Extensions/SwifterSwift.swift
+++ b/Source/Extensions/SwifterSwift.swift
@@ -274,8 +274,11 @@ public extension SwifterSwift {
 	///   - milliseconds: execute closure after the given delay.
 	///   - queue: a queue that completion closure should be executed on (default is DispatchQueue.main).
 	///   - completion: closure to be executed after delay.
-	public static func delay(milliseconds: Double, queue: DispatchQueue = .main, completion: @escaping ()-> Void) {
-		queue.asyncAfter(deadline: .now() + (milliseconds/1000), execute: completion)
+	///   - Returns: DispatchWorkItem task. You can call .cancel() on it to cancel delayed execution.
+	@discardableResult public static func delay(milliseconds: Double, queue: DispatchQueue = .main, completion: @escaping ()-> Void) -> DispatchWorkItem {
+		let task = DispatchWorkItem { completion() }
+		queue.asyncAfter(deadline: .now() + (milliseconds/1000), execute: task)
+		return task
 	}
 	
 	/// SwifterSwift: Debounce function or closure call.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Hello. I applied a little improvement to delay function. It returns a cancellable DispatchWorkItem instance now.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
