### PR TITLE
ArrayExtensions last method codecoverage fix

### DIFF
--- a/Source/Extensions/ArrayExtensions.swift
+++ b/Source/Extensions/ArrayExtensions.swift
@@ -154,7 +154,9 @@ public extension Array {
     /// - Parameter condition: condition to evaluate each element against.
     /// - Returns: the last element in the array matching the specified condition. (optional)
     public func last(where condition: (Element) -> Bool) -> Element? {
-        for element in reversed() where condition(element) { return element }
+        for element in reversed() {
+          if condition(element) { return element }
+        }
         return nil
     }
     


### PR DESCRIPTION
ArrayExtensions has code coverage issue where **last** method code coverage report says **return nil** is not executed even though all the test passes. The exact reason for why this is happening is not clear.

![image](https://cloud.githubusercontent.com/assets/4947384/25392683/ebae94a4-29f6-11e7-83f5-48d6e778e085.png)

But we have a similar method like **lastIndex** in same extensions which is returning nil. Here code coverage report says return nil executed. The only difference I see is the use of where condition in with for loop between lastIndex and last method. 

By this pull request, I made **last** method code similar as **lastIndex**.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [ ] New extensions support iOS 8 or later.
- [ ] New extensions are written in Swift 3.
- [ ] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
