### PR TITLE
Add isWithin method to Date extensions

### DIFF
--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -601,6 +601,18 @@ public extension Date {
 	public func isInCurrent(_ component: Calendar.Component) -> Bool {
 		return calendar.isDate(self, equalTo: Date(), toGranularity: component)
 	}
+    
+    /// SwifterSwift: Check if date is within given calendar component of another date.
+    ///
+    ///     Date().isWithin(.hour, of: Date()) -> true
+    ///     Date().isWithin(.year, of: Date()) -> true
+    ///
+    /// - Parameter component: calendar component to check.
+    /// - Parameter date: date to check.
+    /// - Returns: true if date is within given calendar component of another date.
+    public func isWithin(_ component: Calendar.Component, of date: Date) -> Bool {
+        return calendar.isDate(self, equalTo: date, toGranularity: component)
+    }
 	
 	/// SwifterSwift: Time string from date
 	///

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -595,6 +595,34 @@ class DateExtensionsTests: XCTestCase {
 		
 		XCTAssert(date.isInCurrent(.era))
 	}
+    
+    func testisWithin() {
+        let date = Date()
+        let oldDate = Date(timeIntervalSince1970: 512) // 1970-01-01T00:08:32.000Z
+        
+        XCTAssert(date.isWithin(.second, of: date))
+        XCTAssertFalse(oldDate.isWithin(.second, of: date))
+        
+        XCTAssert(date.isWithin(.minute, of: date))
+        XCTAssertFalse(oldDate.isWithin(.minute, of: date))
+        
+        XCTAssert(date.isWithin(.hour, of: date))
+        XCTAssertFalse(oldDate.isWithin(.hour, of: date))
+        
+        XCTAssert(date.isWithin(.day, of: date))
+        XCTAssertFalse(oldDate.isWithin(.day, of: date))
+        
+        XCTAssert(date.isWithin(.weekOfMonth, of: date))
+        XCTAssertFalse(oldDate.isWithin(.weekOfMonth, of: date))
+        
+        XCTAssert(date.isWithin(.month, of: date))
+        XCTAssertFalse(oldDate.isWithin(.month, of: date))
+        
+        XCTAssert(date.isWithin(.year, of: date))
+        XCTAssertFalse(oldDate.isWithin(.year, of: date))
+        
+        XCTAssert(date.isWithin(.era, of: oldDate))
+    }
 	
 	func testTimeString() {
 		let date = Date(timeIntervalSince1970: 512)


### PR DESCRIPTION
Fixes #258

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.

Don't know why we ever need ```value: Int```
But anyway, check my solution