### PR TITLE
Add UIViewController+UIStoryboardExtensions tests

### DIFF
--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -193,6 +193,12 @@
 		6EF946D91E263DCA0061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B070A0C21E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */; };
 		B070A0C31E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */; };
+		B070A0D41E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0D31E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift */; };
+		B070A0D51E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0D31E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift */; };
+		B070A0D71E62868800EBBD25 /* TestStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B070A0D61E62868800EBBD25 /* TestStoryboard.storyboard */; };
+		B070A0D81E62868800EBBD25 /* TestStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B070A0D61E62868800EBBD25 /* TestStoryboard.storyboard */; };
+		B070A0E41E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0E31E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift */; };
+		B070A0E51E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070A0E31E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift */; };
 		B0C4D1D51E48A52400DACC28 /* UIStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */; };
 		B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */; };
 		B0E3B7991E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */; };
@@ -310,6 +316,9 @@
 		6EF946901E263C4D0061AEFC /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946981E263C4E0061AEFC /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensionsTests.swift; sourceTree = "<group>"; };
+		B070A0D31E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensionsTests.swift; sourceTree = "<group>"; };
+		B070A0D61E62868800EBBD25 /* TestStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TestStoryboard.storyboard; sourceTree = "<group>"; };
+		B070A0E31E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtensionsTests.swift; sourceTree = "<group>"; };
 		B0C4D1D41E48A52400DACC28 /* UIStoryboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensions.swift; sourceTree = "<group>"; };
 		B0E3B78F1E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B7981E52F25800B50FE3 /* UIButtonExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionsTests.swift; sourceTree = "<group>"; };
@@ -529,6 +538,9 @@
 				B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */,
 				B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */,
 				07AE0C2F1E614EB8002FC982 /* UITableViewExtensionsTests.swift */,
+				B070A0E31E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift */,
+				B070A0D31E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift */,
+				B070A0D61E62868800EBBD25 /* TestStoryboard.storyboard */,
 			);
 			path = UIKitExtensionsTests;
 			sourceTree = "<group>";
@@ -772,6 +784,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B070A0D71E62868800EBBD25 /* TestStoryboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -793,6 +806,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B070A0D81E62868800EBBD25 /* TestStoryboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -880,10 +894,12 @@
 				B0E3B7C91E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */,
 				078B0E481E507E4C009189B3 /* CollectionExtensionsTests.swift in Sources */,
 				07445BC21E11D1EF000E9A85 /* ArrayExtensionsTests.swift in Sources */,
+				B070A0E41E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift in Sources */,
 				07750B661E54AD8E0034E625 /* UIViewExtensionsTests.swift in Sources */,
 				B0E3B7C71E559B3100B50FE3 /* UISliderExtensionsTests.swift in Sources */,
 				07AE0C331E615892002FC982 /* UICollectionViewExtensionsTests.swift in Sources */,
 				07AB1A6A1E448CD800CEF96C /* CGFloatExtensionsTests.swift in Sources */,
+				B070A0D41E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift in Sources */,
 				07445BC91E11D1EF000E9A85 /* FloatExtensionsTests.swift in Sources */,
 				07AB1A651E448C4500CEF96C /* UIColorExtensionsTests.swift in Sources */,
 				B0E3B7991E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */,
@@ -979,9 +995,11 @@
 				B0E3B7CA1E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */,
 				B0E3B79A1E52F25800B50FE3 /* UIButtonExtensionsTests.swift in Sources */,
 				07AB1A631E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
+				B070A0E51E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift in Sources */,
 				07AB1A6E1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
 				6EBD19FB1E23E4A5002186D3 /* DoubleExtensionsTests.swift in Sources */,
 				6EBD19FE1E23E4A5002186D3 /* IntExtensionsTests.swift in Sources */,
+				B070A0D51E6284E300EBBD25 /* UIStoryboardExtensionsTests.swift in Sources */,
 				07750B671E54AD8E0034E625 /* UIViewExtensionsTests.swift in Sources */,
 				B0E3B7CD1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */,
 				078B0E4D1E507E7F009189B3 /* DataExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/TestStoryboard.storyboard
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/TestStoryboard.storyboard
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="Bsj-4X-wVF">
+            <objects>
+                <viewController storyboardIdentifier="UIViewController" id="IoH-NR-bAy" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="FCf-4t-C3M"/>
+                        <viewControllerLayoutGuide type="bottom" id="S65-i7-r1e"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="WSF-UG-5Pt">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dK9-jX-ngd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4" y="53"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIStoryboardExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIStoryboardExtensionsTests.swift
@@ -1,0 +1,22 @@
+//
+//  UIStoryboardExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/25/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS)
+
+import XCTest
+@testable import SwifterSwift
+    
+class UIStoryboardExtensionsTests: XCTestCase {
+    
+    func testInstantiateViewController() {
+        let storyboard = UIStoryboard(name: "TestStoryboard", bundle: Bundle(for: UIStoryboardExtensionsTests.self))
+        let viewController = storyboard.instantiateViewController(withClass: UIViewController.self)
+        XCTAssertNotNil(viewController)
+    }
+}
+#endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIViewControllerExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIViewControllerExtensionsTests.swift
@@ -1,0 +1,60 @@
+//
+//  UIViewControllerExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Steven on 2/25/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import XCTest
+@testable import SwifterSwift
+    
+class UIViewControllerExtensionsTests: XCTestCase {
+    
+    class MockNotificationViewController: UIViewController {
+        var notificationFired = false
+        
+        func testSelector() {
+            notificationFired = true
+        }
+    }
+    
+    let notificationIdentifier = Notification.Name("MockNotification")
+    
+    func testNavigationBar() {
+        let viewController = UIViewController()
+        XCTAssertNil(viewController.navigationBar)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        XCTAssertEqual(navigationController.navigationBar, viewController.navigationBar)
+    }
+    
+    func testAddNotificationObserver() {
+        let viewController = MockNotificationViewController()
+        let selector = #selector(MockNotificationViewController.testSelector)
+        viewController.addNotificationObserver(name: notificationIdentifier, selector: selector)
+        NotificationCenter.default.post(name: notificationIdentifier, object: nil)
+        XCTAssert(viewController.notificationFired)
+    }
+    
+    func testRemoveNotificationObserver() {
+        let viewController = MockNotificationViewController()
+        let selector = #selector(MockNotificationViewController.testSelector)
+        viewController.addNotificationObserver(name: notificationIdentifier, selector: selector)
+        viewController.removeNotificationObserver(name: notificationIdentifier)
+        NotificationCenter.default.post(name: notificationIdentifier, object: nil)
+        XCTAssertFalse(viewController.notificationFired)
+
+    }
+    
+    func testRemoveNotificationsObserver() {
+        let viewController = MockNotificationViewController()
+        let selector = #selector(MockNotificationViewController.testSelector)
+        viewController.addNotificationObserver(name: notificationIdentifier, selector: selector)
+        viewController.removeNotificationsObserver()
+        NotificationCenter.default.post(name: notificationIdentifier, object: nil)
+        XCTAssertFalse(viewController.notificationFired)
+    }
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [] New extensions support iOS 8 or later.
- [] New extensions are written in Swift 3.
- [] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All comments headers have the word **SwifterSwift:** before description.

Summary of Pull Request:
- Adds complete testing for UIViewControllerExtensions & UIStoryboardExtensions
- Added a new file TestStoryboard to the SwifterSwiftTests target