### PR TITLE
Adding empty array test case for drop and take methods

### DIFF
--- a/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -252,6 +252,10 @@ class ArrayExtensionsTests: XCTestCase {
         input = [7, 7, 8, 10, 7]
         input.drop(while: { $0 % 2 == 0 })
         XCTAssertEqual(input, [7, 7, 8, 10, 7])
+      
+        input = []
+        input.drop(while: { $0 % 2 == 0 })
+        XCTAssertEqual(input, [])
     }
     
     func testTakeWhile() {
@@ -262,6 +266,8 @@ class ArrayExtensionsTests: XCTestCase {
         input = [7, 7, 8, 10]
         output = input.take(while: {$0 % 2 == 0 })
         XCTAssertEqual(output, [Int]())
+      
+        XCTAssertEqual([].take(while: {$0 % 2 == 0 }), [])
     }
     
     func testSkipWhile() {


### PR DESCRIPTION
By this pull request, I am trying to add empty array test for both **drop** and **take** methods in 
ArrayExtenstions. By adding this, it is expected to have 100% test coverage for ArrayExtensions.swift file alone.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [ ] New extensions support iOS 8 or later.
- [ ] New extensions are written in Swift 3.
- [ ] I have added tests for new extensions, and they passed.
- [x] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
