### PR TITLE
Add CGAffineTransformExtensions: subtracting(transform:)

### DIFF
--- a/Source/Extensions/Cocoa/CGAffineTransformExtensions.swift
+++ b/Source/Extensions/Cocoa/CGAffineTransformExtensions.swift
@@ -1,0 +1,27 @@
+//
+//  CGAffineTransformExtensions.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/12/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(macOS)
+    import Cocoa
+#else
+    import UIKit
+#endif
+
+// MARK: - Methods
+extension CGAffineTransform {
+    
+    /// SwifterSwift: Subtract CGAffineTransform from existing transform
+    ///
+    /// - Parameter transform: The tranform to remove
+    /// - Returns: A new transform with the specified transform removed by concatening its inverse.
+    ///            If the transform cannot be inverted, the original transform is returned.
+    
+    public func subtracting(transform: CGAffineTransform) -> CGAffineTransform {
+        return transform.inverted() == transform ? self : self.concatenating(transform.inverted())
+    }
+}

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -174,6 +174,10 @@
 		6EF946D81E263DC80061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF946D91E263DCA0061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B0C4D1D51E48A52400DACC28 /* UIStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */; };
+		B0E3B7881E51741300B50FE3 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */; };
+		B0E3B7891E51741300B50FE3 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */; };
+		B0E3B78B1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */; };
+		B0E3B78C1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -267,6 +271,8 @@
 		6EF946901E263C4D0061AEFC /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946981E263C4E0061AEFC /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensions.swift; sourceTree = "<group>"; };
+		B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensions.swift; sourceTree = "<group>"; };
+		B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -379,6 +385,7 @@
 				074821F41E446D4C00B0C580 /* CGSizeExtensions.swift */,
 				074821F51E446D4C00B0C580 /* NSAttributedStringExtensions.swift */,
 				074821F61E446D4C00B0C580 /* NSColorExtensions.swift */,
+				B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */,
 			);
 			path = Cocoa;
 			sourceTree = "<group>";
@@ -451,6 +458,7 @@
 				07AB1A681E448CD800CEF96C /* CGFloatExtensionsTests.swift */,
 				07AB1A691E448CD800CEF96C /* CGSizeExtensionsTests.swift */,
 				07AB1A5F1E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift */,
+				B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */,
 			);
 			path = CocoaExtensionsTests;
 			sourceTree = "<group>";
@@ -781,6 +789,7 @@
 				0748222B1E446D4D00B0C580 /* CGPointExtensions.swift in Sources */,
 				074822271E446D4D00B0C580 /* CGFloatExtensions.swift in Sources */,
 				0748229B1E446D4D00B0C580 /* UITabBarExtensions.swift in Sources */,
+				B0E3B7881E51741300B50FE3 /* CGAffineTransformExtensions.swift in Sources */,
 				074822871E446D4D00B0C580 /* UINavigationItemExtensions.swift in Sources */,
 				0748228F1E446D4D00B0C580 /* UISegmentedControlExtensions.swift in Sources */,
 				0748222F1E446D4D00B0C580 /* CGSizeExtensions.swift in Sources */,
@@ -797,6 +806,7 @@
 				07445BC61E11D1EF000E9A85 /* DateExtensionsTests.swift in Sources */,
 				07AB1A621E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07AB1A6D1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
+				B0E3B78B1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */,
 				07445BC81E11D1EF000E9A85 /* DoubleExtensionsTests.swift in Sources */,
 				07445BCB1E11D1EF000E9A85 /* IntExtensionsTests.swift in Sources */,
 				07AB1A711E44AABB00CEF96C /* URLExtensionsTests.swift in Sources */,
@@ -913,6 +923,7 @@
 				074822521E446D4D00B0C580 /* FloatExtensions.swift in Sources */,
 				0748224A1E446D4D00B0C580 /* DictionaryExtensions.swift in Sources */,
 				0748225E1E446D4D00B0C580 /* SwifterSwift.swift in Sources */,
+				B0E3B7891E51741300B50FE3 /* CGAffineTransformExtensions.swift in Sources */,
 				074822361E446D4D00B0C580 /* NSAttributedStringExtensions.swift in Sources */,
 				0748224E1E446D4D00B0C580 /* DoubleExtensions.swift in Sources */,
 				074822B61E446D4D00B0C580 /* URLExtensions.swift in Sources */,
@@ -937,6 +948,7 @@
 				6EF946AB1E263D860061AEFC /* DateExtensionsTests.swift in Sources */,
 				07AB1A641E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07AB1A6F1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
+				B0E3B78C1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */,
 				6EF946AD1E263D860061AEFC /* DoubleExtensionsTests.swift in Sources */,
 				6EF946B01E263D860061AEFC /* IntExtensionsTests.swift in Sources */,
 				07AB1A731E44AABB00CEF96C /* URLExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/CocoaExtensionsTests/CGAffineTransformExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/CocoaExtensionsTests/CGAffineTransformExtensionsTests.swift
@@ -1,0 +1,30 @@
+//
+//  CGAffineTransformExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/12/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import XCTest
+@testable import SwifterSwift
+
+class CGAffineTransformTests: XCTestCase {
+    
+    func testSubtracting() {
+        
+        let originalTransform = CGAffineTransform(a: 10.0, b: 20.0, c: 30.0, d: 40.0, tx: 50.0, ty: 60.0)
+        let transformToAdd = CGAffineTransform(a: 20.0, b: 40.0, c: 60.0, d: 80.0, tx: 100.0, ty: 120.0)
+        
+        let roundTripTransform = originalTransform.concatenating(transformToAdd).subtracting(transform: transformToAdd)
+        
+        XCTAssertEqual(originalTransform, roundTripTransform)
+        
+        let originalTransform2 = CGAffineTransform(scaleX: 50.0, y: 10.0)
+        let nonInvertable = CGAffineTransform(scaleX: 100.0, y: 20.0)
+        
+        let nonInvertedRoundTripTransform = originalTransform2.concatenating(nonInvertable).subtracting(transform: nonInvertable)
+        
+        XCTAssertEqual(originalTransform2, nonInvertedRoundTripTransform)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [X] New extensions support iOS 8 or later.
- [X] New extensions are written in Swift 3.
- [X] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:

First of all sorry for submitting duplicate requests. I broke something major and had to re-fork.

- Adds files for CGAffineTransform extensions + tests