### PR TITLE
Add optional string extension for checking if nil or empty

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -748,3 +748,11 @@ public extension String {
 	}
 	
 }
+
+public extension Optional where Wrapped == String {
+
+    /// A Boolean value indicating whether a string is `nil` or has no characters.
+    public var isNilOrEmpty: Bool {
+        return self?.isEmpty ?? true
+    }
+}

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -584,4 +584,19 @@ class StringExtensionsTests: XCTestCase {
 			XCTAssertEqual(attrs[NSForegroundColorAttributeName] as! UIColor, UIColor.orange)
 		#endif
 	}
+	
+	func testIsNilOrEmpty() {
+        var test: String?
+        
+		XCTAssertTrue(test.isNilOrEmpty)
+        XCTAssertFalse(!test.isNilOrEmpty)
+        
+        test = ""
+		XCTAssertTrue(test.isNilOrEmpty)
+        XCTAssertFalse(!test.isNilOrEmpty)
+        
+        test = "abc"
+		XCTAssertFalse(test.isNilOrEmpty)
+        XCTAssertTrue(!test.isNilOrEmpty)
+	}
 }


### PR DESCRIPTION
Swift 3.1 opens a new world of extensions by allowing to target concrete types. This is an optional string extension for checking for `isNilOrEmpty` stolen from `C#`. Unit test included.

Instead of this:
```
if optionalStr == nil || optionalStr?.isEmpty == true {
    blah.. blah.. show warning.. etc..
}
```
Do this:
```
if optionalStr.isNilOrEmpty {
    blah.. blah.. show warning.. etc..
}
```