### PR TITLE
Add quick setter and getter for `x` and `y` to UIView extension

### DIFF
--- a/Source/Extensions/UIKit/UIViewExtensions.swift
+++ b/Source/Extensions/UIKit/UIViewExtensions.swift
@@ -206,7 +206,27 @@
 				frame.size.width = newValue
 			}
 		}
-		
+
+    /// SwifterSwift: x of view.
+    public var x: CGFloat {
+      get {
+        return frame.origin.x
+      }
+      set {
+        frame.origin.x = newValue
+      }
+    }
+
+    /// SwifterSwift: y of view.
+    public var y: CGFloat {
+      get {
+        return frame.origin.y
+      }
+      set {
+        frame.origin.y = newValue
+      }
+    }
+
 	}
 	
 	

--- a/Source/Extensions/UIKit/UIViewExtensions.swift
+++ b/Source/Extensions/UIKit/UIViewExtensions.swift
@@ -206,27 +206,27 @@
 				frame.size.width = newValue
 			}
 		}
-
-    /// SwifterSwift: x of view.
-    public var x: CGFloat {
-      get {
-        return frame.origin.x
-      }
-      set {
-        frame.origin.x = newValue
-      }
-    }
-
-    /// SwifterSwift: y of view.
-    public var y: CGFloat {
-      get {
-        return frame.origin.y
-      }
-      set {
-        frame.origin.y = newValue
-      }
-    }
-
+		
+		/// SwifterSwift: x origin of view.
+		public var x: CGFloat {
+			get {
+				return frame.origin.x
+			}
+			set {
+				frame.origin.x = newValue
+			}
+		}
+		
+		/// SwifterSwift: y origin of view.
+		public var y: CGFloat {
+			get {
+				return frame.origin.y
+			}
+			set {
+				frame.origin.y = newValue
+			}
+		}
+		
 	}
 	
 	


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
