### PR TITLE
Add Class identifier methods

### DIFF
--- a/Source/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Source/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -39,7 +39,7 @@ public extension UICollectionView {
 
 // MARK: - Methods
 public extension UICollectionView {
-	
+    
 	/// SwifterSwift: IndexPath for last item in section.
 	///
 	/// - Parameter section: section to get last item in.
@@ -64,5 +64,58 @@ public extension UICollectionView {
 			completion()
 		})
 	}
+    
+    /// SwifterSwift: Deque reusable UICollectionViewCell using class name
+    ///
+    /// - Parameter name: UICollectionViewCell type
+    /// - Parameter indexPath: Location of cell in collectionView
+    /// - Returns: UICollectionViewCell object with associated class name
+    public func dequeReusableCell<T: UICollectionViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
+        return dequeueReusableCell(withReuseIdentifier: String(describing: name), for: indexPath) as! T
+    }
+    
+    /// SwifterSwift: Deque reusable UICollectionReusableView using class name
+    ///
+    /// - Parameter ofKind: The kind of supplementary view to retrieve. This value is defined by the layout object
+    /// - Parameter name: UICollectionReusableView type
+    /// - Parameter indexPath: Location of cell in collectionView
+    /// - Returns: UICollectionReusableView object with associated class name
+    func dequeReusableSupplementaryView<T: UICollectionReusableView>(ofKind: String, withClass name: T.Type, for indexPath: IndexPath) -> T {
+        return dequeueReusableSupplementaryView(ofKind: ofKind, withReuseIdentifier: String(describing: name), for: indexPath) as! T
+    }
+    
+    /// SwifterSwift: Register UICollectionReusableView using class name
+    ///
+    /// - Parameter kind: The kind of supplementary view to retrieve. This value is defined by the layout object
+    /// - Parameter name: UICollectionReusableViewType
+    func register<T: UICollectionReusableView>(supplementaryViewOfKind kind: String, withClass name: T.Type) {
+        register(T.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: String(describing: name))
+    }
+    
+    
+    /// SwifterSwift: Register UICollectionViewCell using class name
+    ///
+    /// - Parameter nib: Nib file used to create the collectionView cell
+    /// - Parameter name: UICollectionViewCell type
+    func register<T: UICollectionViewCell>(nib: UINib?, forCellWithClass name: T.Type) {
+        register(nib, forCellWithReuseIdentifier: String(describing: name))
+    }
+    
+    /// SwifterSwift: Register UICollectionReusableView using class name
+    ///
+    /// - Parameter name: UICollectionReusableView type
+    func register<T: UICollectionReusableView>(cellWithClass name: T.Type) {
+        register(T.self, forCellWithReuseIdentifier: String(describing: name))
+    }
+    
+    /// SwifterSwift: Register UICollectionReusableView using class name
+    ///
+    /// - Parameter nib: Nib file used to create the reusable view
+    /// - Parameter kind: The kind of supplementary view to retrieve. This value is defined by the layout object
+    /// - Parameter name: UICollectionReusableView type
+    func register<T: UICollectionReusableView>(nib: UINib?, forSupplementaryViewOfKind kind: String, withClass name: T.Type) {
+        register(nib, forSupplementaryViewOfKind: kind, withReuseIdentifier: String(describing: name))
+    }
+
 }
 #endif

--- a/Source/Extensions/UIKit/UIStoryboardExtensions.swift
+++ b/Source/Extensions/UIKit/UIStoryboardExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  UIStoryboardExtensions.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/6/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - Methods
+extension UIStoryboard {
+    
+    /// SwifterSwift: Instantiate a UIViewController using its class name
+    ///
+    /// - Parameter name: UIViewController type
+    /// - Returns: The view controller corresponding to specified class name
+    public func instantiateViewController<T: UIViewController>(withClass name: T.Type) -> T {
+        return instantiateViewController(withIdentifier: String(describing: name)) as! T
+    }
+}

--- a/Source/Extensions/UIKit/UIStoryboardExtensions.swift
+++ b/Source/Extensions/UIKit/UIStoryboardExtensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2017 omaralbeik. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
 import UIKit
 
 // MARK: - Methods
@@ -19,3 +20,4 @@ extension UIStoryboard {
         return instantiateViewController(withIdentifier: String(describing: name)) as! T
     }
 }
+#endif

--- a/Source/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Source/Extensions/UIKit/UITableViewExtensions.swift
@@ -35,11 +35,10 @@ public extension UITableView {
 	}
 	
 }
