### PR TITLE
UIColor.hexString alpha support #190

### DIFF
--- a/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
@@ -36,13 +36,13 @@ extension UIColor {
 		return Int(blue * CGFloat(255.0))
 	}
 
-	@available(*, deprecated: 3.1.0, message: "Use 'hexString(withAlpha:)' instead", renamed: "hexString(withAlpha:)")
+	@available(*, deprecated: 3.2.0, message: "Use 'hexString(withAlpha:)' instead", renamed: "hexString(withAlpha:)")
 	/// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
 		return hexString(withAlpha: false)
 	}
 
-	@available(*, deprecated: 3.1.0, message: "Use shortHexString(withAlpha:) instead", renamed: "shortHexString(withAlpha:)")
+	@available(*, deprecated: 3.2.0, message: "Use shortHexString(withAlpha:) instead", renamed: "shortHexString(withAlpha:)")
 	/// SwifterSwift: Short hexadecimal value string (read-only, if applicable).
 	public var shortHexString: String? {
 		return shortHexString(withAlpha: false)

--- a/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
@@ -35,6 +35,12 @@ extension UIColor {
 		getRed(nil, green: nil, blue: &blue, alpha: nil)
 		return Int(blue * CGFloat(255.0))
 	}
-	
+
+	@available(*, deprecated: 3.2.0, message: "Use 'hexString(withAlpha:)' instead", renamed: "hexString(withAlpha:)")
+	/// SwifterSwift: Hexadecimal value string (read-only).
+	public var hexString: String {
+		return hexString(withAlpha: false)
+	}
+
 }
 #endif

--- a/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
@@ -36,11 +36,16 @@ extension UIColor {
 		return Int(blue * CGFloat(255.0))
 	}
 
-	@available(*, deprecated: 3.2.0, message: "Use 'hexString(withAlpha:)' instead", renamed: "hexString(withAlpha:)")
+	@available(*, deprecated: 3.1.0, message: "Use 'hexString(withAlpha:)' instead", renamed: "hexString(withAlpha:)")
 	/// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
 		return hexString(withAlpha: false)
 	}
 
+	@available(*, deprecated: 3.1.0, message: "Use shortHexString(withAlpha:) instead", renamed: "shortHexString(withAlpha:)")
+	/// SwifterSwift: Short hexadecimal value string (read-only, if applicable).
+	public var shortHexString: String? {
+		return shortHexString(withAlpha: false)
+	}
 }
 #endif

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -70,19 +70,9 @@ public extension UIColor {
 		return UInt(colorAsUInt32)
 	}
 	
-	/// SwifterSwift: Short hexadecimal value string (read-only, if applicable).
-	public var shortHexString: String? {
-		let string = hexString.replacingOccurrences(of: "#", with: "")
-		let chrs = Array(string.characters)
-		guard chrs[0] == chrs[1], chrs[2] == chrs[3], chrs[4] == chrs[5] else {
-			return nil
-		}
-		return  "#" + "\(chrs[0])\(chrs[2])\(chrs[4])"
-	}
-	
 	/// SwifterSwift: Short hexadecimal value string, or full hexadecimal string if not possible (read-only).
 	public var shortHexOrHexString: String {
-		return shortHexString ?? hexString
+		return shortHexString() ?? hexString()
 	}
 	
 	/// SwifterSwift: Get color complementary (read-only, if applicable).
@@ -145,6 +135,14 @@ public extension UIColor {
 		return String(format: (withAlpha ? "#%08x" : "#%06x"), rgb).uppercased()
 	}
 
+	public func shortHexString(withAlpha: Bool = false) -> String? {
+		let string = hexString(withAlpha: true).replacingOccurrences(of: "#", with: "")
+		let chrs = Array(string.characters)
+		guard chrs[0] == chrs[1], chrs[2] == chrs[3], chrs[4] == chrs[5], chrs[6] == chrs[7] else {
+			return nil
+		}
+		return "#" + (withAlpha ? "\(chrs[0])" : "") + "\(chrs[2])\(chrs[4])\(chrs[6])"
+	}
 }
 
 

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -133,6 +133,10 @@ public extension UIColor {
 		return UIColor(red: l1*r1 + l2*r2, green: l1*g1 + l2*g2, blue: l1*b1 + l2*b2, alpha: l1*a1 + l2*a2)
 	}
 
