### PR TITLE
Fixed the CoreImage accessor in UIColor to be restricted to iOS and tvOS

### DIFF
--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -35,11 +35,13 @@ public extension UIColor {
 		return a
 	}
 	
-	/// SwifterSwift: CoreImage.CIColor (read-only).
-	public var coreImageColor: CoreImage.CIColor? {
-		return CoreImage.CIColor(color: self)  // The resulting Core Image color, or nil
-	}
-	
+    #if os(iOS) || os(tvOS)
+        /// SwifterSwift: CoreImage.CIColor (read-only). Only available on iOS and tvOS
+        public var coreImageColor: CoreImage.CIColor? {
+            return CoreImage.CIColor(color: self)  // The resulting Core Image color, or nil
+        }
+    #endif
+
 	/// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
 	public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
 		var hue:    CGFloat = 0.0

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -124,6 +124,32 @@ class UIColorExtensionsTests: XCTestCase {
 
     }
 
+    func testCoreImageColor() {
+        var color = UIColor(hex: 0xFF0000, transparency: 1.0)
+        var coreImageTestColor = CIColor(red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0)
+        XCTAssertEqual([color!.coreImageColor!.red, color!.coreImageColor!.green, color!.coreImageColor!.blue, color!.coreImageColor!.alpha], [coreImageTestColor.red, coreImageTestColor.green, coreImageTestColor.blue, coreImageTestColor.alpha])
+
+        color = UIColor(hex: 0x00FF00, transparency: 1.0)
+        coreImageTestColor = CIColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0)
+        XCTAssertEqual([color!.coreImageColor!.red, color!.coreImageColor!.green, color!.coreImageColor!.blue, color!.coreImageColor!.alpha], [coreImageTestColor.red, coreImageTestColor.green, coreImageTestColor.blue, coreImageTestColor.alpha])
+
+        color = UIColor(hex: 0x0000FF, transparency: 1.0)
+        coreImageTestColor = CIColor(red: 0.0, green: 0.0, blue: 1.0, alpha: 1.0)
+        XCTAssertEqual([color!.coreImageColor!.red, color!.coreImageColor!.green, color!.coreImageColor!.blue, color!.coreImageColor!.alpha], [coreImageTestColor.red, coreImageTestColor.green, coreImageTestColor.blue, coreImageTestColor.alpha])
+        
+        color = UIColor(hex: 0x000000, transparency: 1.0)
+        coreImageTestColor = CIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+        XCTAssertEqual([color!.coreImageColor!.red, color!.coreImageColor!.green, color!.coreImageColor!.blue, color!.coreImageColor!.alpha], [coreImageTestColor.red, coreImageTestColor.green, coreImageTestColor.blue, coreImageTestColor.alpha])
+        
+        color = UIColor(hex: 0xFFFFFF, transparency: 1.0)
+        coreImageTestColor = CIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+        XCTAssertEqual([color!.coreImageColor!.red, color!.coreImageColor!.green, color!.coreImageColor!.blue, color!.coreImageColor!.alpha], [coreImageTestColor.red, coreImageTestColor.green, coreImageTestColor.blue, coreImageTestColor.alpha])
+        
+        color = UIColor(hex: 0x0000FF, transparency: 0.5)
+        coreImageTestColor = CIColor(red: 0.0, green: 0.0, blue: 1.0, alpha: 0.5)
+        XCTAssertEqual([color!.coreImageColor!.red, color!.coreImageColor!.green, color!.coreImageColor!.blue, color!.coreImageColor!.alpha], [coreImageTestColor.red, coreImageTestColor.green, coreImageTestColor.blue, coreImageTestColor.alpha])
+    }
+    
     func testHexString() {
 		var color = UIColor.red
 		XCTAssertEqual(color.hexString, "#FF0000")


### PR DESCRIPTION
This PR addresses issue #214 

Issue: CoreImage is not available on watchOS, resulting in a compilation error. 
Fix: Restricts the accessor to be only available on iOS and tvOS via wrapping it in a conditional compilation block.