### PR TITLE
Add isBetween method to date extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,11 @@ All notable changes to this project will be documented in this file.
 > N/A
 >
 > ### Enhancements
-> N/A
+> - New **Date** extensions
+>    - added `isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = false) -> Bool` method to check if a date is between two other dates.
 >
 > ### Bugfixes
 > N/A
-
-# v3.2.1
-
-### API Breaking
-N/A
-
-### Enhancements
-- New **Date** extensions
-  - added `isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = false) -> Bool` method to check if a date is between two other dates.
-
-### Bugfixes
-N/A
 
 # v3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to this project will be documented in this file.
 > ### Bugfixes
 > N/A
 
+# v3.2.1
+
+### API Breaking
+N/A
+
+### Enhancements
+- New **Date** extensions
+  - added `isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = false) -> Bool` method to check if a date is between two other dates.
+
+### Bugfixes
+N/A
+
 # v3.2.0
 
 ### API Breaking

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -709,7 +709,21 @@ public extension Date {
 	public func daysSince(_ date: Date) -> Double {
 		return self.timeIntervalSince(date)/(3600*24)
 	}
-	
+    
+    /// SwifterSwift: check if a date is between two other dates
+    ///
+    /// - Parameter startDate: start date to compare self to.
+    /// - Parameter endDate: endDate date to compare self to.
+    /// - Parameter includeBounds: true if the start and end date should be included (default is true)
+    /// - Returns: true if the date is between the two given dates.
+    public func isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = true) -> Bool {
+        if includeBounds {
+            return startDate.compare(self).rawValue * self.compare(endDate).rawValue >= 0
+        } else {
+            return startDate.compare(self).rawValue * self.compare(endDate).rawValue > 0
+        }
+    }
+    
 }
 
 

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -714,9 +714,9 @@ public extension Date {
     ///
     /// - Parameter startDate: start date to compare self to.
     /// - Parameter endDate: endDate date to compare self to.
-    /// - Parameter includeBounds: true if the start and end date should be included (default is true)
+    /// - Parameter includeBounds: true if the start and end date should be included (default is false)
     /// - Returns: true if the date is between the two given dates.
-    public func isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = true) -> Bool {
+    public func isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = false) -> Bool {
         if includeBounds {
             return startDate.compare(self).rawValue * self.compare(endDate).rawValue >= 0
         } else {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -688,24 +688,24 @@ class DateExtensionsTests: XCTestCase {
         let startDate = Date(timeIntervalSince1970: 511)
         let endDate = Date(timeIntervalSince1970: 513)
         XCTAssertTrue(date.isBetween(startDate, endDate))
-        
+    
         date = Date(timeIntervalSince1970: 511)
-        XCTAssertTrue(date.isBetween(startDate, endDate))
+        XCTAssertTrue(date.isBetween(startDate, endDate, includeBounds: true))
         
         date = Date(timeIntervalSince1970: 513)
-        XCTAssertTrue(date.isBetween(startDate, endDate))
+        XCTAssertTrue(date.isBetween(startDate, endDate, includeBounds: true))
+        
+        date = Date(timeIntervalSince1970: 511)
+        XCTAssertFalse(date.isBetween(startDate, endDate))
+        
+        date = Date(timeIntervalSince1970: 513)
+        XCTAssertFalse(date.isBetween(startDate, endDate))
         
         date = Date(timeIntervalSince1970: 230)
         XCTAssertFalse(date.isBetween(startDate, endDate))
         
         date = Date(timeIntervalSince1970: 550)
         XCTAssertFalse(date.isBetween(startDate, endDate))
-        
-        date = Date(timeIntervalSince1970: 511)
-        XCTAssertFalse(date.isBetween(startDate, endDate, includeBounds: false))
-        
-        date = Date(timeIntervalSince1970: 513)
-        XCTAssertFalse(date.isBetween(startDate, endDate, includeBounds: false))
     }
     
 }

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -683,4 +683,29 @@ class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date, dateFromUnixTimestamp)
 	}
 	
+    func testIfDateIsBetween() {
+        var date = Date(timeIntervalSince1970: 512) // 1970-01-01T00:08:32.000Z
+        let startDate = Date(timeIntervalSince1970: 511)
+        let endDate = Date(timeIntervalSince1970: 513)
+        XCTAssertTrue(date.isBetween(startDate, endDate))
+        
+        date = Date(timeIntervalSince1970: 511)
+        XCTAssertTrue(date.isBetween(startDate, endDate))
+        
+        date = Date(timeIntervalSince1970: 513)
+        XCTAssertTrue(date.isBetween(startDate, endDate))
+        
+        date = Date(timeIntervalSince1970: 230)
+        XCTAssertFalse(date.isBetween(startDate, endDate))
+        
+        date = Date(timeIntervalSince1970: 550)
+        XCTAssertFalse(date.isBetween(startDate, endDate))
+        
+        date = Date(timeIntervalSince1970: 511)
+        XCTAssertFalse(date.isBetween(startDate, endDate, includeBounds: false))
+        
+        date = Date(timeIntervalSince1970: 513)
+        XCTAssertFalse(date.isBetween(startDate, endDate, includeBounds: false))
+    }
+    
 }


### PR DESCRIPTION
Added a `isBetween` method to the date extension which can be used to determine if a date is between two given dates including or excluding the given dates itself. Default is to include the dates itself.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 3.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
