### PR TITLE
UIColor, NSColor, and UIImage extensions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    project: true
+    patch: true
+    changes: true
+
+  ignore:
+    - "Sources/Extensions/*/Deprecated/*"
+    - "Tests/**/*"

--- a/Sources/Extensions/Cocoa/NSColorExtensions.swift
+++ b/Sources/Extensions/Cocoa/NSColorExtensions.swift
@@ -1488,7 +1488,7 @@ public extension NSColor {
 
 // MARK: - Flat UI colors
 
-public extension UIColor {
+public extension NSColor {
 
     /// SwifterSwift: Flat UI colors
     public struct flatUI {

--- a/Sources/Extensions/Cocoa/NSColorExtensions.swift
+++ b/Sources/Extensions/Cocoa/NSColorExtensions.swift
@@ -1030,6 +1030,8 @@ public extension NSColor {
 }
 
 
+//MARK: - CSS colors
+
 public extension NSColor {
 	
 	/// SwifterSwift: CSS colors.
@@ -1483,4 +1485,75 @@ public extension NSColor {
 	}
 	
 }
+
+// MARK: - Flat UI colors
+
+public extension UIColor {
+
+    /// SwifterSwift: Flat UI colors
+    public struct flatUI {
+        // http://flatuicolors.com.
+
+        /// SwifterSwift: hex #1ABC9C
+        public static let turquoise             = NSColor(hex: 0x1abc9c)
+
+        /// SwifterSwift: hex #16A085
+        public static let greenSea              = NSColor(hex: 0x16a085)
+
+        /// SwifterSwift: hex #2ECC71
+        public static let emerald               = NSColor(hex: 0x2ecc71)
+
+        /// SwifterSwift: hex #27AE60
+        public static let nephritis             = NSColor(hex: 0x27ae60)
+
+        /// SwifterSwift: hex #3498DB
+        public static let peterRiver            = NSColor(hex: 0x3498db)
+
+        /// SwifterSwift: hex #2980B9
+        public static let belizeHole            = NSColor(hex: 0x2980b9)
+
+        /// SwifterSwift: hex #9B59B6
+        public static let amethyst              = NSColor(hex: 0x9b59b6)
+
+        /// SwifterSwift: hex #8E44AD
+        public static let wisteria              = NSColor(hex: 0x8e44ad)
+
+        /// SwifterSwift: hex #34495E
+        public static let wetAsphalt            = NSColor(hex: 0x34495e)
+
+        /// SwifterSwift: hex #2C3E50
+        public static let midnightBlue          = NSColor(hex: 0x2c3e50)
+
+        /// SwifterSwift: hex #F1C40F
+        public static let sunFlower             = NSColor(hex: 0xf1c40f)
+
+        /// SwifterSwift: hex #F39C12
+        public static let flatOrange            = NSColor(hex: 0xf39c12)
+
+        /// SwifterSwift: hex #E67E22
+        public static let carrot                = NSColor(hex: 0xe67e22)
+
+        /// SwifterSwift: hex #D35400
+        public static let pumkin                = NSColor(hex: 0xd35400)
+
+        /// SwifterSwift: hex #E74C3C
+        public static let alizarin              = NSColor(hex: 0xe74c3c)
+
+        /// SwifterSwift: hex #C0392B
+        public static let pomegranate           = NSColor(hex: 0xc0392b)
+
+        /// SwifterSwift: hex #ECF0F1
+        public static let clouds                = NSColor(hex: 0xecf0f1)
+        
+        /// SwifterSwift: hex #BDC3C7
+        public static let silver                = NSColor(hex: 0xbdc3c7)
+        
+        /// SwifterSwift: hex #7F8C8D
+        public static let asbestos              = NSColor(hex: 0x7f8c8d)
+        
+        /// SwifterSwift: hex #95A5A6
+        public static let concerte              = NSColor(hex: 0x95a5a6)
+    }
+}
+    
 #endif

--- a/Sources/Extensions/Cocoa/NSColorExtensions.swift
+++ b/Sources/Extensions/Cocoa/NSColorExtensions.swift
@@ -1489,71 +1489,71 @@ public extension NSColor {
 // MARK: - Flat UI colors
 
 public extension NSColor {
-
-    /// SwifterSwift: Flat UI colors
-    public struct flatUI {
-        // http://flatuicolors.com.
-
-        /// SwifterSwift: hex #1ABC9C
-        public static let turquoise             = NSColor(hex: 0x1abc9c)
-
-        /// SwifterSwift: hex #16A085
-        public static let greenSea              = NSColor(hex: 0x16a085)
-
-        /// SwifterSwift: hex #2ECC71
-        public static let emerald               = NSColor(hex: 0x2ecc71)
-
-        /// SwifterSwift: hex #27AE60
-        public static let nephritis             = NSColor(hex: 0x27ae60)
-
-        /// SwifterSwift: hex #3498DB
-        public static let peterRiver            = NSColor(hex: 0x3498db)
-
-        /// SwifterSwift: hex #2980B9
-        public static let belizeHole            = NSColor(hex: 0x2980b9)
-
-        /// SwifterSwift: hex #9B59B6
-        public static let amethyst              = NSColor(hex: 0x9b59b6)
-
-        /// SwifterSwift: hex #8E44AD
-        public static let wisteria              = NSColor(hex: 0x8e44ad)
-
-        /// SwifterSwift: hex #34495E
-        public static let wetAsphalt            = NSColor(hex: 0x34495e)
-
-        /// SwifterSwift: hex #2C3E50
-        public static let midnightBlue          = NSColor(hex: 0x2c3e50)
-
-        /// SwifterSwift: hex #F1C40F
-        public static let sunFlower             = NSColor(hex: 0xf1c40f)
-
-        /// SwifterSwift: hex #F39C12
-        public static let flatOrange            = NSColor(hex: 0xf39c12)
-
-        /// SwifterSwift: hex #E67E22
-        public static let carrot                = NSColor(hex: 0xe67e22)
-
-        /// SwifterSwift: hex #D35400
-        public static let pumkin                = NSColor(hex: 0xd35400)
-
-        /// SwifterSwift: hex #E74C3C
-        public static let alizarin              = NSColor(hex: 0xe74c3c)
-
-        /// SwifterSwift: hex #C0392B
-        public static let pomegranate           = NSColor(hex: 0xc0392b)
-
-        /// SwifterSwift: hex #ECF0F1
-        public static let clouds                = NSColor(hex: 0xecf0f1)
-        
-        /// SwifterSwift: hex #BDC3C7
-        public static let silver                = NSColor(hex: 0xbdc3c7)
-        
-        /// SwifterSwift: hex #7F8C8D
-        public static let asbestos              = NSColor(hex: 0x7f8c8d)
-        
-        /// SwifterSwift: hex #95A5A6
-        public static let concerte              = NSColor(hex: 0x95a5a6)
-    }
+	
+	/// SwifterSwift: Flat UI colors
+	public struct flatUI {
+		// http://flatuicolors.com.
+		
+		/// SwifterSwift: hex #1ABC9C
+		public static let turquoise             = NSColor(hex: 0x1abc9c)
+		
+		/// SwifterSwift: hex #16A085
+		public static let greenSea              = NSColor(hex: 0x16a085)
+		
+		/// SwifterSwift: hex #2ECC71
+		public static let emerald               = NSColor(hex: 0x2ecc71)
+		
+		/// SwifterSwift: hex #27AE60
+		public static let nephritis             = NSColor(hex: 0x27ae60)
+		
+		/// SwifterSwift: hex #3498DB
+		public static let peterRiver            = NSColor(hex: 0x3498db)
+		
+		/// SwifterSwift: hex #2980B9
+		public static let belizeHole            = NSColor(hex: 0x2980b9)
+		
+		/// SwifterSwift: hex #9B59B6
+		public static let amethyst              = NSColor(hex: 0x9b59b6)
+		
+		/// SwifterSwift: hex #8E44AD
+		public static let wisteria              = NSColor(hex: 0x8e44ad)
+		
+		/// SwifterSwift: hex #34495E
+		public static let wetAsphalt            = NSColor(hex: 0x34495e)
+		
+		/// SwifterSwift: hex #2C3E50
+		public static let midnightBlue          = NSColor(hex: 0x2c3e50)
+		
+		/// SwifterSwift: hex #F1C40F
+		public static let sunFlower             = NSColor(hex: 0xf1c40f)
+		
+		/// SwifterSwift: hex #F39C12
+		public static let flatOrange            = NSColor(hex: 0xf39c12)
+		
+		/// SwifterSwift: hex #E67E22
+		public static let carrot                = NSColor(hex: 0xe67e22)
+		
+		/// SwifterSwift: hex #D35400
+		public static let pumkin                = NSColor(hex: 0xd35400)
+		
+		/// SwifterSwift: hex #E74C3C
+		public static let alizarin              = NSColor(hex: 0xe74c3c)
+		
+		/// SwifterSwift: hex #C0392B
+		public static let pomegranate           = NSColor(hex: 0xc0392b)
+		
+		/// SwifterSwift: hex #ECF0F1
+		public static let clouds                = NSColor(hex: 0xecf0f1)
+		
+		/// SwifterSwift: hex #BDC3C7
+		public static let silver                = NSColor(hex: 0xbdc3c7)
+		
+		/// SwifterSwift: hex #7F8C8D
+		public static let asbestos              = NSColor(hex: 0x7f8c8d)
+		
+		/// SwifterSwift: hex #95A5A6
+		public static let concerte              = NSColor(hex: 0x95a5a6)
+	}
 }
-    
+
 #endif

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -46,19 +46,18 @@ public extension UIColor {
         return CoreImage.CIColor(color: self)  // The resulting Core Image color, or nil
     }
     
-    /// SwifterSwift: Hue, Saturation, Brightness, and Alpha (read-only).
-    public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat)?
-    {
-        var (hue, saturation, brightness, alpha) = (CGFloat(0.0), CGFloat(0.0), CGFloat(0.0), CGFloat(0.0))
-        if self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) {
-            return (hue, saturation, brightness, alpha)
-        }
-        else {
-            return nil
-        }
+    /// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
+    public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
+        var hue:    CGFloat = 0.0
+        var sat:    CGFloat = 0.0
+        var bri:    CGFloat = 0.0
+        var alpha:  CGFloat = 0.0
+        self.getHue(&hue, saturation: &sat, brightness: &bri, alpha: &alpha)
+
+        return (hue:hue, saturation:sat, brightness:bri, alpha:alpha)
     }
-    
-	/// SwifterSwift: Hexadecimal value string (read-only).
+
+    /// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
 		var red:	CGFloat = 0
 		var green:	CGFloat = 0
@@ -1178,6 +1177,7 @@ public extension UIColor {
 }
 
 
+// MARK: - CSS colors
 public extension UIColor {
 	
 	/// SwifterSwift: CSS colors.
@@ -1631,4 +1631,75 @@ public extension UIColor {
 	}
 	
 }
+
+// MARK: - Flat UI colors
+
+public extension UIColor {
+
+    /// SwifterSwift: Flat UI colors
+    public struct flatUI {
+        // http://flatuicolors.com.
+
+        /// SwifterSwift: hex #1ABC9C
+        public static let turquoise             = UIColor(hex: 0x1abc9c)
+
+        /// SwifterSwift: hex #16A085
+        public static let greenSea              = UIColor(hex: 0x16a085)
+
+        /// SwifterSwift: hex #2ECC71
+        public static let emerald               = UIColor(hex: 0x2ecc71)
+
+        /// SwifterSwift: hex #27AE60
+        public static let nephritis             = UIColor(hex: 0x27ae60)
+
+        /// SwifterSwift: hex #3498DB
+        public static let peterRiver            = UIColor(hex: 0x3498db)
+
+        /// SwifterSwift: hex #2980B9
+        public static let belizeHole            = UIColor(hex: 0x2980b9)
+
+        /// SwifterSwift: hex #9B59B6
+        public static let amethyst              = UIColor(hex: 0x9b59b6)
+
+        /// SwifterSwift: hex #8E44AD
+        public static let wisteria              = UIColor(hex: 0x8e44ad)
+
+        /// SwifterSwift: hex #34495E
+        public static let wetAsphalt            = UIColor(hex: 0x34495e)
+
+        /// SwifterSwift: hex #2C3E50
+        public static let midnightBlue          = UIColor(hex: 0x2c3e50)
+
+        /// SwifterSwift: hex #F1C40F
+        public static let sunFlower             = UIColor(hex: 0xf1c40f)
+
+        /// SwifterSwift: hex #F39C12
+        public static let flatOrange            = UIColor(hex: 0xf39c12)
+
+        /// SwifterSwift: hex #E67E22
+        public static let carrot                = UIColor(hex: 0xe67e22)
+
+        /// SwifterSwift: hex #D35400
+        public static let pumkin                = UIColor(hex: 0xd35400)
+
+        /// SwifterSwift: hex #E74C3C
+        public static let alizarin              = UIColor(hex: 0xe74c3c)
+
+        /// SwifterSwift: hex #C0392B
+        public static let pomegranate           = UIColor(hex: 0xc0392b)
+
+        /// SwifterSwift: hex #ECF0F1
+        public static let clouds                = UIColor(hex: 0xecf0f1)
+        
+        /// SwifterSwift: hex #BDC3C7
+        public static let silver                = UIColor(hex: 0xbdc3c7)
+        
+        /// SwifterSwift: hex #7F8C8D
+        public static let asbestos              = UIColor(hex: 0x7f8c8d)
+        
+        /// SwifterSwift: hex #95A5A6
+        public static let concerte              = UIColor(hex: 0x95a5a6)
+    }
+}
+
 #endif

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -35,40 +35,40 @@ public extension UIColor {
 		return a
 	}
 	
-    /// SwifterSwift: CoreImage.CIColor (read-only).
-    public var coreImageColor: CoreImage.CIColor? {
-        return CoreImage.CIColor(color: self)  // The resulting Core Image color, or nil
-    }
-    
-    /// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
-    public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
-        var hue:    CGFloat = 0.0
-        var sat:    CGFloat = 0.0
-        var bri:    CGFloat = 0.0
-        var alpha:  CGFloat = 0.0
-        self.getHue(&hue, saturation: &sat, brightness: &bri, alpha: &alpha)
-
-        return (hue:hue, saturation:sat, brightness:bri, alpha:alpha)
-    }
-
-    /// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
-    public var uInt: UInt {
-        var colorAsUInt32: UInt32 = 0
-        var r: CGFloat = 0
-        var g: CGFloat = 0
-        var b: CGFloat = 0
-        var a: CGFloat = 0
-
-        self.getRed(&r, green: &g, blue: &b, alpha: &a)
-
-        colorAsUInt32 += UInt32(r * 255.0) << 16
-        colorAsUInt32 += UInt32(g * 255.0) << 8
-        colorAsUInt32 += UInt32(b * 255.0)
-
-        return UInt(colorAsUInt32)
-    }
-
-    /// SwifterSwift: Hexadecimal value string (read-only).
+	/// SwifterSwift: CoreImage.CIColor (read-only).
+	public var coreImageColor: CoreImage.CIColor? {
+		return CoreImage.CIColor(color: self)  // The resulting Core Image color, or nil
+	}
+	
+	/// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
+	public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
+		var hue:    CGFloat = 0.0
+		var sat:    CGFloat = 0.0
+		var bri:    CGFloat = 0.0
+		var alpha:  CGFloat = 0.0
+		self.getHue(&hue, saturation: &sat, brightness: &bri, alpha: &alpha)
+		
+		return (hue:hue, saturation:sat, brightness:bri, alpha:alpha)
+	}
+	
+	/// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
+	public var uInt: UInt {
+		var colorAsUInt32: UInt32 = 0
+		var r: CGFloat = 0
+		var g: CGFloat = 0
+		var b: CGFloat = 0
+		var a: CGFloat = 0
+		
+		self.getRed(&r, green: &g, blue: &b, alpha: &a)
+		
+		colorAsUInt32 += UInt32(r * 255.0) << 16
+		colorAsUInt32 += UInt32(g * 255.0) << 8
+		colorAsUInt32 += UInt32(b * 255.0)
+		
+		return UInt(colorAsUInt32)
+	}
+	
+	/// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
 		var red:	CGFloat = 0
 		var green:	CGFloat = 0
@@ -85,7 +85,7 @@ public extension UIColor {
 		let string = hexString.replacingOccurrences(of: "#", with: "")
 		let chrs = Array(string.characters)
 		guard chrs[0] == chrs[1], chrs[2] == chrs[3], chrs[4] == chrs[5] else {
-				return nil
+			return nil
 		}
 		return  "#" + "\(chrs[0])\(chrs[2])\(chrs[4])"
 	}
@@ -1645,70 +1645,70 @@ public extension UIColor {
 // MARK: - Flat UI colors
 
 public extension UIColor {
-
-    /// SwifterSwift: Flat UI colors
-    public struct flatUI {
-        // http://flatuicolors.com.
-
-        /// SwifterSwift: hex #1ABC9C
-        public static let turquoise             = UIColor(hex: 0x1abc9c)
-
-        /// SwifterSwift: hex #16A085
-        public static let greenSea              = UIColor(hex: 0x16a085)
-
-        /// SwifterSwift: hex #2ECC71
-        public static let emerald               = UIColor(hex: 0x2ecc71)
-
-        /// SwifterSwift: hex #27AE60
-        public static let nephritis             = UIColor(hex: 0x27ae60)
-
-        /// SwifterSwift: hex #3498DB
-        public static let peterRiver            = UIColor(hex: 0x3498db)
-
-        /// SwifterSwift: hex #2980B9
-        public static let belizeHole            = UIColor(hex: 0x2980b9)
-
-        /// SwifterSwift: hex #9B59B6
-        public static let amethyst              = UIColor(hex: 0x9b59b6)
-
-        /// SwifterSwift: hex #8E44AD
-        public static let wisteria              = UIColor(hex: 0x8e44ad)
-
-        /// SwifterSwift: hex #34495E
-        public static let wetAsphalt            = UIColor(hex: 0x34495e)
-
-        /// SwifterSwift: hex #2C3E50
-        public static let midnightBlue          = UIColor(hex: 0x2c3e50)
-
-        /// SwifterSwift: hex #F1C40F
-        public static let sunFlower             = UIColor(hex: 0xf1c40f)
-
-        /// SwifterSwift: hex #F39C12
-        public static let flatOrange            = UIColor(hex: 0xf39c12)
-
-        /// SwifterSwift: hex #E67E22
-        public static let carrot                = UIColor(hex: 0xe67e22)
-
-        /// SwifterSwift: hex #D35400
-        public static let pumkin                = UIColor(hex: 0xd35400)
-
-        /// SwifterSwift: hex #E74C3C
-        public static let alizarin              = UIColor(hex: 0xe74c3c)
-
-        /// SwifterSwift: hex #C0392B
-        public static let pomegranate           = UIColor(hex: 0xc0392b)
-
-        /// SwifterSwift: hex #ECF0F1
-        public static let clouds                = UIColor(hex: 0xecf0f1)
-        
-        /// SwifterSwift: hex #BDC3C7
-        public static let silver                = UIColor(hex: 0xbdc3c7)
-        
-        /// SwifterSwift: hex #7F8C8D
-        public static let asbestos              = UIColor(hex: 0x7f8c8d)
-        
-        /// SwifterSwift: hex #95A5A6
-        public static let concerte              = UIColor(hex: 0x95a5a6)
-    }
+	
+	/// SwifterSwift: Flat UI colors
+	public struct flatUI {
+		// http://flatuicolors.com.
+		
+		/// SwifterSwift: hex #1ABC9C
+		public static let turquoise             = UIColor(hex: 0x1abc9c)
+		
+		/// SwifterSwift: hex #16A085
+		public static let greenSea              = UIColor(hex: 0x16a085)
+		
+		/// SwifterSwift: hex #2ECC71
+		public static let emerald               = UIColor(hex: 0x2ecc71)
+		
+		/// SwifterSwift: hex #27AE60
+		public static let nephritis             = UIColor(hex: 0x27ae60)
+		
+		/// SwifterSwift: hex #3498DB
+		public static let peterRiver            = UIColor(hex: 0x3498db)
+		
+		/// SwifterSwift: hex #2980B9
+		public static let belizeHole            = UIColor(hex: 0x2980b9)
+		
+		/// SwifterSwift: hex #9B59B6
+		public static let amethyst              = UIColor(hex: 0x9b59b6)
+		
+		/// SwifterSwift: hex #8E44AD
+		public static let wisteria              = UIColor(hex: 0x8e44ad)
+		
+		/// SwifterSwift: hex #34495E
+		public static let wetAsphalt            = UIColor(hex: 0x34495e)
+		
+		/// SwifterSwift: hex #2C3E50
+		public static let midnightBlue          = UIColor(hex: 0x2c3e50)
+		
+		/// SwifterSwift: hex #F1C40F
+		public static let sunFlower             = UIColor(hex: 0xf1c40f)
+		
+		/// SwifterSwift: hex #F39C12
+		public static let flatOrange            = UIColor(hex: 0xf39c12)
+		
+		/// SwifterSwift: hex #E67E22
+		public static let carrot                = UIColor(hex: 0xe67e22)
+		
+		/// SwifterSwift: hex #D35400
+		public static let pumkin                = UIColor(hex: 0xd35400)
+		
+		/// SwifterSwift: hex #E74C3C
+		public static let alizarin              = UIColor(hex: 0xe74c3c)
+		
+		/// SwifterSwift: hex #C0392B
+		public static let pomegranate           = UIColor(hex: 0xc0392b)
+		
+		/// SwifterSwift: hex #ECF0F1
+		public static let clouds                = UIColor(hex: 0xecf0f1)
+		
+		/// SwifterSwift: hex #BDC3C7
+		public static let silver                = UIColor(hex: 0xbdc3c7)
+		
+		/// SwifterSwift: hex #7F8C8D
+		public static let asbestos              = UIColor(hex: 0x7f8c8d)
+		
+		/// SwifterSwift: hex #95A5A6
+		public static let concerte              = UIColor(hex: 0x95a5a6)
+	}
 }
 #endif

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -41,6 +41,23 @@ public extension UIColor {
 		return a
 	}
 	
+    /// SwifterSwift: CoreImage.CIColor (read-only).
+    public var coreImageColor: CoreImage.CIColor? {
+        return CoreImage.CIColor(color: self)  // The resulting Core Image color, or nil
+    }
+    
+    /// SwifterSwift: Hue, Saturation, Brightness, and Alpha (read-only).
+    public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat)?
+    {
+        var (hue, saturation, brightness, alpha) = (CGFloat(0.0), CGFloat(0.0), CGFloat(0.0), CGFloat(0.0))
+        if self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) {
+            return (hue, saturation, brightness, alpha)
+        }
+        else {
+            return nil
+        }
+    }
+    
 	/// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
 		var red:	CGFloat = 0

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -57,6 +57,23 @@ public extension UIColor {
         return (hue:hue, saturation:sat, brightness:bri, alpha:alpha)
     }
 
