### PR TITLE
Add UIBarButtonItem+UIButtonExtensions tests

### DIFF
--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -185,6 +185,10 @@
 		B0E3B78B1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */; };
 		B0E3B78C1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */; };
 		B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */; };
+		B0E3B7991E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */; };
+		B0E3B79A1E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */; };
+		B0E3B79C1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */; };
+		B0E3B79D1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -283,6 +287,8 @@
 		B0E3B7871E51741300B50FE3 /* CGAffineTransformExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensions.swift; sourceTree = "<group>"; };
 		B0E3B78A1E51747E00B50FE3 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -480,6 +486,8 @@
 			children = (
 				07AB1A611E448C4500CEF96C /* UIColorExtensionsTests.swift */,
 				B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */,
+				B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */,
+				B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */,
 			);
 			path = UIKitExtensionsTests;
 			sourceTree = "<group>";
@@ -833,7 +841,9 @@
 				07AB1A6A1E448CD800CEF96C /* CGFloatExtensionsTests.swift in Sources */,
 				07445BC91E11D1EF000E9A85 /* FloatExtensionsTests.swift in Sources */,
 				07AB1A651E448C4500CEF96C /* UIColorExtensionsTests.swift in Sources */,
+				B0E3B7991E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */,
 				07445BCC1E11D1EF000E9A85 /* StringExtensionsTests.swift in Sources */,
+				B0E3B79C1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */,
 				07445BC71E11D1EF000E9A85 /* DictionaryExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -913,6 +923,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6EBD19F91E23E4A5002186D3 /* DateExtensionsTests.swift in Sources */,
+				B0E3B79A1E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */,
 				07AB1A631E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07AB1A6E1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
 				6EBD19FB1E23E4A5002186D3 /* DoubleExtensionsTests.swift in Sources */,
@@ -926,6 +937,7 @@
 				6EBD19F51E23E49B002186D3 /* ArrayExtensionsTests.swift in Sources */,
 				07AB1A6B1E448CD800CEF96C /* CGFloatExtensionsTests.swift in Sources */,
 				6EBD19FC1E23E4A5002186D3 /* FloatExtensionsTests.swift in Sources */,
