### PR TITLE
Add UIAlertControllerExtensionsTests

### DIFF
--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		B0E3B7891E51741300B50FE3 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */; };
 		B0E3B78B1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */; };
 		B0E3B78C1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */; };
+		B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -281,6 +282,7 @@
 		B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensions.swift; sourceTree = "<group>"; };
 		B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensions.swift; sourceTree = "<group>"; };
 		B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -477,6 +479,7 @@
 			isa = PBXGroup;
 			children = (
 				07AB1A611E448C4500CEF96C /* UIColorExtensionsTests.swift */,
+				B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */,
 			);
 			path = UIKitExtensionsTests;
 			sourceTree = "<group>";
@@ -817,6 +820,7 @@
 				07AB1A621E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07AB1A6D1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
 				B0E3B78B1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */,
+				B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */,
 				07445BC81E11D1EF000E9A85 /* DoubleExtensionsTests.swift in Sources */,
 				07445BCB1E11D1EF000E9A85 /* IntExtensionsTests.swift in Sources */,
 				078B0E4C1E507E7F009189B3 /* DataExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIAlertControllerExtensionsTests.swift
@@ -43,8 +43,9 @@ class UIAlertControllerExtensionsTests: XCTestCase {
         
         XCTAssertEqual(textField?.text, "TextField")
         XCTAssertEqual(textField?.placeholder, "PlaceHolder")
-        XCTAssertEqual(textField?.allTargets.first, self)
+        XCTAssertNotNil(textField?.allTargets)
         XCTAssertNotNil(textField?.actions(forTarget: self, forControlEvent: .editingChanged))
+
     }
     
     func testMessageInit() {

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIAlertControllerExtensionsTests.swift
@@ -6,84 +6,86 @@
 //  Copyright © 2017 omaralbeik. All rights reserved.
 //
 
+#if os(iOS)
 import XCTest
 @testable import SwifterSwift
 
 class UIAlertControllerExtensionsTests: XCTestCase {
-    
-    func testAddAction() {
-        
-        let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
-        let discardedResult = alertController.addAction(title: "ActionTitle", style: .destructive, isEnabled: false, handler: nil)
-        
-        XCTAssertNotNil(discardedResult)
-        
-        XCTAssertTrue(alertController.actions.count == 1)
-        
-        let action = alertController.actions.first
-        
-        XCTAssertEqual(action?.title, "ActionTitle")
-        XCTAssertEqual(action?.style, .destructive)
-        XCTAssertEqual(action?.isEnabled, false)
-    }
-    
-    func testSelector() {}
-    
-    func testAddTextField() {
-        
-        let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
-        
-        let selector = #selector(UIAlertControllerExtensionsTests.testSelector)
-        
-        alertController.addTextField(text: "TextField", placeholder: "PlaceHolder", editingChangedTarget: self, editingChangedSelector: selector)
-        
-        XCTAssertTrue(alertController.textFields?.count == 1)
-        
-        let textField = alertController.textFields?.first
-        
-        XCTAssertEqual(textField?.text, "TextField")
-        XCTAssertEqual(textField?.placeholder, "PlaceHolder")
-        XCTAssertNotNil(textField?.allTargets)
-        XCTAssertNotNil(textField?.actions(forTarget: self, forControlEvent: .editingChanged))
+	
+	func testAddAction() {
 
-    }
-    
-    func testMessageInit() {
-        
-        let alertController = UIAlertController(title: "Title", message: "Message", defaultActionButtonTitle: "Ok", tintColor: .blue)
-        
-        XCTAssertNotNil(alertController)
-        
-        XCTAssertEqual(alertController.title, "Title")
-        XCTAssertEqual(alertController.message, "Message")
-        XCTAssertEqual(alertController.view.tintColor, .blue)
-        
-        XCTAssertTrue(alertController.actions.count == 1)
-        
-        let defaultAction = alertController.actions.first
-        
-        XCTAssertEqual(defaultAction?.title, "Ok")
-        XCTAssertEqual(defaultAction?.style, .default)
-    }
-    
-    func testErrorInit() {
-        
-        enum TestError: Error { case error }
-        let error = TestError.error
-        
-        let alertController = UIAlertController(title: "Title", error: error, defaultActionButtonTitle: "Ok", tintColor: .red)
-        
-        XCTAssertNotNil(alertController)
-        
-        XCTAssertEqual(alertController.title, "Title")
-        XCTAssertEqual(alertController.message, error.localizedDescription)
-        XCTAssertEqual(alertController.view.tintColor, .red)
-        
-        XCTAssertTrue(alertController.actions.count == 1)
-        
-        let defaultAction = alertController.actions.first
-        
-        XCTAssertEqual(defaultAction?.title, "Ok")
-        XCTAssertEqual(defaultAction?.style, .default)
-    }
+		let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
+		let discardedResult = alertController.addAction(title: "ActionTitle", style: .destructive, isEnabled: false, handler: nil)
+		
+		XCTAssertNotNil(discardedResult)
+		
+		XCTAssertTrue(alertController.actions.count == 1)
+		
+		let action = alertController.actions.first
+		
+		XCTAssertEqual(action?.title, "ActionTitle")
+		XCTAssertEqual(action?.style, .destructive)
+		XCTAssertEqual(action?.isEnabled, false)
+	}
+	
+	func testSelector() {}
+	
+	func testAddTextField() {
+		
+		let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
+		
+		let selector = #selector(testSelector)
+		
+		alertController.addTextField(text: "TextField", placeholder: "PlaceHolder", editingChangedTarget: self, editingChangedSelector: selector)
+		
+		XCTAssertTrue(alertController.textFields?.count == 1)
+		
+		let textField = alertController.textFields?.first
+		
+		XCTAssertEqual(textField?.text, "TextField")
+		XCTAssertEqual(textField?.placeholder, "PlaceHolder")
+		XCTAssertNotNil(textField?.allTargets)
+		XCTAssertNotNil(textField?.actions(forTarget: self, forControlEvent: .editingChanged))
+		
+	}
+	
+	func testMessageInit() {
+		
+		let alertController = UIAlertController(title: "Title", message: "Message", defaultActionButtonTitle: "Ok", tintColor: .blue)
+		
+		XCTAssertNotNil(alertController)
+		
+		XCTAssertEqual(alertController.title, "Title")
+		XCTAssertEqual(alertController.message, "Message")
+		XCTAssertEqual(alertController.view.tintColor, .blue)
+		
+		XCTAssertTrue(alertController.actions.count == 1)
+		
+		let defaultAction = alertController.actions.first
+		
+		XCTAssertEqual(defaultAction?.title, "Ok")
+		XCTAssertEqual(defaultAction?.style, .default)
+	}
+	
+	func testErrorInit() {
+		
+		enum TestError: Error { case error }
+		let error = TestError.error
+		
+		let alertController = UIAlertController(title: "Title", error: error, defaultActionButtonTitle: "Ok", tintColor: .red)
+		
+		XCTAssertNotNil(alertController)
+		
+		XCTAssertEqual(alertController.title, "Title")
+		XCTAssertEqual(alertController.message, error.localizedDescription)
+		XCTAssertEqual(alertController.view.tintColor, .red)
+		
+		XCTAssertTrue(alertController.actions.count == 1)
+		
+		let defaultAction = alertController.actions.first
+		
+		XCTAssertEqual(defaultAction?.title, "Ok")
+		XCTAssertEqual(defaultAction?.style, .default)
+	}
 }
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIAlertControllerExtensionsTests.swift
@@ -1,0 +1,88 @@
+//
+//  UIAlertControllerExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/13/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import XCTest
+@testable import SwifterSwift
+
+class UIAlertControllerExtensionsTests: XCTestCase {
+    
+    func testAddAction() {
+        
+        let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
+        let discardedResult = alertController.addAction(title: "ActionTitle", style: .destructive, isEnabled: false, handler: nil)
+        
+        XCTAssertNotNil(discardedResult)
+        
+        XCTAssertTrue(alertController.actions.count == 1)
+        
+        let action = alertController.actions.first
+        
+        XCTAssertEqual(action?.title, "ActionTitle")
+        XCTAssertEqual(action?.style, .destructive)
+        XCTAssertEqual(action?.isEnabled, false)
+    }
+    
+    func testSelector() {}
+    
+    func testAddTextField() {
+        
+        let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
+        
+        let selector = #selector(UIAlertControllerExtensionsTests.testSelector)
+        
+        alertController.addTextField(text: "TextField", placeholder: "PlaceHolder", editingChangedTarget: self, editingChangedSelector: selector)
+        
+        XCTAssertTrue(alertController.textFields?.count == 1)
+        
+        let textField = alertController.textFields?.first
+        
+        XCTAssertEqual(textField?.text, "TextField")
+        XCTAssertEqual(textField?.placeholder, "PlaceHolder")
+        XCTAssertEqual(textField?.allTargets.first, self)
+        XCTAssertNotNil(textField?.actions(forTarget: self, forControlEvent: .editingChanged))
+    }
+    
+    func testMessageInit() {
+        
+        let alertController = UIAlertController(title: "Title", message: "Message", defaultActionButtonTitle: "Ok", tintColor: .blue)
+        
+        XCTAssertNotNil(alertController)
+        
+        XCTAssertEqual(alertController.title, "Title")
+        XCTAssertEqual(alertController.message, "Message")
+        XCTAssertEqual(alertController.view.tintColor, .blue)
+        
+        XCTAssertTrue(alertController.actions.count == 1)
+        
+        let defaultAction = alertController.actions.first
+        
+        XCTAssertEqual(defaultAction?.title, "Ok")
+        XCTAssertEqual(defaultAction?.style, .default)
+    }
+    
+    func testErrorInit() {
+        
+        enum TestError: Error { case error }
+        let error = TestError.error
+        
+        let alertController = UIAlertController(title: "Title", error: error, defaultActionButtonTitle: "Ok", tintColor: .red)
+        
+        XCTAssertNotNil(alertController)
+        
+        XCTAssertEqual(alertController.title, "Title")
+        XCTAssertEqual(alertController.message, error.localizedDescription)
+        XCTAssertEqual(alertController.view.tintColor, .red)
+        
+        XCTAssertTrue(alertController.actions.count == 1)
+        
+        let defaultAction = alertController.actions.first
+        
+        XCTAssertEqual(defaultAction?.title, "Ok")
+        XCTAssertEqual(defaultAction?.style, .default)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [] New extensions support iOS 8 or later.
- [] New extensions are written in Swift 3.
- [] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:
- This PR adds no new extensions
- Adds new test file for UIAlertControllerExtensions
- The only method not tested is the show(animated:vibrate:completion:)
I had a lot of difficulty figuring out how to test if the controller was actually presented considering there is no UIApplicationMain.
