### PR TITLE
Replace deprecated 'M_PI' with '.pi'

### DIFF
--- a/Source/Extensions/Cocoa/CGFloatExtensions.swift
+++ b/Source/Extensions/Cocoa/CGFloatExtensions.swift
@@ -28,7 +28,7 @@ public extension CGFloat {
 	
 	/// SwifterSwift: Radian value of degree input.
 	public var degreesToRadians: CGFloat {
-		return CGFloat(M_PI) * self / 180.0
+		return CGFloat.pi * self / 180.0
 	}
 	
 	/// SwifterSwift: Floor of CGFloat value.
@@ -38,7 +38,7 @@ public extension CGFloat {
 	
 	/// SwifterSwift: Degree value of radian input.
 	public var radiansToDegrees: CGFloat {
-		return self * 180 / CGFloat(M_PI)
+		return self * 180 / CGFloat.pi
 	}
 	
 }

--- a/Source/Extensions/DoubleExtensions.swift
+++ b/Source/Extensions/DoubleExtensions.swift
@@ -32,7 +32,7 @@ public extension Double {
 	
 	/// SwifterSwift: Radian value of degree input.
 	public var degreesToRadians: Double {
-		return Double(M_PI) * self / 180.0
+		return Double.pi * self / 180.0
 	}
 	
 	/// SwifterSwift: Floor of double value.
@@ -42,7 +42,7 @@ public extension Double {
 	
 	/// SwifterSwift: Degree value of radian input.
 	public var radiansToDegrees: Double {
-		return self * 180 / Double(M_PI)
+		return self * 180 / Double.pi
 	}
 	
 }

--- a/Source/Extensions/FloatExtensions.swift
+++ b/Source/Extensions/FloatExtensions.swift
@@ -32,7 +32,7 @@ public extension Float {
 	
 	/// SwifterSwift: Radian value of degree input.
 	public var degreesToRadians: Float {
-		return Float(M_PI) * self / 180.0
+		return Float.pi * self / 180.0
 	}
 	
 	/// SwifterSwift: Floor of float value.
@@ -42,7 +42,7 @@ public extension Float {
 	
 	/// SwifterSwift: Degree value of radian input.
 	public var radiansToDegrees: Float {
-		return self * 180 / Float(M_PI)
+		return self * 180 / Float.pi
 	}
 	
 }

--- a/Source/Extensions/IntExtensions.swift
+++ b/Source/Extensions/IntExtensions.swift
@@ -27,7 +27,7 @@ public extension Int {
 	
 	/// SwifterSwift: Radian value of degree input.
 	public var degreesToRadians: Double {
-		return Double(M_PI) * Double(self) / 180.0
+		return Double.pi * Double(self) / 180.0
 	}
 	
 	/// SwifterSwift: Array of digits of integer value.
@@ -58,7 +58,7 @@ public extension Int {
 	
 	/// SwifterSwift: Degree value of radian input
 	public var radiansToDegrees: Double {
-		return Double(self) * 180 / Double(M_PI)
+		return Double(self) * 180 / Double.pi
 	}
 	
 	/// SwifterSwift: Roman numeral string from integer (if applicable).

--- a/Source/Extensions/UIKit/UIViewExtensions.swift
+++ b/Source/Extensions/UIKit/UIViewExtensions.swift
@@ -315,7 +315,7 @@ public extension UIView {
 	///   - duration: animation duration in seconds (default is 1 second).
 	///   - completion: optional completion handler to run with animation finishes (default is nil).
 	public func rotate(byAngle angle : CGFloat, ofType type: AngleUnit, animated: Bool = false, duration: TimeInterval = 1, completion:((Bool) -> Void)? = nil) {
-		let angleWithType = (type == .degrees) ? CGFloat(M_PI) * angle / 180.0 : angle
+		let angleWithType = (type == .degrees) ? CGFloat.pi * angle / 180.0 : angle
 		let aDuration = animated ? duration : 0
 		UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
 			self.transform = self.transform.rotated(by: angleWithType)
@@ -331,7 +331,7 @@ public extension UIView {
 	///   - duration: animation duration in seconds (default is 1 second).
 	///   - completion: optional completion handler to run with animation finishes (default is nil).
 	public func rotate(toAngle angle: CGFloat, ofType type: AngleUnit, animated: Bool = false, duration: TimeInterval = 1, completion:((Bool) -> Void)? = nil) {
-		let angleWithType = (type == .degrees) ? CGFloat(M_PI) * angle / 180.0 : angle
+		let angleWithType = (type == .degrees) ? CGFloat.pi * angle / 180.0 : angle
 		let aDuration = animated ? duration : 0
 		UIView.animate(withDuration: aDuration, animations: {
 			self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: angleWithType))

--- a/Tests/SwifterSwiftTests/CocoaExtensionsTests/CGFloatExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/CocoaExtensionsTests/CGFloatExtensionsTests.swift
@@ -35,7 +35,7 @@ class CGFloatExtensionsTests: XCTestCase {
 	
 	#if !os(macOS)
 	func testDegreesToRadians() {
-		XCTAssertEqual(CGFloat(180).degreesToRadians, CGFloat(M_PI))
+		XCTAssertEqual(CGFloat(180).degreesToRadians, CGFloat.pi)
 	}
 	#endif
 	
@@ -54,7 +54,7 @@ class CGFloatExtensionsTests: XCTestCase {
 	
 	#if !os(macOS)
 	func testRadiansToDegrees() {
-		XCTAssertEqual(CGFloat(M_PI).radiansToDegrees, CGFloat(180))
+		XCTAssertEqual(CGFloat.pi.radiansToDegrees, CGFloat(180))
 	}
 	#endif
 	

--- a/Tests/SwifterSwiftTests/DoubleExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/DoubleExtensionsTests.swift
@@ -30,7 +30,7 @@ class DoubleExtensionsTests: XCTestCase {
 	}
 	
 	func testDegreesToRadians() {
-		XCTAssertEqual(Double(180).degreesToRadians, M_PI)
+		XCTAssertEqual(Double(180).degreesToRadians, Double.pi)
 	}
 	
 	func testRandomBetween() {
@@ -43,7 +43,7 @@ class DoubleExtensionsTests: XCTestCase {
 	}
 	
 	func testRadiansToDegrees() {
-		XCTAssertEqual(Double(M_PI).radiansToDegrees, Double(180))
+		XCTAssertEqual(Double.pi.radiansToDegrees, Double(180))
 	}
 	
 	func testOperators() {

--- a/Tests/SwifterSwiftTests/FloatExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/FloatExtensionsTests.swift
@@ -30,7 +30,7 @@ class FloatExtensionsTests: XCTestCase {
 	}
 	
 	func testDegreesToRadians() {
-		XCTAssertEqual(Float(180).degreesToRadians, Float(M_PI))
+		XCTAssertEqual(Float(180).degreesToRadians, Float.pi)
 	}
 	
 	func testRandomBetween() {
@@ -43,7 +43,7 @@ class FloatExtensionsTests: XCTestCase {
 	}
 	
 	func testRadiansToDegrees() {
-		XCTAssertEqual(Float(M_PI).radiansToDegrees, Float(180))
+		XCTAssertEqual(Float.pi.radiansToDegrees, Float(180))
 	}
 	
 	func testOperators() {

--- a/Tests/SwifterSwiftTests/IntExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/IntExtensionsTests.swift
@@ -26,7 +26,7 @@ class IntExtensionsTests: XCTestCase {
 	}
 	
 	func testDegreesToRadians() {
-		XCTAssertEqual(180.degreesToRadians, M_PI)
+		XCTAssertEqual(180.degreesToRadians, Double.pi)
 	}
 	
 	func testDigits() {


### PR DESCRIPTION
`M_PI` is deprecated in Swift 3.1 (Xcode 8.3 beta 2). 

<img width="343" alt="2017-02-14 at 11 11 am" src="https://cloud.githubusercontent.com/assets/158831/22913750/a8288f2c-f2a7-11e6-822b-5f0f13625add.png">

This pull request replaces all `M_PI` with `Double.pi` or `.pi` of corresponding types in the context.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.