### PR TITLE
Refactor Array properties to  methods and minor simplifications

### DIFF
--- a/Source/Extensions/ArrayExtensions.swift
+++ b/Source/Extensions/ArrayExtensions.swift
@@ -9,11 +9,12 @@
 import Foundation
 
 
-// MARK: - Properties (Integer)
+// MARK: - Methods (Integer)
 public extension Array where Element: Integer {
-	
+    
 	/// SwifterSwift: Sum of all elements in array.
-	public var sum: Element {
+    /// Returns: sum of the array's elements (Integer).
+	public func sum() -> Element {
 		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
 		return reduce(0, +)
 	}
@@ -21,17 +22,19 @@ public extension Array where Element: Integer {
 }
 
 
-// MARK: - Properties (FloatingPoint)
+// MARK: - Methods (FloatingPoint)
 public extension Array where Element: FloatingPoint {
 	
 	/// SwifterSwift: Average of all elements in array.
-	public var average: Element {
+    /// Returns: average of the array's elements (FloatingPoint).
+	public func average() -> Element {
 		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
 		return isEmpty ? 0 : reduce(0, +) / Element(count)
 	}
 	
 	/// SwifterSwift: Sum of all elements in array.
-	public var sum: Element {
+    /// Returns: sum of the array's elements (FloatingPoint).
+	public func sum() -> Element {
 		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
 		return reduce(0, +)
 	}
@@ -46,40 +49,8 @@ public extension Array {
 	/// - Parameter index: index of element.
 	/// - Returns: optional element (if exists).
 	public func item(at index: Int) -> Element? {
-		guard 0..<count ~= index else { return nil }
+		guard startIndex...endIndex ~= index else { return nil }
 		return self[index]
-	}
-	
-	/// SwifterSwift: First index of a given item in an array.
-	///
-	/// - Parameter item: item to check.
-	/// - Returns: first index of item in array (if exists).
-	public func firstIndex <Item: Equatable> (of item: Item) -> Int? {
-		if item is Element {
-			for (index, value) in lazy.enumerated() {
-				if value as! Item == item {
-					return index
-				}
-			}
-			return nil
-		}
-		return nil
-	}
-	
-	/// SwifterSwift: Last index of element in array.
-	///
-	/// - Parameter item: item to check.
-	/// - Returns: last index of item in array (if exists).
-	public func lastIndex<Item: Equatable>(of item: Item) -> Int? {
-		if item is Element {
-			for (index, value) in reversed().lazy.enumerated() {
-				if value as! Item == item {
-					return count - 1 - index
-				}
-			}
-			return nil
-		}
-		return nil
 	}
 	
 	/// SwifterSwift: Remove last element from array and return it.
@@ -120,6 +91,7 @@ public extension Array where Element: Equatable {
     }
     
     /// SwifterSwift: Shuffled version of array. (Using Fisher-Yates Algorithm)
+    /// Returns: the array with its elements shuffled.
     public func shuffled() -> [Element] {
         var array = self
         array.shuffle()
@@ -149,7 +121,7 @@ public extension Array where Element: Equatable {
 	/// - Returns: an array with all indexes of the given item.
 	public func indexes(of item: Element) -> [Int] {
 		var indexes: [Int] = []
-		for index in 0..<count {
+		for index in startIndex..<endIndex {
 			if self[index] == item {
 				indexes.append(index)
 			}
@@ -176,4 +148,27 @@ public extension Array where Element: Equatable {
         // Thanks to https://github.com/sairamkotha for improving the property
         return reduce([]){ ($0 as [Element]).contains($1) ? $0 : $0 + [$1] }
     }
+    
+    /// SwifterSwift: First index of a given item in an array.
+    ///
+    /// - Parameter item: item to check.
+    /// - Returns: first index of item in array (if exists).
+    public func firstIndex(of item: Element) -> Int? {
+        for (index, value) in lazy.enumerated() {
+            if value == item { return index }
+        }
+        return nil
+    }
+    
+    /// SwifterSwift: Last index of element in array.
+    ///
+    /// - Parameter item: item to check.
+    /// - Returns: last index of item in array (if exists).
+    public func lastIndex(of item: Element) -> Int? {
+        for (index, value) in lazy.enumerated().reversed() {
+            if value == item { return index }
+        }
+        return nil
+    }
+
 }

--- a/Source/Extensions/CollectionExtensions.swift
+++ b/Source/Extensions/CollectionExtensions.swift
@@ -59,11 +59,12 @@ public extension Collection where Index == Int, IndexDistance == Int {
 
 }
 
-// MARK: - Properties (Integer)
+// MARK: - Methods (Integer)
 public extension Collection where Iterator.Element == Int, Index == Int {
 	
 	/// SwifterSwift: Average of all elements in array.
-	public var average: Double {
+    /// Returns: the average of the array's elements (Double).
+	public func average() -> Double {
 		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
 		return isEmpty ? 0 : Double(reduce(0, +)) / Double(endIndex-startIndex)
 	}

--- a/Source/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Source/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -57,7 +57,7 @@ public extension UICollectionView {
 		return IndexPath(item: numberOfItems(inSection: section) - 1, section: section)
 	}
 	
-	/// Reload data with a completion handler.
+	/// SwifterSwift: Reload data with a completion handler.
 	///
 	/// - Parameter completion: completion handler to run after reloadData finishes.
 	public func reloadData(_ completion: @escaping () -> Void) {

--- a/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -15,17 +15,16 @@ class ArrayExtensionsTests: XCTestCase {
 	}
 	
 	func testAverage() {
-		XCTAssertEqual([1, 2, 3, 4, 5].average, 3)
-		XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].average, 3.4)
-		XCTAssertEqual([Int]().average, 0)
-		XCTAssertEqual([Double]().average, 0)
+		XCTAssertEqual([1, 2, 3, 4, 5].average(), 3)
+		XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].average(), 3.4)
+		XCTAssertEqual([Int]().average(), 0)
+		XCTAssertEqual([Double]().average(), 0)
 	}
 	
 	func testFirstIndex() {
 		XCTAssertNotNil([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 2))
 		XCTAssertEqual([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 2)!, 2)
 		XCTAssertNil([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 7))
-		XCTAssertNil([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: "7"))
 	}
 	
 	func testIndexes() {
@@ -36,7 +35,6 @@ class ArrayExtensionsTests: XCTestCase {
 		XCTAssertNotNil([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 2))
 		XCTAssertEqual([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 2)!, 6)
 		XCTAssertNil([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 7))
-		XCTAssertNil([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: "7"))
 	}
 	
 	func testPop() {
@@ -94,8 +92,8 @@ class ArrayExtensionsTests: XCTestCase {
     }
 	
 	func testSum() {
-		XCTAssertEqual([1, 2, 3, 4, 5].sum, 15)
-		XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].sum, 17)
+		XCTAssertEqual([1, 2, 3, 4, 5].sum(), 15)
+		XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].sum(), 17)
 	}
 	
     func testRemoveDuplicates() {


### PR DESCRIPTION
# In Progress

Summary of Pull Request:
- Convert remaining O(N) Array properties to methods.

- Simplified `firstIndex(of:)` and `lastIndex(of:)` methods by moving them into a conditional extension.

This removed the messy generic constraint on the parameter and now prohibits the caller from passing from passing in a different type than the elements of the array. Thus, also removes some unsafe casting.

- ~~Added the `average()` method back to `Array` for `Integer` elements.
(with forced cast, haven't figured out how to avoid this yet)~~

I didn't see this got moved to an extension on Collection so I removed my change.
I did convert this to a method though.

EDIT: Considering moving this back to Array so we can get the average of `Int` or `UInt` arrays.

- Updated all ranges based on `0..<count` logic to use `startIndex` and `endIndex` instead.

I think these are all the changes I have for 1.6.3
