### PR TITLE
Improve sum & average extensions by not relying on reduce

### DIFF
--- a/Sources/Extensions/Foundation/ArrayExtensions.swift
+++ b/Sources/Extensions/Foundation/ArrayExtensions.swift
@@ -18,8 +18,9 @@ public extension Array where Element: Integer {
 	///
 	/// - Returns: sum of the array's elements.
 	public func sum() -> Element {
-		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
-		return reduce(0, +)
+        var total: Element = 0
+        forEach { total += $0 }
+        return total
 	}
 	
 }
@@ -34,8 +35,10 @@ public extension Array where Element: FloatingPoint {
 	///
 	/// - Returns: average of the array's elements.
 	public func average() -> Element {
-		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
-		return isEmpty ? 0 : reduce(0, +) / Element(count)
+        guard isEmpty == false else { return 0 }
+        var total: Element = 0
+        forEach { total += $0 }
+        return total / Element(count)
 	}
 	
 	/// SwifterSwift: Sum of all elements in array.
@@ -44,8 +47,9 @@ public extension Array where Element: FloatingPoint {
 	///
 	/// - Returns: sum of the array's elements.
 	public func sum() -> Element {
-		// http://stackoverflow.com/questions/28288148/making-my-function-calculate-average-of-array-swift
-		return reduce(0, +)
+        var total: Element = 0
+        forEach { total += $0 }
+        return total
 	}
 	
 }


### PR DESCRIPTION
Sometimes the smallest code isn't always the most performant. I reckon `removeDuplicates()` and `duplicatesRemoved()` would also benefit from this approach. I was a bit too lazy though 😅

I'm using Travis to run my tests for this because my simulator was too slow 😐