### PR TITLE
Add UITextView+UISegmentedControl tests #120

### DIFF
--- a/Source/Extensions/UIKit/UISegmentedControlExtensions.swift
+++ b/Source/Extensions/UIKit/UISegmentedControlExtensions.swift
@@ -14,15 +14,10 @@ import UIKit
 public extension UISegmentedControl {
 	
 	/// SwifterSwift: Segments titles.
-	public var segmentTitles: [String?] {
+	public var segmentTitles: [String] {
 		get {
-			var titles: [String?] = []
-			var i = 0
-			while i < numberOfSegments {
-				titles.append(titleForSegment(at: i))
-				i += 1
-			}
-			return titles
+            let range = 0..<numberOfSegments
+            return range.flatMap { titleForSegment(at: $0) }
 		}
 		set {
 			removeAllSegments()
@@ -33,15 +28,10 @@ public extension UISegmentedControl {
 	}
 	
 	/// SwifterSwift: Segments images.
-	public var segmentImages: [UIImage?] {
+	public var segmentImages: [UIImage] {
 		get {
-			var images: [UIImage?] = []
-			var i = 0
-			while i < numberOfSegments {
-				images.append(imageForSegment(at: i))
-				i += 1
-			}
-			return images
+            let range = 0..<numberOfSegments
+            return range.flatMap { imageForSegment(at: $0) }
 		}
 		set {
 			removeAllSegments()
@@ -50,6 +40,5 @@ public extension UISegmentedControl {
 			}
 		}
 	}
-	
 }
 #endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		B0E3B79A1E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */; };
 		B0E3B79C1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */; };
 		B0E3B79D1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */; };
+		B0E3B7AF1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */; };
+		B0E3B7B01E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -296,6 +298,7 @@
 		B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControlExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -498,6 +501,7 @@
 				B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */,
 				B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */,
 				B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */,
+				B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */,
 			);
 			path = UIKitExtensionsTests;
 			sourceTree = "<group>";
@@ -839,6 +843,7 @@
 				B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */,
 				07445BC81E11D1EF000E9A85 /* DoubleExtensionsTests.swift in Sources */,
 				07445BCB1E11D1EF000E9A85 /* IntExtensionsTests.swift in Sources */,
+				B0E3B7AF1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */,
 				078B0E4C1E507E7F009189B3 /* DataExtensionsTests.swift in Sources */,
 				07AB1A711E44AABB00CEF96C /* URLExtensionsTests.swift in Sources */,
 				07445BCD1E11D1EF000E9A85 /* SwifterSwiftTests.swift in Sources */,
@@ -957,6 +962,7 @@
 				6EBD19FF1E23E4A5002186D3 /* StringExtensionsTests.swift in Sources */,
 				07750B5F1E54A78F0034E625 /* UISearchBarExtensionsTests.swift in Sources */,
 				6EBD19FA1E23E4A5002186D3 /* DictionaryExtensionsTests.swift in Sources */,
+				B0E3B7B01E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UISegmentedControlExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UISegmentedControlExtensionsTests.swift
@@ -1,0 +1,32 @@
+//
+//  UISegmentedControlExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/15/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import XCTest
+@testable import SwifterSwift
+
+class UISegmentedControlExtensionsTests: XCTestCase {
+
+    func testSegmentTitles() {
+        let segmentControl = UISegmentedControl()
+        XCTAssert(segmentControl.segmentTitles.isEmpty)
+        let titles = ["Title1", "Title2"]
+        segmentControl.segmentTitles = titles
+        XCTAssertEqual(segmentControl.segmentTitles, titles)
+    }
+    
+    func testSegmentImages() {
+        let segmentControl = UISegmentedControl()
+        XCTAssert(segmentControl.segmentImages.isEmpty)
+        let images = [UIImage(), UIImage()]
+        segmentControl.segmentImages = images
+        XCTAssertEqual(segmentControl.segmentImages, images)
+    }
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UITextFieldExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UITextFieldExtensionsTests.swift
@@ -46,6 +46,13 @@ import XCTest
 			textField.clear()
 			XCTAssertEqual(textField.text!, "")
 		}
-		
+        
+        func testSetPlaceHolderTextColor() {
+            let textField = UITextField()
+            textField.attributedPlaceholder = NSAttributedString(string: "Attributed Placeholder")
+            textField.setPlaceHolderTextColor(.blue)
+            let color = textField.attributedPlaceholder?.attribute(NSForegroundColorAttributeName, at: 0, effectiveRange: nil) as? UIColor
+            XCTAssertEqual(color, .blue)
+        }
 	}
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [] New extensions support iOS 8 or later.
- [] New extensions are written in Swift 3.
- [] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:
- Updates implementation of UISegmentedControl extensions to return array of non-optionals
- This has been discussed in issue #120

- Adds complete testing for UISegmentedControlExtensions
- Adds a single test for UITextFieldExtensions
```setPlaceHolderTextColor```

I'm working on a bigger PR with more UIKit testing at the moment. Lots of things holding me up today.