### PR TITLE
Fix: Typo in `UICollectionViewExtensions` and `UITableViewExtensions`

### DIFF
--- a/Source/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Source/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -65,22 +65,22 @@ public extension UICollectionView {
 		})
 	}
     
-    /// SwifterSwift: Deque reusable UICollectionViewCell using class name.
+    /// SwifterSwift: Dequeue reusable UICollectionViewCell using class name.
     ///
     /// - Parameter name: UICollectionViewCell type.
     /// - Parameter indexPath: Location of cell in collectionView.
     /// - Returns: UICollectionViewCell object with associated class name.
-    public func dequeReusableCell<T: UICollectionViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
+    public func dequeueReusableCell<T: UICollectionViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
         return dequeueReusableCell(withReuseIdentifier: String(describing: name), for: indexPath) as! T
     }
     
-    /// SwifterSwift: Deque reusable UICollectionReusableView using class name.
+    /// SwifterSwift: Dequeue reusable UICollectionReusableView using class name.
     ///
     /// - Parameter ofKind: The kind of supplementary view to retrieve. This value is defined by the layout object.
     /// - Parameter name: UICollectionReusableView type.
     /// - Parameter indexPath: Location of cell in collectionView.
     /// - Returns: UICollectionReusableView object with associated class name.
-    func dequeReusableSupplementaryView<T: UICollectionReusableView>(ofKind: String, withClass name: T.Type, for indexPath: IndexPath) -> T {
+    func dequeueReusableSupplementaryView<T: UICollectionReusableView>(ofKind: String, withClass name: T.Type, for indexPath: IndexPath) -> T {
         return dequeueReusableSupplementaryView(ofKind: ofKind, withReuseIdentifier: String(describing: name), for: indexPath) as! T
     }
     

--- a/Source/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Source/Extensions/UIKit/UITableViewExtensions.swift
@@ -90,28 +90,28 @@ public extension UITableView {
 		setContentOffset(CGPoint.zero, animated: animated)
 	}
     
-    /// SwifterSwift: Deque reusable UITableViewCell using class name
+    /// SwifterSwift: Dequeue reusable UITableViewCell using class name
     ///
     /// - Parameter name: UITableViewCell type
     /// - Returns: UITableViewCell object with associated class name (optional value)
-    public func dequeReusableCell<T: UITableViewCell>(withClass name: T.Type) -> T? {
+    public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type) -> T? {
         return dequeueReusableCell(withIdentifier: String(describing: name)) as? T
     }
     
-    /// SwiferSwift: Deque reusable UITableViewCell using class name for indexPath
+    /// SwiferSwift: Dequeue reusable UITableViewCell using class name for indexPath
     ///
     /// - Parameter name: UITableViewCell type
     /// - Parameter indexPath: Location of cell in tableView
     /// - Returns: UITableViewCell object with associated class name
-    public func dequeReusableCell<T: UITableViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
+    public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
         return dequeueReusableCell(withIdentifier: String(describing: name), for: indexPath) as! T
     }
     
-    /// SwiferSwift: Deque reusable UITableViewHeaderFooterView using class name
+    /// SwiferSwift: Dequeue reusable UITableViewHeaderFooterView using class name
     ///
     /// - Parameter name: UITableViewHeaderFooterView type
     /// - Returns: UITableViewHeaderFooterView object with associated class name (optional value)
-    func dequeReusableHeaderFooterView<T: UITableViewHeaderFooterView>(withClass name: T.Type) -> T? {
+    func dequeueReusableHeaderFooterView<T: UITableViewHeaderFooterView>(withClass name: T.Type) -> T? {
         return dequeueReusableHeaderFooterView(withIdentifier: String(describing: name)) as? T
     }
     

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UITableViewExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UITableViewExtensionsTests.swift
@@ -76,56 +76,56 @@
             XCTAssertEqual(CGPoint.zero, tableView.contentOffset)
         }
 
-        func testDequeReusableCellWithClass() {
+        func testDequeueReusableCellWithClass() {
             tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCell")
-            let cell = tableView.dequeReusableCell(withClass: UITableViewCell.self)
+            let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
             XCTAssertNotNil(cell)
         }
         
-        func testDequeReusableCellWithClassForIndexPath() {
+        func testDequeueReusableCellWithClassForIndexPath() {
             tableView.register(UITableViewCell.self, forCellReuseIdentifier: "UITableViewCell")
             let indexPath = tableView.indexPathForLastRow!
-            let cell = tableView.dequeReusableCell(withClass: UITableViewCell.self, for: indexPath)
+            let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self, for: indexPath)
             XCTAssertNotNil(cell)
         }
         
-        func testDequeReusableHeaderFooterView() {
+        func testDequeueReusableHeaderFooterView() {
             tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "UITableViewHeaderFooterView")
-            let headerFooterView = tableView.dequeReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
+            let headerFooterView = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
             XCTAssertNotNil(headerFooterView)
         }
         
         func testRegisterReusableViewWithClassAndNib() {
-            let nilView = tableView.dequeReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
+            let nilView = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
             XCTAssertNil(nilView)
             let nib = UINib(nibName: "UITableViewHeaderFooterView", bundle: Bundle(for: UITableViewExtensionsTests.self))
             tableView.register(nib: nib, withHeaderFooterViewClass: UITableViewHeaderFooterView.self)
-            let view = tableView.dequeReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
+            let view = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
             XCTAssertNotNil(view)
         }
         
         func testRegisterReusableViewWithClass() {
-            let nilView = tableView.dequeReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
+            let nilView = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
             XCTAssertNil(nilView)
             tableView.register(headerFooterViewClassWith: UITableViewHeaderFooterView.self)
-            let view = tableView.dequeReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
+            let view = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
             XCTAssertNotNil(view)
         }
         
         func testRegisterCellWithClass() {
-            let nilCell = tableView.dequeReusableCell(withClass: UITableViewCell.self)
+            let nilCell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
             XCTAssertNil(nilCell)
             tableView.register(cellWithClass: UITableViewCell.self)
-            let cell = tableView.dequeReusableCell(withClass: UITableViewCell.self)
+            let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
             XCTAssertNotNil(cell)
         }
         
         func testRegisterCellWithClassAndNib() {
-            let nilCell = tableView.dequeReusableCell(withClass: UITableViewCell.self)
+            let nilCell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
             XCTAssertNil(nilCell)
             let nib = UINib(nibName: "UITableViewCell", bundle: Bundle(for: UITableViewExtensionsTests.self))
             tableView.register(nib: nib, withCellClass: UITableViewCell.self)
-            let cell = tableView.dequeReusableCell(withClass: UITableViewCell.self)
+            let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
             XCTAssertNotNil(cell)
         }
 	}


### PR DESCRIPTION
All functions with prefix `deque` should be `dequeue`.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] I have **only one commit** in this pull request.
- [X] New extensions support iOS 8 or later.
- [X] New extensions are written in Swift 3.
- [X] I have added tests for new extensions, and they passed.
- [X] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All comments headers have the word **SwifterSwift:** before description.
