### PR TITLE
CLLocationExtensions new file with extensions for midPoint and bearing between points.

### DIFF
--- a/Source/Extensions/Cocoa/CLLocationExtensions.swift
+++ b/Source/Extensions/Cocoa/CLLocationExtensions.swift
@@ -12,54 +12,61 @@ import CoreLocation
 
 // MARK: - Methods
 public extension CLLocation {
-    
-    /// SwifterSwift: Calculate the half-way point along a great circle path between the two points.
-    ///
-    /// - Parameters:
-    ///   - start: start location.
-    ///   - end: end location.
-    /// - Returns: Location that represents the half-way point.
-    public class func midLocation( start: CLLocation, end: CLLocation) -> CLLocation {
-        
-        let lat1 = start.coordinate.latitude.degreesToRadians
-        let long1 = start.coordinate.longitude.degreesToRadians
-        let lat2 = end.coordinate.latitude.degreesToRadians
-        let long2 = end.coordinate.longitude.degreesToRadians
-        
-        //Formula
-        //    Bx = cos φ2 ⋅ cos Δλ
-        //    By = cos φ2 ⋅ sin Δλ
-        //    φm = atan2( sin φ1 + sin φ2, √(cos φ1 + Bx)² + By² )
-        //    λm = λ1 + atan2(By, cos(φ1)+Bx)
-        // Source: http://www.movable-type.co.uk/scripts/latlong.html
-        
-        let bx = cos(lat2) * cos( long2 - long1)
-        let by = cos(lat2) * sin( long2 - long1)
-        let mlat = atan2(sin(lat1) + sin(lat2),
-                          sqrt((cos(lat1) + bx)*(cos(lat1) + bx) + (by * by)))
-        let mlong = (long1) + atan2(by, cos(lat1) + bx)
-        
-        return CLLocation(latitude: mlat.radiansToDegrees,
-                          longitude: mlong.radiansToDegrees)
-    }
-    
-    
-    /// SwifterSwift: Calculates the bearing to another CLLocation.
-    ///
-    /// - Parameters:
-    ///   - destination: location to calculate bearing.
-    /// - Returns: calculated bearing degrees in the range 0° ... 360°
-    public func bearing(to destination: CLLocation) -> Double {
-        //http://stackoverflow.com/questions/3925942/cllocation-category-for-calculating-bearing-w-haversine-function
-        let lat1 = self.coordinate.latitude.degreesToRadians
-        let long1 = self.coordinate.longitude.degreesToRadians
-        let lat2 = destination.coordinate.latitude.degreesToRadians
-        let long2 = destination.coordinate.longitude.degreesToRadians
-        
-        //Formula: θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
-        //Source: http://www.movable-type.co.uk/scripts/latlong.html
-        let degrees = atan2(sin(long2 - long1) * cos(lat2),
-                            cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(long2 - long1)).radiansToDegrees
-        return (degrees+360).truncatingRemainder(dividingBy: 360)
-    }
+	
+	/// SwifterSwift: Calculate the half-way point along a great circle path between the two points.
+	///
+	/// - Parameters:
+	///   - start: Start location.
+	///   - end: End location.
+	/// - Returns: Location that represents the half-way point.
+	public static func midLocation(start: CLLocation, end: CLLocation) -> CLLocation {
+		let lat1 = start.coordinate.latitude.degreesToRadians
+		let long1 = start.coordinate.longitude.degreesToRadians
+		let lat2 = end.coordinate.latitude.degreesToRadians
+		let long2 = end.coordinate.longitude.degreesToRadians
+		
+		// Formula
+		//    Bx = cos φ2 ⋅ cos Δλ
+		//    By = cos φ2 ⋅ sin Δλ
+		//    φm = atan2( sin φ1 + sin φ2, √(cos φ1 + Bx)² + By² )
+		//    λm = λ1 + atan2(By, cos(φ1)+Bx)
+		// Source: http://www.movable-type.co.uk/scripts/latlong.html
+		
+		let bx = cos(lat2) * cos(long2 - long1)
+		let by = cos(lat2) * sin(long2 - long1)
+		let mlat = atan2(sin(lat1) + sin(lat2), sqrt((cos(lat1) + bx) * (cos(lat1) + bx) + (by * by)))
+		let mlong = (long1) + atan2(by, cos(lat1) + bx)
+		
+		return CLLocation(latitude: mlat.radiansToDegrees, longitude: mlong.radiansToDegrees)
+	}
+	
+	/// SwifterSwift: Calculate the half-way point along a great circle path between self and another points.
+	///
+	/// - Parameter point: End location.
+	/// - Returns: Location that represents the half-way point.
+	public func midLocation(to point: CLLocation) -> CLLocation {
+		return CLLocation.midLocation(start: self, end: point)
+	}
+	
+	/// SwifterSwift: Calculates the bearing to another CLLocation.
+	///
+	/// - Parameters:
+	///   - destination: Location to calculate bearing.
+	/// - Returns: Calculated bearing degrees in the range 0° ... 360°
+	public func bearing(to destination: CLLocation) -> Double {
+		//http://stackoverflow.com/questions/3925942/cllocation-category-for-calculating-bearing-w-haversine-function
+		let lat1 = self.coordinate.latitude.degreesToRadians
+		let long1 = self.coordinate.longitude.degreesToRadians
+		let lat2 = destination.coordinate.latitude.degreesToRadians
+		let long2 = destination.coordinate.longitude.degreesToRadians
+		
+		//Formula: θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
+		//Source: http://www.movable-type.co.uk/scripts/latlong.html
+		
+		let degrees = atan2(sin(long2 - long1) * cos(lat2),
+		                    cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(long2 - long1)).radiansToDegrees
+		
+		return (degrees+360).truncatingRemainder(dividingBy: 360)
+	}
+	
 }

