### PR TITLE
Add UINavigationElements+UISlider tests

### DIFF
--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -195,6 +195,13 @@
 		B0E3B79D1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */; };
 		B0E3B7AF1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */; };
 		B0E3B7B01E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */; };
+		B0E3B7C41E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7C31E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift */; };
+		B0E3B7C51E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7C31E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift */; };
+		B0E3B7C71E559B3100B50FE3 /* UISliderExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7C61E559B3100B50FE3 /* UISliderExtensionsTests.swift */; };
+		B0E3B7C91E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */; };
+		B0E3B7CA1E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */; };
+		B0E3B7CC1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */; };
+		B0E3B7CD1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -299,6 +306,10 @@
 		B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControlExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B7C31E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationItemExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B7C61E559B3100B50FE3 /* UISliderExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISliderExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtensionsTests.swift; sourceTree = "<group>"; };
+		B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationBarExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -502,6 +513,10 @@
 				B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */,
 				B0E3B79B1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift */,
 				B0E3B7AE1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift */,
+				B0E3B7C31E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift */,
+				B0E3B7C61E559B3100B50FE3 /* UISliderExtensionsTests.swift */,
+				B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */,
+				B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */,
 			);
 			path = UIKitExtensionsTests;
 			sourceTree = "<group>";
@@ -849,9 +864,12 @@
 				07445BCD1E11D1EF000E9A85 /* SwifterSwiftTests.swift in Sources */,
 				07B897E61E3218E400A09B44 /* BoolExtensionsTests.swift in Sources */,
 				07445BC51E11D1EF000E9A85 /* CharacterExtensionsTests.swift in Sources */,
+				B0E3B7C41E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift in Sources */,
+				B0E3B7C91E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */,
 				078B0E481E507E4C009189B3 /* CollectionExtensionsTests.swift in Sources */,
 				07445BC21E11D1EF000E9A85 /* ArrayExtensionsTests.swift in Sources */,
 				07750B661E54AD8E0034E625 /* UIViewExtensionsTests.swift in Sources */,
+				B0E3B7C71E559B3100B50FE3 /* UISliderExtensionsTests.swift in Sources */,
 				07AB1A6A1E448CD800CEF96C /* CGFloatExtensionsTests.swift in Sources */,
 				07445BC91E11D1EF000E9A85 /* FloatExtensionsTests.swift in Sources */,
 				07AB1A651E448C4500CEF96C /* UIColorExtensionsTests.swift in Sources */,
@@ -861,6 +879,7 @@
 				07750B631E54AC990034E625 /* UITextViewExtensionsTests.swift in Sources */,
 				07750B5E1E54A78F0034E625 /* UISearchBarExtensionsTests.swift in Sources */,
 				B0E3B79C1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */,
+				B0E3B7CC1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */,
 				07750B5C1E54A5F00034E625 /* UISwitchExtensionsTests.swift in Sources */,
 				07445BC71E11D1EF000E9A85 /* DictionaryExtensionsTests.swift in Sources */,
 			);
@@ -940,13 +959,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B0E3B7C51E559AE300B50FE3 /* UINavigationItemExtensionsTests.swift in Sources */,
 				6EBD19F91E23E4A5002186D3 /* DateExtensionsTests.swift in Sources */,
+				B0E3B7CA1E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */,
 				B0E3B79A1E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */,
 				07AB1A631E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07AB1A6E1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
 				6EBD19FB1E23E4A5002186D3 /* DoubleExtensionsTests.swift in Sources */,
 				6EBD19FE1E23E4A5002186D3 /* IntExtensionsTests.swift in Sources */,
 				07750B671E54AD8E0034E625 /* UIViewExtensionsTests.swift in Sources */,
