### PR TITLE
Add UIImageViewExtensionsTests + Fix infinite recursive call

### DIFF
--- a/Source/Extensions/UIKit/UIImageViewExtensions.swift
+++ b/Source/Extensions/UIKit/UIImageViewExtensions.swift
@@ -23,7 +23,7 @@ extension UIImageView {
 	public func download(from url: URL,
 	                     contentMode: UIViewContentMode = .scaleAspectFit,
 	                     placeholder: UIImage? = nil,
-	                     completionHandler: ((UIImage?, Error?) -> Void)? = nil) {
+	                     completionHandler: ((UIImage?) -> Void)? = nil) {
 		
 		image = placeholder
 		self.contentMode = contentMode
@@ -31,24 +31,24 @@ extension UIImageView {
 			guard
 				let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
 				let mimeType = response?.mimeType, mimeType.hasPrefix("image"),
-				let data = data, error == nil,
+				let data = data,
 				let image = UIImage(data: data)
 				else {
-					completionHandler?(nil, error)
+					completionHandler?(nil)
 					return
 			}
 			DispatchQueue.main.async() { () -> Void in
 				self.image = image
-				completionHandler?(image, nil)
+				completionHandler?(image)
 			}
 			}.resume()
 	}
 	
 	/// SwifterSwift: Make image view blurry
 	///
-	/// - Parameter withStyle: UIBlurEffectStyle (default is .light).
-	func blur(withStyle: UIBlurEffectStyle = .light) {
-		let blurEffect = UIBlurEffect(style: withStyle)
+	/// - Parameter style: UIBlurEffectStyle (default is .light).
+	func blur(withStyle style: UIBlurEffectStyle = .light) {
+		let blurEffect = UIBlurEffect(style: style)
 		let blurEffectView = UIVisualEffectView(effect: blurEffect)
 		blurEffectView.frame = bounds
 		blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight] // for supporting device rotation
@@ -58,11 +58,13 @@ extension UIImageView {
 	
 	/// SwifterSwift: Blurred version of an image view
 	///
-	/// - Parameter withStyle: UIBlurEffectStyle (default is .light).
+	/// - Parameter style: UIBlurEffectStyle (default is .light).
 	/// - Returns: blurred version of self.
-	func blurred(withStyle: UIBlurEffectStyle = .light) -> UIImageView {
-		self.blur(withStyle: withStyle)
-        return self
+	func blurred(withStyle style: UIBlurEffectStyle = .light) -> UIImageView {
+		let imgView = self
+		imgView.blur(withStyle: style)
+		return imgView
 	}
+	
 }
 #endif

--- a/Source/Extensions/UIKit/UIImageViewExtensions.swift
+++ b/Source/Extensions/UIKit/UIImageViewExtensions.swift
@@ -61,8 +61,8 @@ extension UIImageView {
 	/// - Parameter withStyle: UIBlurEffectStyle (default is .light).
 	/// - Returns: blurred version of self.
 	func blurred(withStyle: UIBlurEffectStyle = .light) -> UIImageView {
-		return self.blurred(withStyle: withStyle)
+		self.blur(withStyle: withStyle)
+        return self
 	}
-	
 }
 #endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -187,6 +187,8 @@
 		6EF946B21E263D860061AEFC /* SwifterSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BC11E11D1EF000E9A85 /* SwifterSwiftTests.swift */; };
 		6EF946D81E263DC80061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF946D91E263DCA0061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B070A0C21E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */; };
+		B070A0C31E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */; };
 		B0C4D1D51E48A52400DACC28 /* UIStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */; };
 		B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */; };
 		B0E3B7991E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */; };
@@ -301,6 +303,7 @@
 		6EBD19E61E23E444002186D3 /* SwifterSwift tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946901E263C4D0061AEFC /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946981E263C4E0061AEFC /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensionsTests.swift; sourceTree = "<group>"; };
 		B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensions.swift; sourceTree = "<group>"; };
 		B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionsTests.swift; sourceTree = "<group>"; };
@@ -517,6 +520,7 @@
 				B0E3B7C61E559B3100B50FE3 /* UISliderExtensionsTests.swift */,
 				B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */,
 				B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */,