--- a/Source/Extensions/Cocoa/CLLocationExtensions.swift
+++ b/Source/Extensions/Cocoa/CLLocationExtensions.swift
@@ -1,0 +1,65 @@
+//
+//  CLLocationExtensions.swift
+//  SwifterSwift
+//
+//  Created by Luciano Almeida on 21/04/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+
+// MARK: - Methods
+public extension CLLocation {
+    
+    /// SwifterSwift: Calculate the half-way point along a great circle path between the two points.
+    ///
+    /// - Parameters:
+    ///   - start: start location.
+    ///   - end: end location.
+    /// - Returns: Location that represents the half-way point.
+    public class func midLocation( start: CLLocation, end: CLLocation) -> CLLocation {
+        
+        let lat1 = start.coordinate.latitude.degreesToRadians
+        let long1 = start.coordinate.longitude.degreesToRadians
+        let lat2 = end.coordinate.latitude.degreesToRadians
+        let long2 = end.coordinate.longitude.degreesToRadians
+        
+        //Formula
+        //    Bx = cos φ2 ⋅ cos Δλ
+        //    By = cos φ2 ⋅ sin Δλ
+        //    φm = atan2( sin φ1 + sin φ2, √(cos φ1 + Bx)² + By² )
+        //    λm = λ1 + atan2(By, cos(φ1)+Bx)
+        // Source: http://www.movable-type.co.uk/scripts/latlong.html
+        
+        let bx = cos(lat2) * cos( long2 - long1)
+        let by = cos(lat2) * sin( long2 - long1)
+        let mlat = atan2(sin(lat1) + sin(lat2),
+                          sqrt((cos(lat1) + bx)*(cos(lat1) + bx) + (by * by)))
+        let mlong = (long1) + atan2(by, cos(lat1) + bx)
+        
+        return CLLocation(latitude: mlat.radiansToDegrees,
+                          longitude: mlong.radiansToDegrees)
+    }
+    
+    
+    /// SwifterSwift: Calculates the bearing to another CLLocation.
+    ///
+    /// - Parameters:
+    ///   - destination: location to calculate bearing.
+    /// - Returns: calculated bearing degrees in the range 0° ... 360°
+    public func bearing(to destination: CLLocation) -> Double {
+        //http://stackoverflow.com/questions/3925942/cllocation-category-for-calculating-bearing-w-haversine-function
+        let lat1 = self.coordinate.latitude.degreesToRadians
+        let long1 = self.coordinate.longitude.degreesToRadians
+        let lat2 = destination.coordinate.latitude.degreesToRadians
+        let long2 = destination.coordinate.longitude.degreesToRadians
+        
+        //Formula: θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
+        //Source: http://www.movable-type.co.uk/scripts/latlong.html
+        let degrees = atan2(sin(long2 - long1) * cos(lat2),
+                            cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(long2 - long1)).radiansToDegrees
+        return (degrees+360).truncatingRemainder(dividingBy: 360)
+    }
+}

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -245,6 +245,11 @@
 		B0E3B7CA1E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */; };
 		B0E3B7CC1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */; };
 		B0E3B7CD1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */; };
