### PR TITLE
Reduce shuffle()/shuffled() complexity and minor updates

### DIFF
--- a/Source/Extensions/ArrayExtensions.swift
+++ b/Source/Extensions/ArrayExtensions.swift
@@ -38,26 +38,6 @@ public extension Array where Element: FloatingPoint {
 	
 }
 
-
-// MARK: - Properties (Equatable)
-public extension Array where Element: Equatable {
-	
-	/// SwifterSwift: Shuffled version of array.
-	public var shuffled: [Element] {
-		var arr = self
-		arr.shuffle()
-		return arr
-	}
-	
-	/// SwifterSwift: Array with all duplicates removed from it.
-	public var withoutDuplicates: [Element] {
-		// Thanks to https://github.com/sairamkotha for improving the preperty
-		return reduce([]){ ($0 as [Element]).contains($1) ? $0 : $0 + [$1] }
-	}
-	
-}
-
-
 // MARK: - Methods
 public extension Array {
 	
@@ -106,8 +86,7 @@ public extension Array {
 	///
 	/// - Returns: last element in array (if applicable).
 	@discardableResult public mutating func pop() -> Element? {
-		guard !isEmpty else { return nil }
-		return removeLast()
+        return popLast()
 	}
 	
 	/// SwifterSwift: Insert an element at the beginning of array.
@@ -130,17 +109,22 @@ public extension Array {
 // MARK: - Methods (Equatable)
 public extension Array where Element: Equatable {
 	
-	/// SwifterSwift: Shuffle array.
-	public mutating func shuffle() {
-		// https://gist.github.com/ijoshsmith/5e3c7d8c2099a3fe8dc3
-		let arr = self
-		for _ in 0..<10 {
-			sort { (_,_) in arc4random() < arc4random() }
-		}
-		if self == arr {
-			shuffle()
-		}
-	}
+    /// SwifterSwift: Shuffle array. (Using Fisher-Yates Algorithm)
+    public mutating func shuffle() {
+        //http://stackoverflow.com/questions/37843647/shuffle-array-swift-3
+        guard count > 1 else { return }
+        for index in startIndex..<endIndex - 1 {
+            let randomIndex = Int(arc4random_uniform(UInt32(endIndex - index))) + index
+            if index != randomIndex { swap(&self[index], &self[randomIndex]) }
+        }
+    }
+    
+    /// SwifterSwift: Shuffled version of array. (Using Fisher-Yates Algorithm)
+    public func shuffled() -> [Element] {
+        var array = self
+        array.shuffle()
+        return array
+    }
 	
 	/// SwifterSwift: Check if array contains an array of elements.
 	///
@@ -180,10 +164,16 @@ public extension Array where Element: Equatable {
 		self = filter { $0 != item }
 	}
 	
-	/// SwifterSwift: Remove all duplicates from array.
-	public mutating func removeDuplicates() {
-		// Thanks to https://github.com/sairamkotha for improving the method
-		self = reduce([]){ $0.contains($1) ? $0 : $0 + [$1] }
-	}
-	
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    public mutating func removeDuplicates() {
+        // Thanks to https://github.com/sairamkotha for improving the method
+        self = reduce([]){ $0.contains($1) ? $0 : $0 + [$1] }
+    }
+    
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    /// - Returns: An array of unique elements.
+    public func duplicatesRemoved() -> [Element] {
+        // Thanks to https://github.com/sairamkotha for improving the property
+        return reduce([]){ ($0 as [Element]).contains($1) ? $0 : $0 + [$1] }
+    }
 }

--- a/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -77,34 +77,43 @@ class ArrayExtensionsTests: XCTestCase {
 		XCTAssertEqual(arr, [1, 2, 3, 4, 5])
 	}
 	
-	func testRemoveDuplicates() {
-		var arr = [1, 2, 1, 3, 4, 5, 1, 1]
-		arr.removeDuplicates()
-		XCTAssertEqual(arr, [1, 2, 3, 4, 5])
-	}
-	
-	func testShuffle() {
-		for _ in 1...1000 {
-			var arr = [1, 2, 3, 4, 5]
-			arr.shuffle()
-			XCTAssertEqual(arr.count, 5)
-			XCTAssertNotEqual(arr, [1, 2, 3, 4, 5])
-		}
-	}
-	
-	func testShuffled() {
-		XCTAssertEqual([1, 2, 3, 4, 5].shuffled.count, 5)
-		XCTAssertNotEqual([1, 2, 3, 4, 5].shuffled, [1, 2, 3, 4, 5])
-	}
+    func testShuffle() {
+        
+        let original = [1, 2, 3, 4, 5]
+        var array = original
+        
+        while original == array {
+            array.shuffle()
+        }
+        XCTAssertEqual(array.count, 5)
+        XCTAssertNotEqual(original, array)
+    }
+    
+    func testShuffled() {
+        let original = [1, 2, 3, 4, 5]
+        var array = original
+        
+        while original == array {
+            array = array.shuffled()
+        }
+        XCTAssertEqual(array.count, 5)
+        XCTAssertNotEqual(original, array)
+    }
 	
 	func testSum() {
 		XCTAssertEqual([1, 2, 3, 4, 5].sum, 15)
 		XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].sum, 17)
 	}
 	
-	func testWithoutDuplicates() {
-		XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates, [1, 2, 3, 4, 5])
-	}
+    func testRemoveDuplicates() {
+        var array = [1, 1, 2, 2, 3, 3, 3, 4, 5]
+        array.removeDuplicates()
+        XCTAssertEqual(array, [1, 2, 3, 4, 5])
+    }
+    
+    func testDuplicatesRemoved() {
+        XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].duplicatesRemoved(), [1, 2, 3, 4, 5])
+    }
 	
 	func testItemAtIndex() {
 		XCTAssertEqual([1, 2, 3].item(at: 0), 1)


### PR DESCRIPTION
@omaralbeik don't merge this yet it's in progress

- Updated `shuffle()` / `shuffled()` methods to use Fisher-Yates Algorithm
Replaces the previous **O(n^2)** complexity with **O(n)**
The output is now completely random. I've removed the check against the original array.

- Converted `shuffled` and `withoutDuplicates` properties to methods
`withoutDuplicates` has been renamed to `duplicatesRemoved()`

- Updating `pop()` to just return the result of `popLast()` so we can rely on the standard libraries implementation of this method

I'm considering putting the shuffle() / shuffled() methods on an extension to MutableCollection
This way they will work for not only Arrays but ArraySlices as well.
This can be refactored at a later date.

The main reason I'm holding off on this is because having an extension on MutableCollection may not be inherently obvious that it can be used on Arrays.

We would have to acknowledge in the SwifterSwift Docs that Array conforms to MutableCollection. 

(although people would see the method with autocomplete or could view the official Apple docs to see what conforms to MutableCollection)

Ultimately, however, I'd like to share as much functionality as possible between Collections by extending their composing protocols.