+    /// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
+    public var uInt: UInt {
+        var colorAsUInt32: UInt32 = 0
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+
+        colorAsUInt32 += UInt32(r * 255.0) << 16
+        colorAsUInt32 += UInt32(g * 255.0) << 8
+        colorAsUInt32 += UInt32(b * 255.0)
+
+        return UInt(colorAsUInt32)
+    }
+
     /// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
 		var red:	CGFloat = 0

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -131,6 +131,24 @@ public extension UIImage {
 		return newImage
 	}
 	
+    /// SwifterSwift: UIImage filled with color
+    ///
+    /// - Parameters:
+    ///   - color: color to tint image with.
+    ///   - blendMode: how to blend the tint
+    /// - Returns: UIImage tinted with given color.
+    public func tint(_ color: UIColor, blendMode: CGBlendMode) -> UIImage {
+        let drawRect = CGRect(x: 0.0, y: 0.0, width: size.width, height: size.height)
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        let context = UIGraphicsGetCurrentContext()
+        context!.clip(to: drawRect, mask: cgImage!)
+        color.setFill()
+        UIRectFill(drawRect)
+        draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
+        let tintedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return tintedImage!
+    }
 }
 
 

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -131,24 +131,24 @@ public extension UIImage {
 		return newImage
 	}
 	
