### PR TITLE
Added empty array test for ArrayExtension skip method

### DIFF
--- a/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -265,6 +265,8 @@ class ArrayExtensionsTests: XCTestCase {
         input = [7, 7, 8, 10]
         output = input.skip(while: {$0 % 2 == 0 })
         XCTAssertEqual(output, [7, 7, 8, 10])
+      
+        XCTAssertEqual([].skip(while: { $0 % 2 == 0}), [])
     }
 	
 }


### PR DESCRIPTION
Test case for an empty array is not covered as part of ArrayExtensions skip method test.

See below test coverage report for the same method.
![image](https://cloud.githubusercontent.com/assets/4947384/25439454/1d42399e-2aba-11e7-9e19-744bc8749dd5.png)

This pull request adds the required empty array test case.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [ ] New extensions support iOS 8 or later.
- [ ] New extensions are written in Swift 3.
- [ ] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
