### PR TITLE
Change Xcode version to 8.3 in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode8.2
+osx_image: xcode8.3
 language: objective-c
 before_install:
     - gem install xcpretty


### PR DESCRIPTION
This pull request is for changing Xcode version from 8.2 to 8.3 in .travis file.
Travis is already supporting Xcode 8.3 version. 

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [ ] New extensions support iOS 8 or later.
- [ ] New extensions are written in Swift 3.
- [ ] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All comments headers have the word **SwifterSwift:** before description.