-    /// SwifterSwift: UIImage tinted with color
-    ///
-    /// - Parameters:
-    ///   - color: color to tint image with.
-    ///   - blendMode: how to blend the tint
-    /// - Returns: UIImage tinted with given color.
-    public func tint(_ color: UIColor, blendMode: CGBlendMode) -> UIImage {
-        let drawRect = CGRect(x: 0.0, y: 0.0, width: size.width, height: size.height)
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        let context = UIGraphicsGetCurrentContext()
-        context!.clip(to: drawRect, mask: cgImage!)
-        color.setFill()
-        UIRectFill(drawRect)
-        draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
-        let tintedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return tintedImage!
-    }
+	/// SwifterSwift: UIImage tinted with color
+	///
+	/// - Parameters:
+	///   - color: color to tint image with.
+	///   - blendMode: how to blend the tint
+	/// - Returns: UIImage tinted with given color.
+	public func tint(_ color: UIColor, blendMode: CGBlendMode) -> UIImage {
+		let drawRect = CGRect(x: 0.0, y: 0.0, width: size.width, height: size.height)
+		UIGraphicsBeginImageContextWithOptions(size, false, scale)
+		let context = UIGraphicsGetCurrentContext()
+		context!.clip(to: drawRect, mask: cgImage!)
+		color.setFill()
+		UIRectFill(drawRect)
+		draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
+		let tintedImage = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		return tintedImage!
+	}
 }
 
 

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -131,7 +131,7 @@ public extension UIImage {
 		return newImage
 	}
 	
