### PR TITLE
Add localized and localized(comment:) to String

### DIFF
--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -371,6 +371,14 @@ public extension String {
 		}
 		return result
 	}
+    
+    /// SwifterSwift: Returns a localized string, with an optional comment for translators.
+    ///
+    ///        "Hello world".localized -> Hallo Welt
+    ///
+    public func localized(comment: String = "") -> String {
+        return NSLocalizedString(self, comment: comment)
+    }
 	
 	/// SwifterSwift: The most common character in string.
 	///


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.

I wasn't able to write tests for these extensions, because they require running with a different localization. As far as I know, it is currently not possible to set the 'Application Language' for a single test.