+				B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */,
 			);
 			path = UIKitExtensionsTests;
 			sourceTree = "<group>";
@@ -879,6 +883,7 @@
 				07750B631E54AC990034E625 /* UITextViewExtensionsTests.swift in Sources */,
 				07750B5E1E54A78F0034E625 /* UISearchBarExtensionsTests.swift in Sources */,
 				B0E3B79C1E52F47500B50FE3 /* UIBarButtonExtensionsTests.swift in Sources */,
+				B070A0C21E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift in Sources */,
 				B0E3B7CC1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */,
 				07750B5C1E54A5F00034E625 /* UISwitchExtensionsTests.swift in Sources */,
 				07445BC71E11D1EF000E9A85 /* DictionaryExtensionsTests.swift in Sources */,
@@ -970,6 +975,7 @@
 				07750B671E54AD8E0034E625 /* UIViewExtensionsTests.swift in Sources */,
 				B0E3B7CD1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */,
 				078B0E4D1E507E7F009189B3 /* DataExtensionsTests.swift in Sources */,
+				B070A0C31E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift in Sources */,
 				07AB1A721E44AABB00CEF96C /* URLExtensionsTests.swift in Sources */,
 				6EBD1A001E23E4A5002186D3 /* SwifterSwiftTests.swift in Sources */,
 				07B897E71E3218E400A09B44 /* BoolExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIImageViewExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIImageViewExtensionsTests.swift
@@ -1,0 +1,61 @@
+//
+//  UIImageViewExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/19/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import XCTest
+@testable import SwifterSwift
+
+class UIImageViewExtensionsTests: XCTestCase {
+    
+    func testDownload() {
+        let imageView = UIImageView()
+        let url = URL(string: "https://developer.apple.com/swift/images/swift-og.png")!
+        let placeHolder = UIImage()
+        var completionCalled = false
+        imageView.download(from: url, contentMode: .scaleAspectFill, placeholder: placeHolder) { (image, error) in
+            completionCalled = true
+            XCTAssert(completionCalled)
+            XCTAssertNil(error)
+            XCTAssertEqual(imageView.image, image)
+        }
+        XCTAssertEqual(imageView.image, placeHolder)
+        XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
+        
+        let failingURL = URL(string: "https://developer.apple.com/")!
+        var failingCompletionCalled = false
+        imageView.download(from: failingURL, contentMode: .center, placeholder: nil) { (image, error) in
+            failingCompletionCalled = true
+            XCTAssertNil(error)
+            XCTAssertNil(image)
+            XCTAssert(failingCompletionCalled)
+        }
+        XCTAssertEqual(imageView.contentMode, .center)
+        XCTAssertNil(imageView.image)
+    }
+    
+    func testBlur() {
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 50, height: 100))
+        imageView.blur(withStyle: .dark)
+        
+        let blurView = imageView.subviews.first as? UIVisualEffectView
+        XCTAssertNotNil(blurView)
+        XCTAssertNotNil(blurView?.effect)
+        XCTAssertEqual(blurView?.frame, imageView.bounds)
+        XCTAssertEqual(blurView?.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+        XCTAssert(imageView.clipsToBounds)
+    }
+    
+    func testBlurred() {
+        let imageView = UIImageView()
+        let blurredImageView = imageView.blurred(withStyle: .extraLight)
+        XCTAssertEqual(blurredImageView, imageView)
+    }
+    
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIImageViewExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIImageViewExtensionsTests.swift
@@ -7,55 +7,53 @@
 //
 
 #if os(iOS) || os(tvOS)
-
+	
 import XCTest
 @testable import SwifterSwift
 
 class UIImageViewExtensionsTests: XCTestCase {
-    
-    func testDownload() {
-        let imageView = UIImageView()
-        let url = URL(string: "https://developer.apple.com/swift/images/swift-og.png")!
-        let placeHolder = UIImage()
-        var completionCalled = false
-        imageView.download(from: url, contentMode: .scaleAspectFill, placeholder: placeHolder) { (image, error) in
-            completionCalled = true
-            XCTAssert(completionCalled)
-            XCTAssertNil(error)
-            XCTAssertEqual(imageView.image, image)
-        }
-        XCTAssertEqual(imageView.image, placeHolder)
-        XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
-        
-        let failingURL = URL(string: "https://developer.apple.com/")!
-        var failingCompletionCalled = false
-        imageView.download(from: failingURL, contentMode: .center, placeholder: nil) { (image, error) in
-            failingCompletionCalled = true
-            XCTAssertNil(error)
-            XCTAssertNil(image)
-            XCTAssert(failingCompletionCalled)
-        }
-        XCTAssertEqual(imageView.contentMode, .center)
-        XCTAssertNil(imageView.image)
-    }
-    
-    func testBlur() {
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 50, height: 100))
-        imageView.blur(withStyle: .dark)
-        
-        let blurView = imageView.subviews.first as? UIVisualEffectView
-        XCTAssertNotNil(blurView)
-        XCTAssertNotNil(blurView?.effect)
-        XCTAssertEqual(blurView?.frame, imageView.bounds)
-        XCTAssertEqual(blurView?.autoresizingMask, [.flexibleWidth, .flexibleHeight])
-        XCTAssert(imageView.clipsToBounds)
-    }
-    
-    func testBlurred() {
-        let imageView = UIImageView()
-        let blurredImageView = imageView.blurred(withStyle: .extraLight)
-        XCTAssertEqual(blurredImageView, imageView)
-    }
-    
+	
+	func testDownload() {
+		let imageView = UIImageView()
+		let url = URL(string: "https://developer.apple.com/swift/images/swift-og.png")!
+		let placeHolder = UIImage()
+		var completionCalled = false
+		imageView.download(from: url, contentMode: .scaleAspectFill, placeholder: placeHolder) { image in
+			completionCalled = true
+			XCTAssert(completionCalled)
+			XCTAssertEqual(imageView.image, image)
+		}
+		XCTAssertEqual(imageView.image, placeHolder)
+		XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
+		
+		let failingURL = URL(string: "https://developer.apple.com/")!
+		var failingCompletionCalled = false
+		imageView.download(from: failingURL, contentMode: .center, placeholder: nil) { image in
+			failingCompletionCalled = true
+			XCTAssertNil(image)
+			XCTAssert(failingCompletionCalled)
+		}
+		XCTAssertEqual(imageView.contentMode, .center)
+		XCTAssertNil(imageView.image)
+	}
+	
+	func testBlur() {
+		let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 50, height: 100))
+		imageView.blur(withStyle: .dark)
+		
+		let blurView = imageView.subviews.first as? UIVisualEffectView
+		XCTAssertNotNil(blurView)
+		XCTAssertNotNil(blurView?.effect)
+		XCTAssertEqual(blurView?.frame, imageView.bounds)
+		XCTAssertEqual(blurView?.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+		XCTAssert(imageView.clipsToBounds)
+	}
+	
+	func testBlurred() {
+		let imageView = UIImageView()
+		let blurredImageView = imageView.blurred(withStyle: .extraLight)
+		XCTAssertEqual(blurredImageView, imageView)
+	}
+	
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [] New extensions support iOS 8 or later.
- [] New extensions are written in Swift 3.
- [] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:
- Adds complete testing for UIImageViewExtensions

- Fixes endless recursive call in blurred() method

Something we may want to consider here is combining the blur() and blurred() methods and just giving it a discardable result. I didn't implement this since I was not the one who originally created the extension.

- Note for the blur() method I did not like that I could not test if the applied UIVisualEffectView has the correct style due to UIBlurEffect having no accessible properties. 