-    /// SwifterSwift: UIImage filled with color
+    /// SwifterSwift: UIImage tinted with color
     ///
     /// - Parameters:
     ///   - color: color to tint image with.

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -54,7 +54,50 @@ class UIColorExtensionsTests: XCTestCase {
 		XCTAssertEqual(color.alpha, 1.0)
 	}
 	
-	func testHexString() {
+    // MARK: - Test properties
+    func testHsbaComponenets() {
+        var color = UIColor(hex: 0xFF0000, transparency: 1.0)
+        XCTAssertEqual(color.hsbaComponents.hue, 1)
+        XCTAssertEqual(color.hsbaComponents.saturation, 1)
+        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+
+        color = UIColor(hex: 0x00FF00, transparency: 1.0)
+        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (120/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.saturation, 1)
+        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+
+        color = UIColor(hex: 0x0000FF, transparency: 1.0)
+        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (240/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.saturation, 1)
+        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+
+        color = UIColor(hex: 0x000000, transparency: 1.0)
+        XCTAssertEqual(color.hsbaComponents.hue, 0)
+        XCTAssertEqual(color.hsbaComponents.saturation, 0)
+        XCTAssertEqual(color.hsbaComponents.brightness, 0)
+
+        color = UIColor(hex: 0xFFFFFF, transparency: 1.0)
+        XCTAssertEqual(color.hsbaComponents.hue, 0)
+        XCTAssertEqual(color.hsbaComponents.saturation, 0)
+        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+
+        color = UIColor(hex: 0x123456, transparency: 1.0)
+        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (210/360)) / 1000))
+        XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 79)
+        XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 34)
+
+        color = UIColor(hex: 0xFCA864, transparency: 1.0)
+        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (27/360)) / 1000))
+        XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 60)
+        XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 99)
+
+        color = UIColor(hex: 0x1F2D3C, transparency: 1.0)
+        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (211/360)) / 1000))
+        XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 48)
+        XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 24)
+    }
+
+    func testHexString() {
 		var color = UIColor.red
 		XCTAssertEqual(color.hexString, "#FF0000")
 		

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -54,67 +54,67 @@ class UIColorExtensionsTests: XCTestCase {
     // MARK: - Test properties
     func testHsbaComponenets() {
         var color = UIColor(hex: 0xFF0000, transparency: 1.0)
-        XCTAssertEqual(color.hsbaComponents.hue, 1)
-        XCTAssertEqual(color.hsbaComponents.saturation, 1)
-        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+        XCTAssertEqual(color?.hsbaComponents.hue, 1)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 1)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
 
         color = UIColor(hex: 0x00FF00, transparency: 1.0)
         XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (120/360)) / 1000))
