### PR TITLE
New attributed string operators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ All notable changes to this project will be documented in this file.
 N/A
 
 ### Enhancements
-N/A
-
+- New **NSAttributedString** extensions
+  - added `NSAttributedString + NSAttributedString` operator to return a new appended NSAttributedString. [#218](https://github.com/SwifterSwift/SwifterSwift/pull/218) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+  - added `NSAttributedString += String` operator to append a string to a NSAttributedString. [#218](https://github.com/SwifterSwift/SwifterSwift/pull/218) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+  - added `NSAttributedString + String` operator to return a new appended NSAttributedString. [#218](https://github.com/SwifterSwift/SwifterSwift/pull/218) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+  
 ### Bugfixes
 N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ N/A
 
 ### Enhancements
 - New **NSAttributedString** extensions
-  - added `NSAttributedString + NSAttributedString` operator to return a new appended NSAttributedString. [#218](https://github.com/SwifterSwift/SwifterSwift/pull/218) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
-  - added `NSAttributedString += String` operator to append a string to a NSAttributedString. [#218](https://github.com/SwifterSwift/SwifterSwift/pull/218) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+  - added `NSAttributedString + NSAttributedString` operator to return a new appended NSAttributedString.
+  - added `NSAttributedString += String` operator to append a string to a NSAttributedString.
   - added `NSAttributedString + String` operator to return a new appended NSAttributedString. [#218](https://github.com/SwifterSwift/SwifterSwift/pull/218) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
   
 ### Bugfixes

--- a/Sources/Extensions/Cocoa/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Cocoa/NSAttributedStringExtensions.swift
@@ -89,4 +89,33 @@ public extension NSAttributedString {
 		ns.append(rhs)
 		lhs = ns
 	}
+    
+    /// SwifterSwift: Add a NSAttributedString to another NSAttributedString and return a new NSAttributedString instance.
+    ///
+    /// - Parameters:
+    ///   - lhs: NSAttributedString to add.
+    ///   - rhs: NSAttributedString to add.
+    public static func + (lhs: NSAttributedString, rhs: NSAttributedString) -> NSAttributedString {
+        let ns = NSMutableAttributedString(attributedString: lhs)
+        ns.append(rhs)
+        return NSAttributedString(attributedString: ns)
+    }
+    
+    /// SwifterSwift: Add a NSAttributedString to another NSAttributedString.
+    ///
+    /// - Parameters:
+    ///   - lhs: NSAttributedString to add to.
+    ///   - rhs: String to add.
+    public static func += (lhs: inout NSAttributedString, rhs: String) {
+        lhs += NSAttributedString(string: rhs)
+    }
+    
+    /// SwifterSwift: Add a NSAttributedString to another NSAttributedString and return a new NSAttributedString instance.
+    ///
+    /// - Parameters:
+    ///   - lhs: NSAttributedString to add.
+    ///   - rhs: String to add.
+    public static func + (lhs: NSAttributedString, rhs: String) -> NSAttributedString {
+        return lhs + NSAttributedString(string: rhs)
+    }
 }

--- a/Sources/Extensions/Cocoa/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Cocoa/NSAttributedStringExtensions.swift
@@ -95,6 +95,7 @@ public extension NSAttributedString {
     /// - Parameters:
     ///   - lhs: NSAttributedString to add.
     ///   - rhs: NSAttributedString to add.
+    /// - Returns: New instance with added NSAttributedString.
     public static func + (lhs: NSAttributedString, rhs: NSAttributedString) -> NSAttributedString {
         let ns = NSMutableAttributedString(attributedString: lhs)
         ns.append(rhs)
@@ -115,6 +116,7 @@ public extension NSAttributedString {
     /// - Parameters:
     ///   - lhs: NSAttributedString to add.
     ///   - rhs: String to add.
+    /// - Returns: New instance with added NSAttributedString.
     public static func + (lhs: NSAttributedString, rhs: String) -> NSAttributedString {
         return lhs + NSAttributedString(string: rhs)
     }

--- a/Sources/Extensions/Foundation/ArrayExtensions.swift
+++ b/Sources/Extensions/Foundation/ArrayExtensions.swift
@@ -261,7 +261,10 @@ public extension Array {
     }
 	
 	/// SwifterSwift: Reduces an array while returning each interim combination.
-	///
+	///     
+    ///     [1, 2, 3].accumulate(initial: 0, next: +) -> [1, 3, 6]
+    ///     // It also works for other types!
+    ///
 	/// - Parameters:
     ///   - initial: initial value.
     ///   - next: closure that combines the accumulating value and next element of the array.
@@ -276,6 +279,9 @@ public extension Array {
     
     /// SwifterSwift: Filtered and map in a single operation.
 	///
+    ///     [1,2,3,4,5].filtered({ $0 % 2 == 0 }, map: { $0.string }) -> ["2", "4"]
+    ///     // It also works for other types!
+    ///
 	/// - Parameters:
     ///   - isIncluded: condition of inclusion to evaluate each element against.
     ///   - transform: transform element function to evaluate every element.

--- a/Sources/Extensions/Foundation/StringExtensions.swift
+++ b/Sources/Extensions/Foundation/StringExtensions.swift
@@ -190,8 +190,10 @@ public extension String {
 	}
 	
 	/// SwifterSwift: Check if string is a valid file URL.
-	///
-	public var isValidFileUrl: Bool {
+    ///
+    ///		"file://Documents/file.txt".isValidFileUrl -> true
+    ///	
+    public var isValidFileUrl: Bool {
 		return URL(string: self)?.isFileURL ?? false
 	}
 	

--- a/Tests/CocoaTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/CocoaTests/NSAttributedStringExtensionsTests.swift
@@ -117,5 +117,103 @@ class NSAttributedStringExtensionsTests: XCTestCase {
 
 		XCTAssertEqual(filteredAttributes.count, 1)
 	}
+    
+    func testPlusAttributedString() {
+        let a : NSAttributedString = NSAttributedString(string: "Test").italicized.underlined.struckthrough
+        let b : NSAttributedString = NSAttributedString(string: " Appending").bolded
+        let result = a + b
+        
+        XCTAssertEqual(result.string, "Test Appending")
+        
+        var attributes = result.attributes(at: 0, effectiveRange: nil)
+        var filteredAttributes = attributes.filter { (key, value) -> Bool in
+            var valid = false
+            if key == NSFontAttributeName, let value = value as? UIFont, value == .italicSystemFont(ofSize: UIFont.systemFontSize) {
+                valid = true
+            }
+            if key == NSUnderlineStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+                valid = true
+            }
+            if key == NSStrikethroughStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+                valid = true
+            }
+            
+            return valid
+        }
+        
+        XCTAssertEqual(filteredAttributes.count, 3)
+        
+        attributes = result.attributes(at: 5, effectiveRange: nil)
+        filteredAttributes = attributes.filter { (key, value) -> Bool in
+            return (key == NSFontAttributeName && (value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize))
+        }
+        
+        XCTAssertEqual(filteredAttributes.count, 1)
+    }
+    
+    func testAppendingString() {
+        var string = NSAttributedString(string: "Test").italicized.underlined.struckthrough
+        string += " Appending"
+        
+        XCTAssertEqual(string.string, "Test Appending")
+        
+        var attributes = string.attributes(at: 0, effectiveRange: nil)
+        var filteredAttributes = attributes.filter { (key, value) -> Bool in
+            var valid = false
+            if key == NSFontAttributeName, let value = value as? UIFont, value == .italicSystemFont(ofSize: UIFont.systemFontSize) {
+                valid = true
+            }
+            if key == NSUnderlineStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+                valid = true
+            }
+            if key == NSStrikethroughStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+                valid = true
+            }
+            
+            return valid
+        }
+        
+        XCTAssertEqual(filteredAttributes.count, 3)
+        
+        attributes = string.attributes(at: 5, effectiveRange: nil)
+        filteredAttributes = attributes.filter { (key, value) -> Bool in
+            return (key == NSFontAttributeName && (value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize))
+        }
+        
+        XCTAssertEqual(filteredAttributes.count, 0)
+    }
+    
+    func testPlusString() {
+        let a : NSAttributedString = NSAttributedString(string: "Test").italicized.underlined.struckthrough
+        let b : String = " Appending"
+        let result = a + b
+        
+        XCTAssertEqual(result.string, "Test Appending")
+        
+        var attributes = result.attributes(at: 0, effectiveRange: nil)
+        var filteredAttributes = attributes.filter { (key, value) -> Bool in
+            var valid = false
+            if key == NSFontAttributeName, let value = value as? UIFont, value == .italicSystemFont(ofSize: UIFont.systemFontSize) {
+                valid = true
+            }
+            if key == NSUnderlineStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+                valid = true
+            }
+            if key == NSStrikethroughStyleAttributeName, let value = value as? NSUnderlineStyle.RawValue, value == NSUnderlineStyle.styleSingle.rawValue {
+                valid = true
+            }
+            
+            return valid
+        }
+        
+        XCTAssertEqual(filteredAttributes.count, 3)
+        
+        attributes = result.attributes(at: 5, effectiveRange: nil)
+        filteredAttributes = attributes.filter { (key, value) -> Bool in
+            return (key == NSFontAttributeName && (value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize))
+        }
+        
+        XCTAssertEqual(filteredAttributes.count, 0)
+    }
 	#endif
 }

--- a/Tests/CocoaTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/CocoaTests/NSAttributedStringExtensionsTests.swift
@@ -86,7 +86,7 @@ class NSAttributedStringExtensionsTests: XCTestCase {
 
 	#if !os(macOS) && !os(tvOS)
 	// MARK: - Operators
-	func testAppending() {
+	func testPlusEqual() {
 		var string = NSAttributedString(string: "Test").italicized.underlined.struckthrough
 		string += NSAttributedString(string: " Appending").bolded
 
@@ -151,7 +151,7 @@ class NSAttributedStringExtensionsTests: XCTestCase {
         XCTAssertEqual(filteredAttributes.count, 1)
     }
     
-    func testAppendingString() {
+    func testPlusEqualString() {
         var string = NSAttributedString(string: "Test").italicized.underlined.struckthrough
         string += " Appending"
         


### PR DESCRIPTION
Adding missing string and array exemples.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 3.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
