### PR TITLE
IBOutlet connectable ‘nextField’

### DIFF
--- a/Sources/Extensions/UIKit/UITextFieldExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextFieldExtensions.swift
@@ -127,7 +127,10 @@ public extension UITextField {
 	}
     
     /// SwifterSwift: Next text field to become first responder
-    /// textField.nextField?.becomeFirstResponder()
+    ///
+    ///     textField.nextField = someOtherTextField
+    ///     textField.nextField?.becomeFirstResponder() -> 'someOtherTextField` is now first responder
+    ///
     /// https://stackoverflow.com/a/27030181
     @IBOutlet public var nextField: UITextField? {
         

--- a/Sources/Extensions/UIKit/UITextFieldExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextFieldExtensions.swift
@@ -8,6 +8,8 @@
 
 #if os(iOS) || os(tvOS)
 import UIKit
+    
+fileprivate var kAssociationKeyNextField: UInt8 = 0
 
 // MARK: - Enums
 public extension UITextField {
@@ -123,6 +125,21 @@ public extension UITextField {
 			iconView.tintColor = newValue
 		}
 	}
+    
+    /// SwifterSwift: Next text field to become first responder
+    /// textField.nextField?.becomeFirstResponder()
+    /// https://stackoverflow.com/a/27030181
+    @IBOutlet public var nextField: UITextField? {
+        
+        get {
+            
+            return objc_getAssociatedObject(self, &kAssociationKeyNextField) as? UITextField
+        }
+        set(newField) {
+            
+            objc_setAssociatedObject(self, &kAssociationKeyNextField, newField, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
 
 }
 

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -525,6 +525,42 @@ public extension UIView {
 		anchorCenterXToSuperview()
 		anchorCenterYToSuperview()
 	}
+    
+    /// SwifterSwift: Blur the background of the view
+    ///
+    /// - Parameter effectStyle: The UIBlurEffectStyle to apply to the background
+    @available(iOS 9, *) public func blurBackground(using effectStyle: UIBlurEffectStyle) {
+        
+        backgroundColor = .clear
+        removeBlurs()
+        
+        let blurEffect = UIBlurEffect(style: effectStyle)
+        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
+        blurredEffectView.frame = bounds
+        
+        addSubview(blurredEffectView)
+        sendSubview(toBack: blurredEffectView)
+        blurredEffectView.fillToSuperview()
+        
+        let vibrancyEffect = UIVibrancyEffect(blurEffect: blurEffect)
+        let vibrancyEffectView = UIVisualEffectView(effect: vibrancyEffect)
+        vibrancyEffectView.frame = bounds
+        
+        blurredEffectView.contentView.addSubview(vibrancyEffectView)
+        vibrancyEffectView.fillToSuperview()
+    }
+    
+    // SwifterSwift: Remove previous blurs from the view
+    @available(iOS 9, *) public func removeBlurs() {
+        
+        for view in subviews {
+            
+            if view is UIVisualEffectView {
+                
+                view.removeFromSuperview()
+            }
+        }
+    }
 	
 }
 #endif

--- a/Tests/UIKitTests/UITextFieldExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextFieldExtensionsTests.swift
@@ -107,6 +107,17 @@ class UITextFieldExtensionsTests: XCTestCase {
 		textField.rightViewTintColor = .yellow
 		XCTAssertNil(textField.rightViewTintColor)
 	}
+    
+    func testNextField() {
+        
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 30)
+        let textField = UITextField(frame: frame)
+        let nextField = UITextField(frame: frame)
+        
+        textField.nextField = nextField
+        XCTAssertNotNil(textField.nextField)
+        XCTAssertEqual(textField.nextField, nextField)
+    }
 	
 	
 	func testClear() {

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -254,6 +254,32 @@ class UIViewExtensionsTests: XCTestCase {
 		XCTAssertNotNil(subview.centerYAnchor)
 	}
 	
+    func testBlur() {
+        
+        let blurExpectation = expectation(description: "Should be blurred")
+        
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        view.blurBackground(using: .extraLight)
+        
+        for view in view.subviews {
+            
+            if view is UIVisualEffectView {
+                
+                blurExpectation.fulfill()
+            }
+        }
+        
+        view.removeBlurs()
+        for view in view.subviews {
+            
+            if view is UIVisualEffectView {
+                
+                XCTFail("Failed to remove blur from view")
+            }
+        }
+        
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
 	
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**IBOutlet Connectable 'nextField'**
This is useful for forms. By assigning the 'nextField' for each textField in a form, the UITextFieldDelegate can do the following to move to the next active field when the user taps the return key on the keyboard.

`textField.nextField?.becomeFirstResponder()`

**Blur background view of UIView**
Blur the background of any UIView using a UIVisualBlurEffectStyle.
Example:
```
let view = UIView(frame: frame)
view.blurBackground(using: .dark) // Blurs the view's background with a Apple's UIVisualBlurEffectStyle.dark
```

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x ] New extensions are written in Swift 3.
- [x ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ x] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x ] All extensions are declared as **public**.