-        XCTAssertEqual(color.hsbaComponents.saturation, 1)
-        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 1)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
 
         color = UIColor(hex: 0x0000FF, transparency: 1.0)
         XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (240/360)) / 1000))
-        XCTAssertEqual(color.hsbaComponents.saturation, 1)
-        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 1)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
 
         color = UIColor(hex: 0x000000, transparency: 1.0)
-        XCTAssertEqual(color.hsbaComponents.hue, 0)
-        XCTAssertEqual(color.hsbaComponents.saturation, 0)
-        XCTAssertEqual(color.hsbaComponents.brightness, 0)
+        XCTAssertEqual(color?.hsbaComponents.hue, 0)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 0)
 
         color = UIColor(hex: 0xFFFFFF, transparency: 1.0)
-        XCTAssertEqual(color.hsbaComponents.hue, 0)
-        XCTAssertEqual(color.hsbaComponents.saturation, 0)
-        XCTAssertEqual(color.hsbaComponents.brightness, 1)
+        XCTAssertEqual(color?.hsbaComponents.hue, 0)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
 
         color = UIColor(hex: 0x123456, transparency: 1.0)
         XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (210/360)) / 1000))
-        XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 79)
-        XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 34)
+        XCTAssertEqual((color?.hsbaComponents.saturation * 100).rounded(), 79)
+        XCTAssertEqual((color?.hsbaComponents.brightness * 100).rounded(), 34)
 
         color = UIColor(hex: 0xFCA864, transparency: 1.0)
         XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (27/360)) / 1000))