+				B0E3B79D1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */,
 				07AB1A661E448C4500CEF96C /* UIColorExtensionsTests.swift in Sources */,
 				6EBD19FF1E23E4A5002186D3 /* StringExtensionsTests.swift in Sources */,
 				6EBD19FA1E23E4A5002186D3 /* DictionaryExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIBarButtonExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIBarButtonExtensionsTests.swift
@@ -1,0 +1,31 @@
+//
+//  UIBarButtonExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/14/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import XCTest
+@testable import SwifterSwift
+
+class UIBarButtonExtensionsTests: XCTestCase {
+    
+    func testSelector() {}
+    
+    func testAddTargetForAction() {
+        
+        let barButton = UIBarButtonItem()
+        let selector = #selector(testSelector)
+        
+        barButton.addTargetForAction(target: self, action: selector)
+        
+        let target = barButton.target as? UIBarButtonExtensionsTests
+        
+        XCTAssertEqual(target, self)
+        XCTAssertEqual(barButton.action, selector)
+    }
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIButtonExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIButtonExtensionsTests.swift
@@ -1,0 +1,168 @@
+//
+//  UIButtonExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/14/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+    
+import XCTest
+@testable import SwifterSwift
+    
+class UIButtonExtensionsTests: XCTestCase {
+        
+    func testImageForDisabled() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.imageForDisabled, button.image(for: .disabled))
+        
+        let newImage = UIImage()
+        button.imageForDisabled = newImage
+        XCTAssertEqual(button.imageForDisabled, newImage)
+    }
+    
+    func testImageForHighlighted() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.imageForHighlighted, button.image(for: .highlighted))
+        
+        let newImage = UIImage()
+        button.imageForHighlighted = newImage
+        XCTAssertEqual(button.imageForHighlighted, newImage)
+    }
+    
+    func testImageForNormal() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.imageForNormal, button.image(for: .normal))
+        
+        let newImage = UIImage()
+        button.imageForNormal = newImage
+        XCTAssertEqual(button.imageForNormal, newImage)
+    }
+    
+    func testImageForSelected() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.imageForSelected, button.image(for: .selected))
+        
+        let newImage = UIImage()
+        button.imageForSelected = newImage
+        XCTAssertEqual(button.imageForSelected, newImage)
+    }
+    
+    func testTitleColorForDisabled() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.titleColorForDisabled, button.titleColor(for: .disabled))
+        
+        button.titleColorForDisabled = .black
+        XCTAssertEqual(button.titleColorForDisabled, .black)
+    }
+    
+    func testTitleColorForHighlighted() {
+            
+        let button = UIButton()
+        XCTAssertEqual(button.titleColorForHighlighted, button.titleColor(for: .highlighted))
+        
+        button.titleColorForHighlighted = .black
+        XCTAssertEqual(button.titleColorForHighlighted, .black)
+    }
+        
+    func testTitleColorForNormal() {
+            
+        let button = UIButton()
+        XCTAssertEqual(button.titleColorForNormal, button.titleColor(for: .normal))
+        
+        button.titleColorForNormal = .black
+        XCTAssertEqual(button.titleColorForNormal, .black)
+    }
+    
+    func testTitleColorForSelected() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.titleColorForSelected, button.titleColor(for: .selected))
+        
+        button.titleColorForSelected = .black
+        XCTAssertEqual(button.titleColorForSelected, .black)
+    }
+    
+    func testTitleForDisabled() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.titleForDisabled, button.title(for: .disabled))
+        
+        let title = "Disabled"
+        button.titleForDisabled = title
+        XCTAssertEqual(button.titleForDisabled, title)
+    }
+    
+    func testTitleForHighlighted() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.titleForHighlighted, button.title(for: .highlighted))
+        
+        let title = "Highlighted"
+        button.titleForHighlighted = title
+        XCTAssertEqual(button.titleForHighlighted, title)
+    }
+    
+    func testTitleForNormal() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.titleForNormal, button.title(for: .normal))
+        
+        let title = "Normal"
+        button.titleForNormal = title
+        XCTAssertEqual(button.titleForNormal, title)
+    }
+    
+    func testTitleForSelected() {
+        
+        let button = UIButton()
+        XCTAssertEqual(button.titleForSelected, button.title(for: .selected))
+        
+        let title = "Selected"
+        button.titleForSelected = title
+        XCTAssertEqual(button.titleForSelected, title)
+    }
+    
+    func testSetImageForAllStates() {
+        
+        let button = UIButton()
+        let image = UIImage()
+        button.setImageForAllStates(image)
+        
+        XCTAssertEqual(button.imageForDisabled, image)
+        XCTAssertEqual(button.imageForHighlighted, image)
+        XCTAssertEqual(button.imageForNormal, image)
+        XCTAssertEqual(button.imageForSelected, image)
+    }
+    
+    func testSetTitleColorForAllStates() {
+        
+        let button = UIButton()
+        let color = UIColor.white
+        button.setTitleColorForAllStates(color)
+        
+        XCTAssertEqual(button.titleColorForDisabled, color)
+        XCTAssertEqual(button.titleColorForHighlighted, color)
+        XCTAssertEqual(button.titleColorForNormal, color)
+        XCTAssertEqual(button.titleColorForSelected, color)
+    }
+        
+    func testSetTitleForAllStates() {
+            
+        let button = UIButton()
+        let title = "Title"
+        button.setTitleForAllStates(title)
+        
+        XCTAssertEqual(button.titleForDisabled, title)
+        XCTAssertEqual(button.titleForHighlighted, title)
+        XCTAssertEqual(button.titleForNormal, title)
+        XCTAssertEqual(button.titleForSelected, title)
+    }
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [] New extensions support iOS 8 or later.
- [] New extensions are written in Swift 3.
- [] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:
- This PR adds no new extensions
- Adds 2 new files for testing UIBarButtonItem + UIButton extensions
- All methods/properties are tested

Not related to Pull Request:

Consider the following method name change for UIBarButtonItem:

From:
``` func addTargetForAction(target: AnyObject, action: Selector)```

To:
```func add(target: AnyObject, for action: Selector)```