### PR TITLE
Fixes #224

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,15 @@ let package = Package(
 
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/DictionaryExtensions.swift"><code>Dictionary extensions</code></a></li>
 
+<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/SignedNumberExtensions.swift"><code>SignedNumber extensions</code></a></li>
+
+<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/FloatingPointExtensions.swift"><code>FloatingPoint extensions</code></a></li>
+
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/DoubleExtensions.swift"><code>Double extensions</code></a></li>
 
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/FloatExtensions.swift"><code>Float extensions</code></a></li>
 
-<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/FloatingPointExtensions.swift"><code>FloatingPoint extensions</code></a></li>
+<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/SignedIntegerExtensions.swift"><code>SignedInteger extensions</code></a></li>
 
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/Extensions/Foundation/IntExtensions.swift"><code>Int extensions</code></a></li>
 

--- a/Sources/Extensions/Foundation/DoubleExtensions.swift
+++ b/Sources/Extensions/Foundation/DoubleExtensions.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 
 // MARK: - Properties

--- a/Sources/Extensions/Foundation/FloatExtensions.swift
+++ b/Sources/Extensions/Foundation/FloatExtensions.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 
 // MARK: - Properties

--- a/Sources/Extensions/Foundation/FloatingPointExtensions.swift
+++ b/Sources/Extensions/Foundation/FloatingPointExtensions.swift
@@ -12,19 +12,6 @@ import Foundation
 // MARK: - Properties
 public extension FloatingPoint {
 	
-	/// SwifterSwift: Absolute of number.
-	public var abs: Self {
-		return Swift.abs(self)
-	}
-	
-	/// SwifterSwift: String with number and current locale currency.
-	public var asLocaleCurrency: String {
-		let formatter = NumberFormatter()
-		formatter.numberStyle = .currency
-		formatter.locale = Locale.current
-		return formatter.string(from: self as! NSNumber)!
-	}
-	
 	/// SwifterSwift: Ceil of number.
 	public var ceil: Self {
 		return Foundation.ceil(self)
@@ -38,21 +25,6 @@ public extension FloatingPoint {
 	/// SwifterSwift: Floor of number.
 	public var floor: Self {
 		return Foundation.floor(self)
-	}
-	
-	/// SwifterSwift: Check if number is positive.
-	public var isPositive: Bool {
-		return self > 0
-	}
-	
-	/// SwifterSwift: Check if number is negative.
-	public var isNegative: Bool {
-		return self < 0
-	}
-	
-	/// SwifterSwift: String.
-	public var string: String {
-		return String(describing: self as! NSNumber)
 	}
 	
 	/// SwifterSwift: Degree value of radian input.

--- a/Sources/Extensions/Foundation/IntExtensions.swift
+++ b/Sources/Extensions/Foundation/IntExtensions.swift
@@ -6,28 +6,12 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 
 // MARK: - Properties
 public extension Int {
 	
-	/// SwifterSwift: Absolute value of integer.
-	public var abs: Int {
-		return Swift.abs(self)
-	}
-	
-	/// SwifterSwift: String with number and current locale currency.
-	public var asLocaleCurrency: String {
-		let formatter = NumberFormatter()
-		formatter.numberStyle = .currency
-		formatter.locale = Locale.current
-		return formatter.string(from: self as NSNumber)!
-	}
 	
 	/// SwifterSwift: CountableRange 0..<Int.
 	public var countableRange: CountableRange<Int> {
@@ -39,15 +23,9 @@ public extension Int {
 		return Double.pi * Double(self) / 180.0
 	}
 	
-	/// SwifterSwift: Array of digits of integer value.
-	public var digits: [Int] {
-		var digits: [Int] = []
-		for char in String(self).characters {
-			if let int = Int(String(char)) {
-				digits.append(int)
-			}
-		}
-		return digits
+	/// SwifterSwift: Degree value of radian input
+	public var radiansToDegrees: Double {
+		return Double(self) * 180 / Double.pi
 	}
 	
 	/// SwifterSwift: Number of digits of integer value.
@@ -55,25 +33,6 @@ public extension Int {
 		return String(self).characters.count
 	}
 	
-	/// SwifterSwift: Check if integer is even.
-	public var isEven: Bool {
-		return (self % 2) == 0
-	}
-	
-	/// SwifterSwift: Check if integer is odd.
-	public var isOdd: Bool {
-		return (self % 2) != 0
-	}
-	
-	/// SwifterSwift: Check if integer is positive.
-	public var isPositive: Bool {
-		return self > 0
-	}
-	
-	/// SwifterSwift: Check if integer is negative.
-	public var isNegative: Bool {
-		return self < 0
-	}
 	
 	/// SwifterSwift: UInt.
 	public var uInt: UInt {
@@ -93,16 +52,6 @@ public extension Int {
 	/// SwifterSwift: CGFloat.
 	public var cgFloat: CGFloat {
 		return CGFloat(self)
-	}
-	
-	/// SwifterSwift: String.
-	public var string: String {
-		return String(self)
-	}
-	
-	/// SwifterSwift: Degree value of radian input
-	public var radiansToDegrees: Double {
-		return Double(self) * 180 / Double.pi
 	}
 	
 	/// SwifterSwift: Roman numeral string from integer (if applicable).
@@ -130,26 +79,6 @@ public extension Int {
 		return romanValue
 	}
 	
-	/// SwifterSwift: String of format (XXh XXm) from seconds Int.
-	public var timeString: String {
-		guard self > 0 else {
-			return "0 sec"
-		}
-		if self < 60 {
-			return "\(self) sec"
-		}
-		if self < 3600 {
-			return "\(self / 60) min"
-		}
-		let hours = self / 3600
-		let mins = (self % 3600) / 60
-		
-		if hours != 0 && mins == 0 {
-			return "\(hours)h"
-		}
-		return "\(hours)h \(mins)m"
-	}
-	
 	/// SwifterSwift: String formatted for values over ±1000 (example: 1k, -2k, 100k, 1kk, -5kk..)
 	public var kFormatted: String {
 		var sign: String {
@@ -171,22 +100,6 @@ public extension Int {
 
 // MARK: - Methods
 public extension Int {
-	
-	/// SwifterSwift: Greatest common divisor of integer value and n.
-	///
-	/// - Parameter n: integer value to find gcd with.
-	/// - Returns: greatest common divisor of self and n.
-	public func gcd(of n: Int) -> Int {
-		return n == 0 ? self : n.gcd(of: self % n)
-	}
-	
-	/// SwifterSwift: Least common multiple of integer and n.
-	///
-	/// - Parameter n: integer value to find lcm with.
-	/// - Returns: least common multiple of self and n.
-	public func lcm(of n: Int) -> Int {
-		return (self * n).abs / gcd(of: n)
-	}
 	
 	/// SwifterSwift: Random integer between two integer values.
 	///

--- a/Sources/Extensions/Foundation/SignedIntegerExtensions.swift
+++ b/Sources/Extensions/Foundation/SignedIntegerExtensions.swift
@@ -1,0 +1,85 @@
+//
+//  SignedIntegerExtensions.swift
+//  SwifterSwift
+//
+//  Created by Omar Albeik on 8/15/17.
+//
+//
+
+import Foundation
+
+
+// MARK: - Properties
+public extension SignedInteger {
+	
+	/// SwifterSwift: Check if integer is even.
+	public var isEven: Bool {
+		return (self % 2) == 0
+	}
+	
+	/// SwifterSwift: Check if integer is odd.
+	public var isOdd: Bool {
+		return (self % 2) != 0
+	}
+	
+	/// SwifterSwift: Array of digits of integer value.
+	public var digits: [Self] {
+		var digits: [Self] = []
+		for char in String(self).characters {
+			if let int = IntMax(String(char)) {
+				digits.append(Self(int))
+			}
+		}
+		return digits
+	}
+	
+	/// SwifterSwift: Number of digits of integer value.
+	public var digitsCount: Int {
+		return String(self).characters.count
+	}
+	
+	/// SwifterSwift: String of format (XXh XXm) from seconds Int.
+	public var timeString: String {
+		guard self > 0 else {
+			return "0 sec"
+		}
+		if self < 60 {
+			return "\(self) sec"
+		}
+		if self < 3600 {
+			return "\(self / 60) min"
+		}
+		let hours = self / 3600
+		let mins = (self % 3600) / 60
+		
+		if hours != 0 && mins == 0 {
+			return "\(hours)h"
+		}
+		return "\(hours)h \(mins)m"
+	}
+
+}
+
+
+// MARK: - Methods
+public extension SignedInteger {
+	
+	/// SwifterSwift: Greatest common divisor of integer value and n.
+	///
+	/// - Parameter n: integer value to find gcd with.
+	/// - Returns: greatest common divisor of self and n.
+	public func gcd(of n: Self) -> Self {
+		return n == 0 ? self : n.gcd(of: self % n)
+	}
+	
+	/// SwifterSwift: Least common multiple of integer and n.
+	///
+	/// - Parameter n: integer value to find lcm with.
+	/// - Returns: least common multiple of self and n.
+	public func lcm(of n: Self) -> Self {
+		return (self * n).abs / gcd(of: n)
+	}
+	
+}
+
+

--- a/Sources/Extensions/Foundation/SignedNumberExtensions.swift
+++ b/Sources/Extensions/Foundation/SignedNumberExtensions.swift
@@ -1,0 +1,42 @@
+//
+//  SignedNumberExtensions.swift
+//  SwifterSwift
+//
+//  Created by Omar Albeik on 8/15/17.
+//
+//
+
+import Foundation
+
+
+public extension SignedNumber {
+	
+	/// SwifterSwift: Absolute value of integer.
+	public var abs: Self {
+		return Swift.abs(self)
+	}
+	
+	/// SwifterSwift: Check if integer is positive.
+	public var isPositive: Bool {
+		return self > 0
+	}
+	
+	/// SwifterSwift: Check if integer is negative.
+	public var isNegative: Bool {
+		return self < 0
+	}
+	
+	/// SwifterSwift: String.
+	public var string: String {
+		return String(describing: self)
+	}
+	
+	/// SwifterSwift: String with number and current locale currency.
+	public var asLocaleCurrency: String {
+		let formatter = NumberFormatter()
+		formatter.numberStyle = .currency
+		formatter.locale = Locale.current
+		return formatter.string(from: self as! NSNumber)!
+	}
+}
+

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		077A72CC1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72CB1F436357003DC1C4 /* SignedNumberExtensions.swift */; };
+		077A72CD1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72CB1F436357003DC1C4 /* SignedNumberExtensions.swift */; };
+		077A72CE1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72CB1F436357003DC1C4 /* SignedNumberExtensions.swift */; };
+		077A72CF1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72CB1F436357003DC1C4 /* SignedNumberExtensions.swift */; };
+		077A72D11F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72D01F436433003DC1C4 /* SignedIntegerExtensions.swift */; };
+		077A72D21F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72D01F436433003DC1C4 /* SignedIntegerExtensions.swift */; };
+		077A72D31F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72D01F436433003DC1C4 /* SignedIntegerExtensions.swift */; };
+		077A72D41F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077A72D01F436433003DC1C4 /* SignedIntegerExtensions.swift */; };
 		077AD1BA1F13873600D3214D /* SwifterSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07DFA3AE1F1380F100D0C644 /* SwifterSwift.framework */; };
 		077AD1C91F13875100D3214D /* SwifterSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07DFA3BC1F13816200D0C644 /* SwifterSwift.framework */; };
 		077AD1D81F13876000D3214D /* SwifterSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07DFA3C91F13817200D0C644 /* SwifterSwift.framework */; };
@@ -318,6 +326,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		077A72CB1F436357003DC1C4 /* SignedNumberExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignedNumberExtensions.swift; sourceTree = "<group>"; };
+		077A72D01F436433003DC1C4 /* SignedIntegerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignedIntegerExtensions.swift; sourceTree = "<group>"; };
 		077AD1B51F13873600D3214D /* SwifterSwift iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		077AD1C41F13875100D3214D /* SwifterSwift macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		077AD1D31F13876000D3214D /* SwifterSwift tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwifterSwift tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -543,6 +553,8 @@
 				07897F521F138A3300A3A4E1 /* DoubleExtensions.swift */,
 				07897F531F138A3300A3A4E1 /* FloatExtensions.swift */,
 				07897F541F138A3300A3A4E1 /* IntExtensions.swift */,
+				077A72CB1F436357003DC1C4 /* SignedNumberExtensions.swift */,
+				077A72D01F436433003DC1C4 /* SignedIntegerExtensions.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1142,6 +1154,7 @@
 				07897FFC1F138A3300A3A4E1 /* UISliderExtensions.swift in Sources */,
 				078980041F138A3300A3A4E1 /* UISwitchExtensions.swift in Sources */,
 				078980101F138A3300A3A4E1 /* UITextFieldExtensions.swift in Sources */,
+				077A72D11F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */,
 				07B8600D1F21CE550032CE3A /* UIKitDeprecated.swift in Sources */,
 				07897FF81F138A3300A3A4E1 /* UISegmentedControlExtensions.swift in Sources */,
 				07897F8C1F138A3300A3A4E1 /* NSViewExtensions.swift in Sources */,
@@ -1160,6 +1173,7 @@
 				07897FD01F138A3300A3A4E1 /* UIButtonExtensions.swift in Sources */,
 				07897FDC1F138A3300A3A4E1 /* UIImageExtensions.swift in Sources */,
 				078980081F138A3300A3A4E1 /* UITabBarExtensions.swift in Sources */,
+				077A72CC1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */,
 				078473951F24F3E1001F8575 /* FloatingPointExtensions.swift in Sources */,
 				078980001F138A3300A3A4E1 /* UIStoryboardExtensions.swift in Sources */,
 				078980141F138A3300A3A4E1 /* UITextViewExtensions.swift in Sources */,
@@ -1183,6 +1197,7 @@
 				07897FC11F138A3300A3A4E1 /* StringExtensions.swift in Sources */,
 				07897F751F138A3300A3A4E1 /* CGFloatExtensions.swift in Sources */,
 				07897F991F138A3300A3A4E1 /* CharacterExtensions.swift in Sources */,
+				077A72CD1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */,
 				07897F791F138A3300A3A4E1 /* CGPointExtensions.swift in Sources */,
 				07B8600E1F21CE550032CE3A /* UIKitDeprecated.swift in Sources */,
 				07897FA91F138A3300A3A4E1 /* DictionaryExtensions.swift in Sources */,
@@ -1195,6 +1210,7 @@
 				07897FBD1F138A3300A3A4E1 /* OptionalExtensions.swift in Sources */,
 				078473961F24F3E1001F8575 /* FloatingPointExtensions.swift in Sources */,
 				07897F711F138A3300A3A4E1 /* CGColorExtensions.swift in Sources */,
+				077A72D21F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */,
 				07897F951F138A3300A3A4E1 /* BoolExtensions.swift in Sources */,
 				078980E21F138B7900A3A4E1 /* SwifterSwift.swift in Sources */,
 				07897FAD1F138A3300A3A4E1 /* DoubleExtensions.swift in Sources */,
@@ -1225,6 +1241,8 @@
 				07897F7E1F138A3300A3A4E1 /* CGSizeExtensions.swift in Sources */,
 				07897FA61F138A3300A3A4E1 /* DateExtensions.swift in Sources */,
 				0789800E1F138A3300A3A4E1 /* UITableViewExtensions.swift in Sources */,
+				077A72D31F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */,
+				077A72CE1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */,
 				07897FB61F138A3300A3A4E1 /* IntExtensions.swift in Sources */,
 				07897FFE1F138A3300A3A4E1 /* UISliderExtensions.swift in Sources */,
 				078980061F138A3300A3A4E1 /* UISwitchExtensions.swift in Sources */,
@@ -1304,11 +1322,13 @@
 				078980171F138A3300A3A4E1 /* UITextViewExtensions.swift in Sources */,
 				07897FE31F138A3300A3A4E1 /* UIImageViewExtensions.swift in Sources */,
 				07897FC71F138A3300A3A4E1 /* URLExtensions.swift in Sources */,
+				077A72CF1F436357003DC1C4 /* SignedNumberExtensions.swift in Sources */,
 				07897FEB1F138A3300A3A4E1 /* UINavigationBarExtensions.swift in Sources */,
 				07897F931F138A3300A3A4E1 /* ArrayExtensions.swift in Sources */,
 				07897F871F138A3300A3A4E1 /* NSAttributedStringExtensions.swift in Sources */,
 				07897FCB1F138A3300A3A4E1 /* UIAlertControllerExtensions.swift in Sources */,
 				07B8600F1F21CE550032CE3A /* UIKitDeprecated.swift in Sources */,
+				077A72D41F436433003DC1C4 /* SignedIntegerExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Add SignedNumberExtensions
Add SignedIntegerExtensions

- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 3.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