-        XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 60)
-        XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 99)
+        XCTAssertEqual((color?.hsbaComponents.saturation * 100).rounded(), 60)
+        XCTAssertEqual((color?.hsbaComponents.brightness * 100).rounded(), 99)
 
         color = UIColor(hex: 0x1F2D3C, transparency: 1.0)
         XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (211/360)) / 1000))
-        XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 48)
-        XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 24)
+        XCTAssertEqual((color?.hsbaComponents.saturation * 100).rounded(), 48)
+        XCTAssertEqual((color?.hsbaComponents.brightness * 100).rounded(), 24)
     }
 
     func testUInt() {
         var color = UIColor(hex: 0xFF0000, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0xFF0000)
+        XCTAssertEqual(color?.uInt, 0xFF0000)
 
         color = UIColor(hex: 0x00FF00, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0x00FF00)
+        XCTAssertEqual(color?.uInt, 0x00FF00)
 
         color = UIColor(hex: 0x0000FF, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0x0000FF)
+        XCTAssertEqual(color?.uInt, 0x0000FF)
 
         color = UIColor(hex: 0x000000, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0x000000)
+        XCTAssertEqual(color?.uInt, 0x000000)
 
         color = UIColor(hex: 0xFFFFFF, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0xFFFFFF)
+        XCTAssertEqual(color?.uInt, 0xFFFFFF)
 
         color = UIColor(hex: 0x123456, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0x123456)
+        XCTAssertEqual(color?.uInt, 0x123456)
 
         color = UIColor(hex: 0xFCA864, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0xFCA864)
+        XCTAssertEqual(color?.uInt, 0xFCA864)
 
         color = UIColor(hex: 0xFCA864, transparency: 1.0)
         XCTAssertEqual(color.uInt, 0xFCA864)

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -97,6 +97,36 @@ class UIColorExtensionsTests: XCTestCase {
         XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 24)
     }
 
