### PR TITLE
Add addPaddingLeft UITextField extension & fix broken UIImageView test

### DIFF
--- a/Source/Extensions/UIKit/UITextFieldExtensions.swift
+++ b/Source/Extensions/UIKit/UITextFieldExtensions.swift
@@ -9,7 +9,6 @@
 #if os(iOS) || os(tvOS)
 import UIKit
 
-
 // MARK: - Properties
 public extension UITextField {
 	
@@ -40,7 +39,7 @@ public extension UITextField {
 			iconView.tintColor = newValue
 		}
 	}
-	
+
 	@IBInspectable
 	/// SwifterSwift: Right view tint color.
 	public var rightViewTintColor: UIColor? {
@@ -58,8 +57,8 @@ public extension UITextField {
 			iconView.tintColor = newValue
 		}
 	}
-}
 
+}
 
 // MARK: - Methods
 public extension UITextField {
@@ -79,6 +78,15 @@ public extension UITextField {
 		}
 		self.attributedPlaceholder = NSAttributedString(string: holder, attributes: [NSForegroundColorAttributeName: color])
 	}
-	
+  
+  /// SwifterSwift: Add padding to the left of the textfield rect.
+  ///
+  /// - Parameter padding: amount of padding to apply to the left of the textfield rect.
+  public func addPaddingLeft(_ padding: CGFloat) {
+    let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: padding, height: frame.height))
+    leftView = paddingView
+    leftViewMode = .always
+  }
+
 }
 #endif

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIImageViewExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UIImageViewExtensionsTests.swift
@@ -14,29 +14,31 @@ import XCTest
 class UIImageViewExtensionsTests: XCTestCase {
 	
 	func testDownload() {
+    // Success
 		let imageView = UIImageView()
 		let url = URL(string: "https://developer.apple.com/swift/images/swift-og.png")!
 		let placeHolder = UIImage()
-		var completionCalled = false
+    let downloadExpectation = expectation(description: "Download success")
 		imageView.download(from: url, contentMode: .scaleAspectFill, placeholder: placeHolder) { image in
-			completionCalled = true
-			XCTAssert(completionCalled)
 			XCTAssertEqual(imageView.image, image)
+      downloadExpectation.fulfill()
 		}
 		XCTAssertEqual(imageView.image, placeHolder)
 		XCTAssertEqual(imageView.contentMode, .scaleAspectFill)
-		
+    
+    // Failure
+    let failImageView = UIImageView()
 		let failingURL = URL(string: "https://developer.apple.com/")!
-		var failingCompletionCalled = false
-		imageView.image = nil
-		imageView.download(from: failingURL, contentMode: .center, placeholder: nil) { image in
-			failingCompletionCalled = true
+    let failExpectation = expectation(description: "Download failure")
+		failImageView.image = nil
+		failImageView.download(from: failingURL, contentMode: .center, placeholder: nil) { image in
 			XCTAssertNil(image)
-			XCTAssertNil(imageView.image)
-			XCTAssert(failingCompletionCalled)
+			XCTAssertNil(failImageView.image)
+      failExpectation.fulfill()
 		}
-		XCTAssertEqual(imageView.contentMode, .center)
-		XCTAssertNil(imageView.image)
+		XCTAssertEqual(failImageView.contentMode, .center)
+		XCTAssertNil(failImageView.image)
+    waitForExpectations(timeout: 15, handler: nil)
 	}
 	
 	func testBlur() {

--- a/Tests/SwifterSwiftTests/UIKitExtensionsTests/UITextFieldExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/UIKitExtensionsTests/UITextFieldExtensionsTests.swift
@@ -92,5 +92,12 @@ class UITextFieldExtensionsTests: XCTestCase {
 		let emptyColor = textField.attributedPlaceholder?.attribute(NSForegroundColorAttributeName, at: 0, effectiveRange: nil) as? UIColor
 		XCTAssertNil(emptyColor)
 	}
+  
+  func testAddPaddingLeft() {
+    let textfield = UITextField()
+    textfield.frame = CGRect(x: 0, y: 0, width: 100, height: 30)
+    textfield.addPaddingLeft(40)
+    XCTAssertEqual(textfield.leftView?.frame.width, 40)
+  }
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [😅] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [:+1:] I have **only one commit** in this pull request.
- [:+1: ] New extensions support iOS 8 or later.
- [:+1: ] New extensions are written in Swift 3.
- [:+1: ] I have added tests for new extensions, and they passed.
- [:+1:] Pull request was created to [**master head branch**](https://github.com/omaralbeik/SwifterSwift/tree/master).
- [:+1:] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [:+1:] All comments headers have the word **SwifterSwift:** before description.

### Summary of Pull Request:
- Adds new extension `addPaddingLeft(padding:)` for `UITextField`
- Hopefully fixes that pesky failing test for `UIImageView` 😅