+		B21CB4BA1EAAED2F00595C76 /* CLLocationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21CB4B91EAAED2F00595C76 /* CLLocationExtensions.swift */; };
+		B21CB4BC1EAAFE2100595C76 /* CLLocationExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21CB4BB1EAAFE2100595C76 /* CLLocationExtensionsTests.swift */; };
+		B21CB4BD1EAAFF1100595C76 /* CLLocationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21CB4B91EAAED2F00595C76 /* CLLocationExtensions.swift */; };
+		B21CB4BE1EAAFF1200595C76 /* CLLocationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21CB4B91EAAED2F00595C76 /* CLLocationExtensions.swift */; };
+		B21CB4BF1EAAFF1300595C76 /* CLLocationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21CB4B91EAAED2F00595C76 /* CLLocationExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -372,6 +377,8 @@
 		B0E3B7C61E559B3100B50FE3 /* UISliderExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISliderExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B7C81E559B7800B50FE3 /* UINavigationControllerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtensionsTests.swift; sourceTree = "<group>"; };
 		B0E3B7CB1E559BCF00B50FE3 /* UINavigationBarExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationBarExtensionTests.swift; sourceTree = "<group>"; };
+		B21CB4B91EAAED2F00595C76 /* CLLocationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLLocationExtensions.swift; sourceTree = "<group>"; };
+		B21CB4BB1EAAFE2100595C76 /* CLLocationExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLLocationExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -492,6 +499,7 @@
 				07770F591E6A902C003339B2 /* NSViewExtensions.swift */,
 				074821F51E446D4C00B0C580 /* NSAttributedStringExtensions.swift */,
 				074821F61E446D4C00B0C580 /* NSColorExtensions.swift */,
+				B21CB4B91EAAED2F00595C76 /* CLLocationExtensions.swift */,
 			);
 			path = Cocoa;
 			sourceTree = "<group>";
@@ -566,6 +574,7 @@
 				07CBDFDC1E88AA020056E514 /* CGPointExtensionsTests.swift */,
 				07AB1A5F1E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift */,
 				07770F5D1E6A9612003339B2 /* NSViewExtensionsTests.swift */,
+				B21CB4BB1EAAFE2100595C76 /* CLLocationExtensionsTests.swift */,
 			);
 			path = CocoaExtensionsTests;
 			sourceTree = "<group>";
@@ -944,6 +953,7 @@
 				0748225F1E446D4D00B0C580 /* UIAlertControllerExtensions.swift in Sources */,
 				B0C4D1D51E48A52400DACC28 /* UIStoryboardExtensions.swift in Sources */,
 				074822571E446D4D00B0C580 /* StringExtensions.swift in Sources */,
+				B21CB4BA1EAAED2F00595C76 /* CLLocationExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -954,6 +964,7 @@
 				07445BC61E11D1EF000E9A85 /* DateExtensionsTests.swift in Sources */,
 				07AB1A621E448C4500CEF96C /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07AB1A6D1E448CD800CEF96C /* CGSizeExtensionsTests.swift in Sources */,
+				B21CB4BC1EAAFE2100595C76 /* CLLocationExtensionsTests.swift in Sources */,
 				B0E3B7901E52970500B50FE3 /* UIAlertControllerExtensionsTests.swift in Sources */,
 				07445BC81E11D1EF000E9A85 /* DoubleExtensionsTests.swift in Sources */,
 				07445BCB1E11D1EF000E9A85 /* IntExtensionsTests.swift in Sources */,
@@ -1006,6 +1017,7 @@
 				074822491E446D4D00B0C580 /* DictionaryExtensions.swift in Sources */,
 				0748225D1E446D4D00B0C580 /* SwifterSwift.swift in Sources */,
 				074822351E446D4D00B0C580 /* NSAttributedStringExtensions.swift in Sources */,
+				B21CB4BE1EAAFF1200595C76 /* CLLocationExtensions.swift in Sources */,
 				0748224D1E446D4D00B0C580 /* DoubleExtensions.swift in Sources */,
 				074822B51E446D4D00B0C580 /* URLExtensions.swift in Sources */,
 				0748221D1E446D4D00B0C580 /* BoolExtensions.swift in Sources */,
@@ -1038,6 +1050,7 @@
 				074822741E446D4D00B0C580 /* UIImageExtensions.swift in Sources */,
 				074822481E446D4D00B0C580 /* DictionaryExtensions.swift in Sources */,
 				074822641E446D4D00B0C580 /* UIBarButtonItemExtensions.swift in Sources */,
+				B21CB4BD1EAAFF1100595C76 /* CLLocationExtensions.swift in Sources */,
 				074822841E446D4D00B0C580 /* UINavigationControllerExtensions.swift in Sources */,
 				0748225C1E446D4D00B0C580 /* SwifterSwift.swift in Sources */,
 				074822681E446D4D00B0C580 /* UIButtonExtensions.swift in Sources */,