+    func testUInt() {
+        var color = UIColor(hex: 0xFF0000, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0xFF0000)
+
+        color = UIColor(hex: 0x00FF00, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0x00FF00)
+
+        color = UIColor(hex: 0x0000FF, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0x0000FF)
+
+        color = UIColor(hex: 0x000000, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0x000000)
+
+        color = UIColor(hex: 0xFFFFFF, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0xFFFFFF)
+
+        color = UIColor(hex: 0x123456, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0x123456)
+
+        color = UIColor(hex: 0xFCA864, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0xFCA864)
+
+        color = UIColor(hex: 0xFCA864, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0xFCA864)
+
+        color = UIColor(hex: 0x1F2D3C, transparency: 1.0)
+        XCTAssertEqual(color.uInt, 0x1F2D3C)
+
+    }
+
     func testHexString() {
 		var color = UIColor.red
 		XCTAssertEqual(color.hexString, "#FF0000")

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -54,44 +54,44 @@ class UIColorExtensionsTests: XCTestCase {
     // MARK: - Test properties
     func testHsbaComponenets() {
         var color = UIColor(hex: 0xFF0000, transparency: 1.0)
-        XCTAssertEqual(color?.hsbaComponents.hue, 1)
-        XCTAssertEqual(color?.hsbaComponents.saturation, 1)
-        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
+        XCTAssertEqual(color?.hsbaComponents.hue, 0.0)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 1.0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1.0)
 
         color = UIColor(hex: 0x00FF00, transparency: 1.0)
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (120/360)) / 1000))
-        XCTAssertEqual(color?.hsbaComponents.saturation, 1)
-        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
+        XCTAssertEqual(CGFloat(round(1000 * (color?.hsbaComponents.hue)!) / 1000), CGFloat(round(1000 * (120/360)) / 1000))
+        XCTAssertEqual(color?.hsbaComponents.saturation, 1.0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1.0)
 
         color = UIColor(hex: 0x0000FF, transparency: 1.0)
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (240/360)) / 1000))
-        XCTAssertEqual(color?.hsbaComponents.saturation, 1)
-        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
+        XCTAssertEqual(CGFloat(round(1000 * (color?.hsbaComponents.hue)!) / 1000), CGFloat(round(1000 * (240/360)) / 1000))
+        XCTAssertEqual(color?.hsbaComponents.saturation, 1.0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1.0)
 
         color = UIColor(hex: 0x000000, transparency: 1.0)
