### PR TITLE
Remove drop(while:) Array extension

### DIFF
--- a/Source/Extensions/ArrayExtensions.swift
+++ b/Source/Extensions/ArrayExtensions.swift
@@ -240,19 +240,6 @@ public extension Array {
         }
     }
     
-    /// SwifterSwift: Drop elements of Array while condition is true.
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    public mutating func drop(while condition: (Element) -> Bool) {
-        for (index, element) in lazy.enumerated() {
-            if !condition(element) {
-                self = Array(self[index..<endIndex])
-                return
-            }
-        }
-        self = []
-    }
-    
     /// SwifterSwift: Take element of Array while condition is true.
     ///
     /// - Parameter condition: condition to evaluate each element against.

--- a/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -244,20 +244,6 @@ class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(input, [Int]())
     }
     
-    func testDropWhile() {
-        var input = [2, 4, 6, 7, 8, 9, 10]
-        input.drop(while: { $0 % 2 == 0 })
-        XCTAssertEqual(input, [7, 8, 9, 10])
-        
-        input = [7, 7, 8, 10, 7]
-        input.drop(while: { $0 % 2 == 0 })
-        XCTAssertEqual(input, [7, 7, 8, 10, 7])
-      
-        input = []
-        input.drop(while: { $0 % 2 == 0 })
-        XCTAssertEqual(input, [])
-    }
-    
     func testTakeWhile() {
         var input = [2, 4, 6, 7, 8, 9, 10]
         var output = input.take(while: {$0 % 2 == 0 })


### PR DESCRIPTION
### Summary of Pull Request:
- Removes `drop(while:)` extension on `Array` that already exists in the Swift Standard Library