### PR TITLE
Add the limit length of the UITextField

### DIFF
--- a/Sources/Extensions/UIKit/UITextFieldExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextFieldExtensions.swift
@@ -100,6 +100,19 @@ public extension UITextField {
         self.leftView?.frame.size = CGSize(width: image.size.width + padding, height: image.size.height)
         self.leftViewMode = UITextFieldViewMode.always
     }
+    
+    /// SwifterSwift: Add the limit length
+    ///
+    /// - Parameter length: length limit
+    public func limit(_ length: Int) {
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.UITextFieldTextDidChange, object: nil, queue: OperationQueue.main) { (notification) in
+            
+            if ((self.text!.characters.count > length) && self.markedTextRange == nil) {
+                
+                self.text = (self.text! as NSString).substring(to: length)
+            }
+        }
+    }
 
 }
 #endif

--- a/Tests/UIKitTests/UITextFieldExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextFieldExtensionsTests.swift
@@ -109,5 +109,14 @@ class UITextFieldExtensionsTests: XCTestCase {
         textfield.addPaddingLeftIcon(image, padding: 5)
         XCTAssertEqual(textfield.leftView?.frame.width, image.size.width + 5)
     }
+    
+    func testlimit() {
+        let textfield = UITextField()
+        textfield.frame = CGRect(x: 0, y: 0, width: 200, height: 30)
+        textfield.text = "xxxxxxxxxxxxxxxxxxx"
+        textfield.limit(16)
+        NotificationCenter.default.post(name: NSNotification.Name.UITextFieldTextDidChange, object: nil)
+        XCTAssertEqual(textfield.text?.length, 16)
+    }
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 3.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