+				B0E3B7CD1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */,
 				078B0E4D1E507E7F009189B3 /* DataExtensionsTests.swift in Sources */,
 				07AB1A721E44AABB00CEF96C /* URLExtensionsTests.swift in Sources */,
 				6EBD1A001E23E4A5002186D3 /* SwifterSwiftTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UINavigationBarExtensionTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UINavigationBarExtensionTests.swift
@@ -1,0 +1,57 @@
+//
+//  UINavigationBarExtensionTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/16/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+    
+import XCTest
+@testable import SwifterSwift
+    
+class UINavigationBarExtensionsTests: XCTestCase {
+    
+    func testSetTitleFont() {
+        let navigationBar = UINavigationBar()
+        let helveticaFont = UIFont(name: "HelveticaNeue", size: 14)!
+        navigationBar.setTitleFont(helveticaFont, color: .green)
+        let color = navigationBar.titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        XCTAssertEqual(color, .green)
+        let font = navigationBar.titleTextAttributes?[NSFontAttributeName] as? UIFont
+        XCTAssertEqual(font, helveticaFont)
+        
+        navigationBar.setTitleFont(helveticaFont)
+        let defaultColor = navigationBar.titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        XCTAssertEqual(defaultColor, .black)
+    }
+    
+    func testMakeTransparent() {
+        let navigationBar = UINavigationBar()
+        navigationBar.makeTransparent(withTint: .red)
+        XCTAssertNotNil(navigationBar.backgroundImage(for: .default))
+        XCTAssertNotNil(navigationBar.shadowImage)
+        XCTAssert(navigationBar.isTranslucent)
+        XCTAssertEqual(navigationBar.tintColor, .red)
+        let color = navigationBar.titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        XCTAssertEqual(color, .red)
+        
+        navigationBar.makeTransparent()
+        let defaultColor = navigationBar.titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        XCTAssertEqual(defaultColor, .white)
+    }
+    
+    func testSetColors() {
+        let navigationBar = UINavigationBar()
+        navigationBar.setColors(background: .blue, text: .green)
+        XCTAssertFalse(navigationBar.isTranslucent)
+        XCTAssertEqual(navigationBar.backgroundColor, .blue)
+        XCTAssertEqual(navigationBar.barTintColor, .blue)
+        XCTAssertNotNil(navigationBar.backgroundImage(for: .default))
+        XCTAssertEqual(navigationBar.tintColor, .green)
+        let color = navigationBar.titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        XCTAssertEqual(color, .green)
+    }
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UINavigationControllerExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UINavigationControllerExtensionsTests.swift
@@ -1,0 +1,58 @@
+//
+//  UINavigationControllerExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/16/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+    
+import XCTest
+@testable import SwifterSwift
+    
+class UINavigationControllerExtensionsTests: XCTestCase {
+    
+    func testPopViewController() {
+        let navigationController = UINavigationController()
+        let vcToPop = UIViewController()
+        
+        navigationController.pushViewController(vcToPop, animated: false)
+        
+        var completionCalled = false
+        
+        navigationController.popViewController() {
+            completionCalled = true
+            XCTAssert(completionCalled)
+            XCTAssert(navigationController.viewControllers.isEmpty)
+        }
+    }
+    
+    func testPushViewController() {
+        let navigationController = UINavigationController()
+        let vcToPush = UIViewController()
+        
+        navigationController.pushViewController(vcToPush, animated: false)
+        
+        var completionCalled = false
+        
+        navigationController.pushViewController(viewController: vcToPush) {
+            completionCalled = true
+            XCTAssert(completionCalled)
+            XCTAssert(navigationController.viewControllers.count == 1)
+            XCTAssertEqual(navigationController.topViewController, vcToPush)
+        }
+    }
+    
+    func testMakeTransparent() {
+        let navigationController = UINavigationController()
+        navigationController.makeTransparent(withTint: .red)
+        XCTAssertNotNil(navigationController.navigationBar.backgroundImage(for: .default))
+        XCTAssertNotNil(navigationController.navigationBar.shadowImage)
+        XCTAssert(navigationController.navigationBar.isTranslucent)
+        XCTAssertEqual(navigationController.navigationBar.tintColor, .red)
+        let titleColor = navigationController.navigationBar.titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        XCTAssertEqual(titleColor, .red)
+    }
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UINavigationItemExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UINavigationItemExtensionsTests.swift
@@ -1,0 +1,31 @@
+//
+//  UINavigationItemExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/16/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+    
+import XCTest
+@testable import SwifterSwift
+    
+class UINavigationItemExtensionsTests: XCTestCase {
+    
+    func testReplaceTitle() {
+        let navigationItem = UINavigationItem()
+        let image = UIImage()
+        navigationItem.replaceTitle(with: image)
+        
+        let imageView = navigationItem.titleView as? UIImageView
+        XCTAssertNotNil(imageView)
+        
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 30)
+        XCTAssertEqual(imageView?.frame, frame)
+        
+        XCTAssertEqual(imageView?.contentMode, .scaleAspectFit)
+        XCTAssertEqual(imageView?.image, image)
+    }
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UISliderExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UISliderExtensionsTests.swift
@@ -1,0 +1,38 @@
+//
+//  UISliderExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/16/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS)
+    
+import XCTest
+@testable import SwifterSwift
+
+class UISliderExtensionsTests: XCTestCase {
+
+    func testSetValue() {
+        let slider = UISlider()
+        slider.minimumValue = 0
+        slider.maximumValue = 100
+        var completionCalled = false
+        
+        slider.setValue(99) {
+            completionCalled = true
+            XCTAssert(completionCalled)
+        }
+        XCTAssert(slider.value == 99)
+        
+        completionCalled = false
+        XCTAssertFalse(completionCalled)
+        
+        slider.setValue(50, animated: false, duration: 2) {
+            completionCalled = true
+            XCTAssert(completionCalled)
+        }
+        XCTAssert(slider.value == 50)
+    }
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [] New extensions support iOS 8 or later.
- [] New extensions are written in Swift 3.
- [] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:
- Completely test UINavigationBarExtensions
- Completely test UINavigationControllerExtensions
- Completely test UINavigationItemExtensions
- Completely test UISliderExtensions