-        XCTAssertEqual(color?.hsbaComponents.hue, 0)
-        XCTAssertEqual(color?.hsbaComponents.saturation, 0)
-        XCTAssertEqual(color?.hsbaComponents.brightness, 0)
+        XCTAssertEqual(color?.hsbaComponents.hue, 0.0)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 0.0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 0.0)
 
         color = UIColor(hex: 0xFFFFFF, transparency: 1.0)
-        XCTAssertEqual(color?.hsbaComponents.hue, 0)
-        XCTAssertEqual(color?.hsbaComponents.saturation, 0)
-        XCTAssertEqual(color?.hsbaComponents.brightness, 1)
+        XCTAssertEqual(color?.hsbaComponents.hue, 0.0)
+        XCTAssertEqual(color?.hsbaComponents.saturation, 0.0)
+        XCTAssertEqual(color?.hsbaComponents.brightness, 1.0)
 
         color = UIColor(hex: 0x123456, transparency: 1.0)
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (210/360)) / 1000))
-        XCTAssertEqual((color?.hsbaComponents.saturation * 100).rounded(), 79)
-        XCTAssertEqual((color?.hsbaComponents.brightness * 100).rounded(), 34)
+        XCTAssertEqual(CGFloat(round(1000 * (color?.hsbaComponents.hue)!) / 1000), CGFloat(round(1000 * (210/360)) / 1000))
+        XCTAssertEqual(((color?.hsbaComponents.saturation)! * 100).rounded(), 79)
+        XCTAssertEqual(((color?.hsbaComponents.brightness)! * 100).rounded(), 34)
 
         color = UIColor(hex: 0xFCA864, transparency: 1.0)
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (27/360)) / 1000))
-        XCTAssertEqual((color?.hsbaComponents.saturation * 100).rounded(), 60)
-        XCTAssertEqual((color?.hsbaComponents.brightness * 100).rounded(), 99)
+        XCTAssertEqual(CGFloat(round(1000 * (color?.hsbaComponents.hue)!) / 1000), CGFloat(round(1000 * (27/360)) / 1000))
+        XCTAssertEqual(((color?.hsbaComponents.saturation)! * 100).rounded(), 60)
+        XCTAssertEqual(((color?.hsbaComponents.brightness)! * 100).rounded(), 99)
 
         color = UIColor(hex: 0x1F2D3C, transparency: 1.0)
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (211/360)) / 1000))
-        XCTAssertEqual((color?.hsbaComponents.saturation * 100).rounded(), 48)
-        XCTAssertEqual((color?.hsbaComponents.brightness * 100).rounded(), 24)
+        XCTAssertEqual(CGFloat(round(1000 * (color?.hsbaComponents.hue)!) / 1000), CGFloat(round(1000 * (211/360)) / 1000))
+        XCTAssertEqual(((color?.hsbaComponents.saturation)! * 100).rounded(), 48)
+        XCTAssertEqual(((color?.hsbaComponents.brightness)! * 100).rounded(), 24)
     }
 
     func testUInt() {
@@ -117,10 +117,10 @@ class UIColorExtensionsTests: XCTestCase {
         XCTAssertEqual(color?.uInt, 0xFCA864)
 
         color = UIColor(hex: 0xFCA864, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0xFCA864)
+        XCTAssertEqual(color?.uInt, 0xFCA864)
 
         color = UIColor(hex: 0x1F2D3C, transparency: 1.0)
-        XCTAssertEqual(color.uInt, 0x1F2D3C)
+        XCTAssertEqual(color?.uInt, 0x1F2D3C)
 
     }
 

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -87,5 +87,13 @@ class UIImageExtensionsTests: XCTestCase {
 		XCTAssertEqual(emptyImage, filledImage)
 	}
 	
+    
+    func testTinted() {
+        let baseImage = UIImage(color: .white, size: CGSize(width: 20, height: 20))
+        let tintedImage = baseImage.tint(.black, blendMode: .overlay)
+        let testImage = UIImage(color: .black, size: CGSize(width: 20, height: 20))
+        XCTAssertEqual(testImage.bytesSize, tintedImage.bytesSize)
+    }
+    
 }
 #endif


### PR DESCRIPTION
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 3.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.

UIColor: HBSA component access, UInt conversion, access to CoreImage.CIColor, and FlatUI colors
NSColor: FlatUI colors
UIImage: Tinted image