### PR TITLE
Add convenience initializer init(text:) to UILabel, including a test

### DIFF
--- a/Sources/Extensions/UIKit/UILabelExtensions.swift
+++ b/Sources/Extensions/UIKit/UILabelExtensions.swift
@@ -12,6 +12,12 @@ import UIKit
 // MARK: - Methods
 public extension UILabel {
 	
+    /// SwifterSwift: Initialize a UILabel with text
+    public convenience init(text: String?) {
+        self.init()
+        self.text = text
+    }
+    
 	/// SwifterSwift: Required height for a label
 	public var requiredHeight: CGFloat {
 		let label = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width, height: CGFloat.greatestFiniteMagnitude))

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -12,6 +12,11 @@ import XCTest
 #if os(iOS) || os(tvOS)
 	class UILabelExtensionsTests: XCTestCase {
 		
+        func testInitWithText() {
+            let label = UILabel(text: "Hello world")
+            XCTAssertEqual(label.text, "Hello world")
+        }
+        
 		func testrequiredHeight() {
 			let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
 			let label = UILabel(frame: frame)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