@@ -1124,6 +1137,7 @@
 				0748225E1E446D4D00B0C580 /* SwifterSwift.swift in Sources */,
 				074822361E446D4D00B0C580 /* NSAttributedStringExtensions.swift in Sources */,
 				0748224E1E446D4D00B0C580 /* DoubleExtensions.swift in Sources */,
+				B21CB4BF1EAAFF1300595C76 /* CLLocationExtensions.swift in Sources */,
 				8B4967C81EA8043600091A7D /* LocaleExtensions.swift in Sources */,
 				074822B61E446D4D00B0C580 /* URLExtensions.swift in Sources */,
 				0748221E1E446D4D00B0C580 /* BoolExtensions.swift in Sources */,

--- a/Tests/SwifterSwiftTests/CocoaExtensionsTests/CLLocationExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/CocoaExtensionsTests/CLLocationExtensionsTests.swift
@@ -9,24 +9,27 @@
 import XCTest
 import CoreLocation
 
+
 class CLLocationExtensionsTests: XCTestCase {
-    
-    func testMidLocation() {
-        let location = CLLocation(latitude: -15.822877, longitude: -47.941839)
-        let other = CLLocation(latitude: -15.692030, longitude: -47.594397)
-        
-        let mid = CLLocation.midLocation(start: location, end: other)
-
-        XCTAssertEqualWithAccuracy(mid.coordinate.latitude, -15.7575223324019, accuracy: 0.0000000000001)
-        XCTAssertEqualWithAccuracy(mid.coordinate.longitude, -47.7680620274339, accuracy: 0.0000000000001)
-
-    }
-    
-    func testBearing() {
-        let location = CLLocation(latitude: 38.6318909290283, longitude: -90.2828979492187)
-        let other = CLLocation(latitude: 38.5352759115441, longitude: -89.8448181152343)
-        let bearing = location.bearing(to: other)
-        
-        XCTAssertEqualWithAccuracy(bearing, 105.619, accuracy: 0.001)
-    }
+	
+	func testMidLocation() {
+		let a = CLLocation(latitude: -15.822877, longitude: -47.941839)
+		let b = CLLocation(latitude: -15.692030, longitude: -47.594397)
+		let mid = CLLocation.midLocation(start: a, end: b)
+		
+		XCTAssertEqualWithAccuracy(mid.coordinate.latitude, -15.7575223324019, accuracy: 0.0000000000001)
+		XCTAssertEqualWithAccuracy(mid.coordinate.longitude, -47.7680620274339, accuracy: 0.0000000000001)
+		
+		XCTAssertEqualWithAccuracy(a.midLocation(to: b).coordinate.latitude, -15.7575223324019, accuracy: 0.0000000000001)
+		XCTAssertEqualWithAccuracy(a.midLocation(to: b).coordinate.longitude, -47.7680620274339, accuracy: 0.0000000000001)
+		
+	}
+	
+	func testBearing() {
+		let a = CLLocation(latitude: 38.6318909290283, longitude: -90.2828979492187)
+		let b = CLLocation(latitude: 38.5352759115441, longitude: -89.8448181152343)
+		let bearing = a.bearing(to: b)
+		
+		XCTAssertEqualWithAccuracy(bearing, 105.619, accuracy: 0.001)
+	}
 }

--- a/Tests/SwifterSwiftTests/CocoaExtensionsTests/CLLocationExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/CocoaExtensionsTests/CLLocationExtensionsTests.swift
@@ -1,0 +1,32 @@
+//
+//  CLLocationExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Luciano Almeida on 21/04/17.
+//  Copyright © 2017 omaralbeik. All rights reserved.
+//
+
+import XCTest
+import CoreLocation
+
+class CLLocationExtensionsTests: XCTestCase {
+    
+    func testMidLocation() {
+        let location = CLLocation(latitude: -15.822877, longitude: -47.941839)
+        let other = CLLocation(latitude: -15.692030, longitude: -47.594397)
+        
+        let mid = CLLocation.midLocation(start: location, end: other)
+
+        XCTAssertEqualWithAccuracy(mid.coordinate.latitude, -15.7575223324019, accuracy: 0.0000000000001)
+        XCTAssertEqualWithAccuracy(mid.coordinate.longitude, -47.7680620274339, accuracy: 0.0000000000001)
+
+    }
+    
+    func testBearing() {
+        let location = CLLocation(latitude: 38.6318909290283, longitude: -90.2828979492187)
+        let other = CLLocation(latitude: 38.5352759115441, longitude: -89.8448181152343)
+        let bearing = location.bearing(to: other)
+        
+        XCTAssertEqualWithAccuracy(bearing, 105.619, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
