### PR TITLE
String matches regex extension and simplify isEmail implementation.

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -103,9 +103,7 @@ public extension String {
 	/// SwifterSwift: Check if string is valid email format.
 	public var isEmail: Bool {
 		// http://stackoverflow.com/questions/25471114/how-to-validate-an-e-mail-address-in-swift
-		let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
-		let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
-		return emailTest.evaluate(with: self)
+		return matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
 	}
 	
 	/// SwifterSwift: Check if string is a valid URL.
@@ -581,6 +579,15 @@ public extension String {
 		}
 	}
 	
+    /// SwifterSwift: Verify if string matches the regex pattern.
+    /// - Parameter pattern: Pattern to verify.
+    /// - Returns: true if string matches the pattern.
+    func matches(pattern: String) -> Bool {
+        return range(of: pattern,
+                     options: String.CompareOptions.regularExpression,
+                     range: nil, locale: nil) != nil
+    }
+
 }
 
 

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -431,6 +431,13 @@ class StringExtensionsTests: XCTestCase {
 		XCTAssertEqual("it's easy to encode strings".urlEncoded, "it's%20easy%20to%20encode%20strings")
 	}
 	
+    func testMatches() {
+        XCTAssertTrue("123".matches(pattern: "\\d{3}"))
+        XCTAssertFalse("dasda".matches(pattern: "\\d{3}"))
+        XCTAssertFalse("notanemail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
+        XCTAssertTrue("email@mail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
+    }
+    
 	func testWithoutSpacesAndNewLines() {
 		XCTAssertEqual("Hello \n Test".withoutSpacesAndNewLines, "HelloTest")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