-
-
+    
 // MARK: - Methods
 public extension UITableView {
-	
+
 	/// SwifterSwift: IndexPath for last row in section.
 	///
 	/// - Parameter section: section to get last row in.
@@ -90,6 +89,61 @@ public extension UITableView {
 	public func scrollToTop(animated: Bool = true) {
 		setContentOffset(CGPoint.zero, animated: animated)
 	}
+    
+    /// SwifterSwift: Deque reusable UITableViewCell using class name
+    ///
+    /// - Parameter name: UITableViewCell type
+    /// - Returns: UITableViewCell object with associated class name (optional value)
+    public func dequeReusableCell<T: UITableViewCell>(withClass name: T.Type) -> T? {
+        return dequeueReusableCell(withIdentifier: String(describing: name)) as? T
+    }
+    
+    /// SwiferSwift: Deque reusable UITableViewCell using class name for indexPath
+    ///
+    /// - Parameter name: UITableViewCell type
+    /// - Parameter indexPath: Location of cell in tableView
+    /// - Returns: UITableViewCell object with associated class name
+    public func dequeReusableCell<T: UITableViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
+        return dequeueReusableCell(withIdentifier: String(describing: name), for: indexPath) as! T
+    }
+    
+    /// SwiferSwift: Deque reusable UITableViewHeaderFooterView using class name
+    ///
+    /// - Parameter name: UITableViewHeaderFooterView type
+    /// - Returns: UITableViewHeaderFooterView object with associated class name (optional value)
+    func dequeReusableHeaderFooterView<T: UITableViewHeaderFooterView>(withClass name: T.Type, for indexPath: IndexPath) -> T? {
+        return dequeueReusableHeaderFooterView(withIdentifier: String(describing: name)) as? T
+    }
+    
+    /// SwifterSwift: Register UITableViewHeaderFooterView using class name
+    ///
+    /// - Parameter nib: Nib file used to create the header or footer view
+    /// - Parameter name: UITableViewHeaderFooterView type
+    func register<T: UITableViewHeaderFooterView>(nib: UINib?, withHeaderFooterViewClass name: T.Type) {
+        register(nib, forHeaderFooterViewReuseIdentifier: String(describing: name))
+    }
+    
+    /// SwifterSwift: Register UITableViewHeaderFooterView using class name
+    ///
+    /// - Parameter name: UITableViewHeaderFooterView type
+    func register<T: UITableViewHeaderFooterView>(headerFooterViewClassWith name: T.Type) {
+        register(T.self, forHeaderFooterViewReuseIdentifier: String(describing: name))
+    }
+    
+    /// SwifterSwift: Register UITableViewCell using class name
+    ///
+    /// - Parameter name: UITableViewCell type
+    func register<T: UITableViewCell>(cellWithClass name: T.Type) {
+        register(T.self, forCellReuseIdentifier: String(describing: name))
+    }
+    
+    /// SwifterSwift: Register UITableViewCell using class name
+    ///
+    /// - Parameter nib: Nib file used to create the tableView cell
+    /// - Paramter name: UITableViewCell type
+    func register<T: UITableViewCell>(nib: UINib?, withCellClass name: T.Type) {
+        register(nib, forCellReuseIdentifier: String(describing: name))
+    }
 	
 }
 #endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		6EF946B21E263D860061AEFC /* SwifterSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BC11E11D1EF000E9A85 /* SwifterSwiftTests.swift */; };
 		6EF946D81E263DC80061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF946D91E263DCA0061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B0C4D1D51E48A52400DACC28 /* UIStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -265,6 +266,7 @@
 		6EBD19E61E23E444002186D3 /* SwifterSwift tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946901E263C4D0061AEFC /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946981E263C4E0061AEFC /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -405,6 +407,7 @@
 				074822131E446D4D00B0C580 /* UITextViewExtensions.swift */,
 				074822141E446D4D00B0C580 /* UIViewControllerExtensions.swift */,
 				074822151E446D4D00B0C580 /* UIViewExtensions.swift */,
+				B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -782,6 +785,7 @@
 				0748228F1E446D4D00B0C580 /* UISegmentedControlExtensions.swift in Sources */,
 				0748222F1E446D4D00B0C580 /* CGSizeExtensions.swift in Sources */,
 				0748225F1E446D4D00B0C580 /* UIAlertControllerExtensions.swift in Sources */,
+				B0C4D1D51E48A52400DACC28 /* UIStoryboardExtensions.swift in Sources */,
 				074822571E446D4D00B0C580 /* StringExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [X] New extensions support iOS 8 or later.
- [X] New extensions are written in Swift 3.
- [  ] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All comments headers have the word **SwifterSwift:** before description.

 Pull request summary:

Affects 2 existing classes: UITableView, UICollectionView
- The methods added to these classes allow a user to both deque and register cells using the class name as the identifier as opposed to the traditional String.

Adds 1 new class: UIStoryboard
- A new method was added allowing the user to instantiate a UIViewController using its class name as the identifier.

I have not written Unit Tests for these methods. 