+	/// SwifterSwift: return hexString of color
+	///
+	/// - Parameter: withAlpha: Boolean value to include alpha or not in output
+	/// - Returns: A hex-string representation of the color
 	public func hexString(withAlpha: Bool = false) -> String {
 		var red:	CGFloat = 0
 		var green:	CGFloat = 0

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -70,18 +70,12 @@ public extension UIColor {
 		return UInt(colorAsUInt32)
 	}
 	
-	/// SwifterSwift: Hexadecimal value string (read-only).
+	/// SwifterSwift: -Deprecated- Hexadecimal value string (read-only).
+	@available(*, deprecated, message: "Variable format no longer supported, use 'hexString(withAlpha:)' instead")
 	public var hexString: String {
-		var red:	CGFloat = 0
-		var green:	CGFloat = 0
-		var blue:	CGFloat = 0
-		var alpha:	CGFloat = 0
-		
-		getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-		let rgb: Int = (Int)(red*255)<<16 | (Int)(green*255)<<8 | (Int)(blue*255)<<0
-		return NSString(format:"#%06x", rgb).uppercased as String
+		return hexString(withAlpha: false)
 	}
-	
+
 	/// SwifterSwift: Short hexadecimal value string (read-only, if applicable).
 	public var shortHexString: String? {
 		let string = hexString.replacingOccurrences(of: "#", with: "")
@@ -138,7 +132,21 @@ public extension UIColor {
 		color2.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
 		return UIColor(red: l1*r1 + l2*r2, green: l1*g1 + l2*g2, blue: l1*b1 + l2*b2, alpha: l1*a1 + l2*a2)
 	}
-	
+
+	public func hexString(withAlpha: Bool = false) -> String {
+		var red:	CGFloat = 0
+		var green:	CGFloat = 0
+		var blue:	CGFloat = 0
+		var alpha:	CGFloat = 0
+
+		getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+		let rgb: Int = (withAlpha ? ((Int)(alpha*255) << 24) : 0)
+			| ((Int)(red*255)   << 16)
+			| ((Int)(green*255) << 8)
+			| ((Int)(blue*255)  << 0)
+		return String(format: (withAlpha ? "#%08x" : "#%06x"), rgb).uppercased()
+	}
+
 }
 
 

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -70,12 +70,6 @@ public extension UIColor {
 		return UInt(colorAsUInt32)
 	}
 	
-	/// SwifterSwift: -Deprecated- Hexadecimal value string (read-only).
-	@available(*, deprecated, message: "Variable format no longer supported, use 'hexString(withAlpha:)' instead")
-	public var hexString: String {
-		return hexString(withAlpha: false)
-	}
-
 	/// SwifterSwift: Short hexadecimal value string (read-only, if applicable).
 	public var shortHexString: String? {
 		let string = hexString.replacingOccurrences(of: "#", with: "")

--- a/Sources/Extensions/UIKit/UIColorExtensions.swift
+++ b/Sources/Extensions/UIKit/UIColorExtensions.swift
@@ -133,10 +133,10 @@ public extension UIColor {
 		return UIColor(red: l1*r1 + l2*r2, green: l1*g1 + l2*g2, blue: l1*b1 + l2*b2, alpha: l1*a1 + l2*a2)
 	}
 
-	/// SwifterSwift: return hexString of color
+	/// SwifterSwift: return hexString of color (ARGB)
 	///
 	/// - Parameter: withAlpha: Boolean value to include alpha or not in output
-	/// - Returns: A hex-string representation of the color
+	/// - Returns: A hex-string representation of the color (ARGB)
 	public func hexString(withAlpha: Bool = false) -> String {
 		var red:	CGFloat = 0
 		var green:	CGFloat = 0

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -175,16 +175,22 @@ class UIColorExtensionsTests: XCTestCase {
 	
 	func testShortHexString() {
 		var color: UIColor? = UIColor.red
-		XCTAssertEqual(color?.shortHexString, "#F00")
+		XCTAssertEqual(color?.shortHexString(), "#F00")
 		
 		color = UIColor.blue
-		XCTAssertEqual(color?.shortHexString, "#00F")
+		XCTAssertEqual(color?.shortHexString(), "#00F")
 		
 		color = UIColor(hexString: "#0F120F")
-		XCTAssertNil(color?.shortHexString)
+		XCTAssertNil(color?.shortHexString())
 		
 		color = UIColor(hexString: "#8FFFF")
-		XCTAssertNil(color?.shortHexString)
+		XCTAssertNil(color?.shortHexString())
+
+		color = UIColor.red
+		XCTAssertEqual(color?.shortHexString(withAlpha: true), "#FF00")
+
+		color = UIColor.blue
+		XCTAssertEqual(color?.shortHexString(withAlpha: true), "#F00F")
 	}
 	
 	func testShortHexOrHexString() {

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -152,19 +152,25 @@ class UIColorExtensionsTests: XCTestCase {
     
     func testHexString() {
 		var color = UIColor.red
-		XCTAssertEqual(color.hexString, "#FF0000")
-		
+		XCTAssertEqual(color.hexString(), "#FF0000")
+
 		color = UIColor.blue
-		XCTAssertEqual(color.hexString, "#0000FF")
+		XCTAssertEqual(color.hexString(), "#0000FF")
 		
 		color = UIColor(hex: 0xABCDEF)!
-		XCTAssertEqual(color.hexString, "#ABCDEF")
+		XCTAssertEqual(color.hexString(), "#ABCDEF")
 		
 		color = UIColor(hex: 0xABC)!
-		XCTAssertEqual(color.hexString, "#000ABC")
+		XCTAssertEqual(color.hexString(), "#000ABC")
 		
 		color = UIColor.black
-		XCTAssertEqual(color.hexString, "#000000")
+		XCTAssertEqual(color.hexString(), "#000000")
+
+		color = UIColor.clear
+		XCTAssertEqual(color.hexString(withAlpha: true), "#00000000")
+
+		color = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 0.5)
+		XCTAssertEqual(color.hexString(withAlpha: true), "#7F7F7F7F")
 	}
 	
 	func testShortHexString() {


### PR DESCRIPTION
## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 3.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.

also without `continue` @omaralbeik ;)

also little question here:
shouldn't `UIColor(hex: 0xABC)` generate `0xAABBCC` rather than `0x000ABC` ?