### PR TITLE
Add new locale extension with POSIX static property

### DIFF
--- a/Source/Extensions/DateExtensions.swift
+++ b/Source/Extensions/DateExtensions.swift
@@ -212,7 +212,7 @@ public extension Date {
 	public var iso8601String: String {
 		// https://github.com/justinmakaila/NSDate-ISO-8601/blob/master/NSDateISO8601.swift
 		let dateFormatter = DateFormatter()
-		dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+		dateFormatter.locale = .posix
 		dateFormatter.timeZone = TimeZone(abbreviation: "GMT")
 		dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
 		
@@ -544,7 +544,7 @@ public extension Date {
 	public init?(iso8601String: String) {
 		// https://github.com/justinmakaila/NSDate-ISO-8601/blob/master/NSDateISO8601.swift
 		let dateFormatter = DateFormatter()
-		dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+		dateFormatter.locale = .posix
 		dateFormatter.timeZone = TimeZone.current
 		dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 		if let date = dateFormatter.date(from: iso8601String) {

--- a/Source/Extensions/LocaleExtensions.swift
+++ b/Source/Extensions/LocaleExtensions.swift
@@ -1,0 +1,18 @@
+//
+//  LocalExtensions.swift
+//  SwifterSwift
+//
+//  Created by Basem Emara on 4/19/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import Foundation
+
+
+public extension Locale {
+
+    /// Unix representation of locale usually used for normalizing.
+    public static var posix: Locale = {
+        return Locale(identifier: "en_US_POSIX")
+    }()
+}

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -211,6 +211,13 @@
 		6EF946B21E263D860061AEFC /* SwifterSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07445BC11E11D1EF000E9A85 /* SwifterSwiftTests.swift */; };
 		6EF946D81E263DC80061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EF946D91E263DCA0061AEFC /* SwifterSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 072F7A961E11DDDD0021AB84 /* SwifterSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B4967AE1EA7FF4800091A7D /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967AD1EA7FF4800091A7D /* LocaleExtensions.swift */; };
+		8B4967AF1EA7FF4800091A7D /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967AD1EA7FF4800091A7D /* LocaleExtensions.swift */; };
+		8B4967B01EA7FF4800091A7D /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967AD1EA7FF4800091A7D /* LocaleExtensions.swift */; };
+		8B4967C41EA802B200091A7D /* LocaleExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967C31EA802B200091A7D /* LocaleExtensionsTests.swift */; };
+		8B4967C51EA802B200091A7D /* LocaleExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967C31EA802B200091A7D /* LocaleExtensionsTests.swift */; };
+		8B4967C61EA802B200091A7D /* LocaleExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967C31EA802B200091A7D /* LocaleExtensionsTests.swift */; };
+		8B4967C81EA8043600091A7D /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4967AD1EA7FF4800091A7D /* LocaleExtensions.swift */; };
 		B02BE3651E663FED00523EBD /* UITableViewHeaderFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B02BE3641E663FED00523EBD /* UITableViewHeaderFooterView.xib */; };
 		B02BE3661E663FED00523EBD /* UITableViewHeaderFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B02BE3641E663FED00523EBD /* UITableViewHeaderFooterView.xib */; };
 		B02BE3681E66426500523EBD /* UITableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B02BE3671E66426500523EBD /* UITableViewCell.xib */; };
@@ -348,6 +355,8 @@
 		6EBD19E61E23E444002186D3 /* SwifterSwift tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946901E263C4D0061AEFC /* SwifterSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EF946981E263C4E0061AEFC /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B4967AD1EA7FF4800091A7D /* LocaleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleExtensions.swift; sourceTree = "<group>"; };
+		8B4967C31EA802B200091A7D /* LocaleExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleExtensionsTests.swift; sourceTree = "<group>"; };
 		B02BE3641E663FED00523EBD /* UITableViewHeaderFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UITableViewHeaderFooterView.xib; sourceTree = "<group>"; };
 		B02BE3671E66426500523EBD /* UITableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UITableViewCell.xib; sourceTree = "<group>"; };
 		B070A0C11E5A813D00EBBD25 /* UIImageViewExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensionsTests.swift; sourceTree = "<group>"; };
@@ -429,6 +438,7 @@
 				07B897E51E3218E400A09B44 /* BoolExtensionsTests.swift */,
 				07445BB91E11D1EF000E9A85 /* CharacterExtensionsTests.swift */,
 				07445BBA1E11D1EF000E9A85 /* DateExtensionsTests.swift */,
+				8B4967C31EA802B200091A7D /* LocaleExtensionsTests.swift */,
 				07770F551E6A8CD7003339B2 /* OptionalExtensionsTests.swift */,
 				078B0E471E507E4C009189B3 /* CollectionExtensionsTests.swift */,
 				078B0E4B1E507E7F009189B3 /* DataExtensionsTests.swift */,
@@ -459,6 +469,7 @@
 				074821FA1E446D4C00B0C580 /* DictionaryExtensions.swift */,
 				074821FB1E446D4C00B0C580 /* DoubleExtensions.swift */,
 				074821FC1E446D4C00B0C580 /* FloatExtensions.swift */,
+				8B4967AD1EA7FF4800091A7D /* LocaleExtensions.swift */,
 				07770F501E6A8B62003339B2 /* OptionalExtensions.swift */,
 				074821FD1E446D4D00B0C580 /* IntExtensions.swift */,
 				074821FE1E446D4D00B0C580 /* StringExtensions.swift */,
@@ -906,6 +917,7 @@
 				0748225B1E446D4D00B0C580 /* SwifterSwift.swift in Sources */,
 				074822671E446D4D00B0C580 /* UIButtonExtensions.swift in Sources */,
 				074822331E446D4D00B0C580 /* NSAttributedStringExtensions.swift in Sources */,
+				8B4967AE1EA7FF4800091A7D /* LocaleExtensions.swift in Sources */,
 				0748224B1E446D4D00B0C580 /* DoubleExtensions.swift in Sources */,
 				074822AF1E446D4D00B0C580 /* UIViewExtensions.swift in Sources */,
 				074822B31E446D4D00B0C580 /* URLExtensions.swift in Sources */,
@@ -947,6 +959,7 @@
 				07445BCB1E11D1EF000E9A85 /* IntExtensionsTests.swift in Sources */,
 				B0E3B7AF1E555DF100B50FE3 /* UISegmentedControlExtensionsTests.swift in Sources */,
 				078B0E4C1E507E7F009189B3 /* DataExtensionsTests.swift in Sources */,
+				8B4967C41EA802B200091A7D /* LocaleExtensionsTests.swift in Sources */,
 				07AB1A711E44AABB00CEF96C /* URLExtensionsTests.swift in Sources */,
 				07445BCD1E11D1EF000E9A85 /* SwifterSwiftTests.swift in Sources */,
 				07B897E61E3218E400A09B44 /* BoolExtensionsTests.swift in Sources */,
@@ -1005,6 +1018,7 @@
 				07770F531E6A8B62003339B2 /* OptionalExtensions.swift in Sources */,
 				0748222D1E446D4D00B0C580 /* CGPointExtensions.swift in Sources */,
 				074822291E446D4D00B0C580 /* CGFloatExtensions.swift in Sources */,
+				8B4967B01EA7FF4800091A7D /* LocaleExtensions.swift in Sources */,
 				074822311E446D4D00B0C580 /* CGSizeExtensions.swift in Sources */,
 				074822591E446D4D00B0C580 /* StringExtensions.swift in Sources */,
 			);
@@ -1037,6 +1051,7 @@
 				0748226C1E446D4D00B0C580 /* UICollectionViewExtensions.swift in Sources */,
 				074822541E446D4D00B0C580 /* IntExtensions.swift in Sources */,
 				074822241E446D4D00B0C580 /* CGColorExtensions.swift in Sources */,
+				8B4967AF1EA7FF4800091A7D /* LocaleExtensions.swift in Sources */,
 				074822A41E446D4D00B0C580 /* UITextFieldExtensions.swift in Sources */,
 				0748227C1E446D4D00B0C580 /* UILabelExtensions.swift in Sources */,
 				0748228C1E446D4D00B0C580 /* UISearchBarExtensions.swift in Sources */,
@@ -1068,6 +1083,7 @@
 				072711AE1E88528E0020CA34 /* UILabelExtensionsTests.swift in Sources */,
 				B070A0E51E6291AA00EBBD25 /* UIViewControllerExtensionsTests.swift in Sources */,
 				072711B11E8854A80020CA34 /* UITabBarExtensionsTests.swift in Sources */,
+				8B4967C51EA802B200091A7D /* LocaleExtensionsTests.swift in Sources */,
 				07AB1A6E1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
 				6EBD19FB1E23E4A5002186D3 /* DoubleExtensionsTests.swift in Sources */,
 				6EBD19FE1E23E4A5002186D3 /* IntExtensionsTests.swift in Sources */,
@@ -1108,6 +1124,7 @@
 				0748225E1E446D4D00B0C580 /* SwifterSwift.swift in Sources */,
 				074822361E446D4D00B0C580 /* NSAttributedStringExtensions.swift in Sources */,
 				0748224E1E446D4D00B0C580 /* DoubleExtensions.swift in Sources */,
+				8B4967C81EA8043600091A7D /* LocaleExtensions.swift in Sources */,
 				074822B61E446D4D00B0C580 /* URLExtensions.swift in Sources */,
 				0748221E1E446D4D00B0C580 /* BoolExtensions.swift in Sources */,
 				074822221E446D4D00B0C580 /* CharacterExtensions.swift in Sources */,
@@ -1145,6 +1162,7 @@
 				6EF946A71E263D860061AEFC /* ArrayExtensionsTests.swift in Sources */,
 				07AB1A6C1E448CD800CEF96C /* CGFloatExtensionsTests.swift in Sources */,
 				6EF946AE1E263D860061AEFC /* FloatExtensionsTests.swift in Sources */,
+				8B4967C61EA802B200091A7D /* LocaleExtensionsTests.swift in Sources */,
 				07AB1A671E448C4500CEF96C /* UIColorExtensionsTests.swift in Sources */,
 				6EF946B11E263D860061AEFC /* StringExtensionsTests.swift in Sources */,
 				07770F5E1E6A9612003339B2 /* NSViewExtensionsTests.swift in Sources */,

--- a/Tests/SwifterSwiftTests/LocaleExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/LocaleExtensionsTests.swift
@@ -1,0 +1,18 @@
+//
+//  LocaleExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Basem Emara on 4/19/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import XCTest
+@testable import SwifterSwift
+
+class LocaleExtensionsTests: XCTestCase {
+    
+    func testPosix() {
+        let test: Locale = .posix
+        XCTAssertEqual(test.identifier, "en_US_POSIX")
+    }
+}


### PR DESCRIPTION
Provides a static property for POSIX locale. Great on performance too since statically cached for reuse. Added new locale unit tests.

Instead of this:
```
dateFormatter.locale = Locale(identifier: "en_US_POSIX")
```
Do this:
```
dateFormatter.locale = .posix
```