### PR TITLE
Updated all class that subclass XCTestCase as final class

### DIFF
--- a/Tests/AppKitTests/NSViewExtensionsTests.swift
+++ b/Tests/AppKitTests/NSViewExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class NSViewExtensionsTests: XCTestCase {
+final class NSViewExtensionsTests: XCTestCase {
 	
 	func testBorderColor() {
 		let frame = CGRect(x: 0, y: 0, width: 100, height: 100)

--- a/Tests/CoreGraphicsTests/CGFloatExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGFloatExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class CGFloatExtensionsTests: XCTestCase {
+final class CGFloatExtensionsTests: XCTestCase {
 	
 	#if !os(macOS)
 	func testAbs() {

--- a/Tests/CoreGraphicsTests/CGPointExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGPointExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class CGPointExtensionsTests: XCTestCase {
+final class CGPointExtensionsTests: XCTestCase {
 	
 	let point1 = CGPoint(x: 10, y: 10)
 	let point2 = CGPoint(x: 30, y: 30)

--- a/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class CGSizeExtensionsTests: XCTestCase {
+final class CGSizeExtensionsTests: XCTestCase {
 	
 	func testAspectFit() {
 		let rect = CGSize(width: 120, height: 80)

--- a/Tests/CoreLocationTests/CLLocationExtensionsTests.swift
+++ b/Tests/CoreLocationTests/CLLocationExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 import CoreLocation
 
-class CLLocationExtensionsTests: XCTestCase {
+final class CLLocationExtensionsTests: XCTestCase {
 	
 	func testMidLocation() {
 		let a = CLLocation(latitude: -15.822877, longitude: -47.941839)

--- a/Tests/FoundationTests/DataExtensionsTests.swift
+++ b/Tests/FoundationTests/DataExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class DataExtensionsTests: XCTestCase {
+final class DataExtensionsTests: XCTestCase {
 	
 	func testString() {
 		let dataFromString = "hello".data(using: .utf8)

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class DateExtensionsTests: XCTestCase {
+final class DateExtensionsTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()

--- a/Tests/FoundationTests/LocaleExtensionsTests.swift
+++ b/Tests/FoundationTests/LocaleExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class LocaleExtensionsTests: XCTestCase {
+final class LocaleExtensionsTests: XCTestCase {
     
     func testPosix() {
         let test: Locale = .posix

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class NSAttributedStringExtensionsTests: XCTestCase {
+final class NSAttributedStringExtensionsTests: XCTestCase {
 	
 	#if !os(macOS) && !os(tvOS)
 	func testBolded() {

--- a/Tests/FoundationTests/NSPredicateExtensionsTests.swift
+++ b/Tests/FoundationTests/NSPredicateExtensionsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class NSPredicateExtensionsTests: XCTestCase {
+final class NSPredicateExtensionsTests: XCTestCase {
     
     func testNot() {
         let predicate = NSPredicate(format: "a < 7")

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class URLExtensionsTests: XCTestCase {
+final class URLExtensionsTests: XCTestCase {
 	
 	var url = URL(string: "https://www.google.com")!
 	let params = ["q": "swifter swift"]

--- a/Tests/FoundationTests/URLRequestExtensionsTests.swift
+++ b/Tests/FoundationTests/URLRequestExtensionsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class URLRequestExtensionsTests: XCTestCase {
+final class URLRequestExtensionsTests: XCTestCase {
 	
 	func testInitFromURLString() {
 		let urlString = "https://www.w3schools.com/"

--- a/Tests/FoundationTests/UserDefaultsExtensionsTests.swift
+++ b/Tests/FoundationTests/UserDefaultsExtensionsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UserDefaultsExtensionsTests: XCTestCase {
+final class UserDefaultsExtensionsTests: XCTestCase {
 	
 	func testSubscript() {
 		let key = "testKey"

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -20,7 +20,7 @@ import XCTest
 	import CoreImage
 #endif
 
-class ColorExtensionsTests: XCTestCase {
+final class ColorExtensionsTests: XCTestCase {
 	
 	// MARK: - Test properties
 	func testRgbComponents() {

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class ArrayExtensionsTests: XCTestCase {
+final class ArrayExtensionsTests: XCTestCase {
 
 	func testRandomItem() {
 		XCTAssert([1, 2, 3].contains([1, 2, 3].randomItem))

--- a/Tests/SwiftStdlibTests/BoolExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BoolExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class BoolExtensionsTests: XCTestCase {
+final class BoolExtensionsTests: XCTestCase {
 	
 	func testInt() {
 		XCTAssertEqual(true.int, 1)

--- a/Tests/SwiftStdlibTests/CharacterExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CharacterExtensionsTests.swift
@@ -17,7 +17,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class CharacterExtensionsTests: XCTestCase {
+final class CharacterExtensionsTests: XCTestCase {
 	
 	func testOperators() {
 		let s = Character("s")

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class CollectionExtensionsTests: XCTestCase {
+final class CollectionExtensionsTests: XCTestCase {
 	
 	func testForEachInParallel() {
 		let collection = [1, 2, 3, 4, 5]

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class DictionaryExtensionsTests: XCTestCase {
+final class DictionaryExtensionsTests: XCTestCase {
 	
 	var testDict: [String : Any] = ["testKey": "testValue", "testArrayKey": [1, 2, 3, 4, 5]]
     

--- a/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class DoubleExtensionsTests: XCTestCase {
+final class DoubleExtensionsTests: XCTestCase {
 	
 	func testAbs() {
 		XCTAssertEqual(Double(-9.3).abs, Double(9.3))

--- a/Tests/SwiftStdlibTests/FloatExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/FloatExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class FloatExtensionsTests: XCTestCase {
+final class FloatExtensionsTests: XCTestCase {
 	
 	func testAbs() {
 		XCTAssertEqual(Float(-9.3).abs, Float(9.3))

--- a/Tests/SwiftStdlibTests/IntExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/IntExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class IntExtensionsTests: XCTestCase {
+final class IntExtensionsTests: XCTestCase {
 	
 	func testAbs() {
 		XCTAssertEqual((-9).abs, 9)

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class OptionalExtensionsTests: XCTestCase {
+final class OptionalExtensionsTests: XCTestCase {
 	
 	func testUnwrappedOrDefault() {
 		var str: String? = nil

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class StringExtensionsTests: XCTestCase {
+final class StringExtensionsTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()

--- a/Tests/SwifterSwiftTests.swift
+++ b/Tests/SwifterSwiftTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class SwifterSwiftTests: XCTestCase {
+final class SwifterSwiftTests: XCTestCase {
 	
 	func testTypeName() {
 		let number = 8

--- a/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
@@ -10,7 +10,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UIAlertControllerExtensionsTests: XCTestCase {
+final class UIAlertControllerExtensionsTests: XCTestCase {
 	
 	func testAddAction() {
 

--- a/Tests/UIKitTests/UIBarButtonExtensionsTests.swift
+++ b/Tests/UIKitTests/UIBarButtonExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UIBarButtonExtensionsTests: XCTestCase {
+final class UIBarButtonExtensionsTests: XCTestCase {
 	
 	func testSelector() {}
 	

--- a/Tests/UIKitTests/UIButtonExtensionsTests.swift
+++ b/Tests/UIKitTests/UIButtonExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UIButtonExtensionsTests: XCTestCase {
+final class UIButtonExtensionsTests: XCTestCase {
 	
 	func testImageForDisabled() {
 		

--- a/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UICollectionViewExtensionsTests: XCTestCase {
+final class UICollectionViewExtensionsTests: XCTestCase {
 	
 	let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
 	let emptyCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())

--- a/Tests/UIKitTests/UIFontExtensionsTest.swift
+++ b/Tests/UIKitTests/UIFontExtensionsTest.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UIFontExtension: XCTestCase {
+final class UIFontExtension: XCTestCase {
 	
 	func testMonospacedDigitFont() {
 		let font = UIFont.preferredFont(forTextStyle: .body)

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UIImageExtensionsTests: XCTestCase {
+final class UIImageExtensionsTests: XCTestCase {
 	
 	func testBytesSize() {
 		let bundle = Bundle.init(for: UIImageExtensionsTests.self)

--- a/Tests/UIKitTests/UIImageViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageViewExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UIImageViewExtensionsTests: XCTestCase {
+final class UIImageViewExtensionsTests: XCTestCase {
 	
 	func testDownload() {
     // Success

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwifterSwift
 
 #if os(iOS) || os(tvOS)
-	class UILabelExtensionsTests: XCTestCase {
+	final class UILabelExtensionsTests: XCTestCase {
 		
         func testInitWithText() {
             let label = UILabel(text: "Hello world")

--- a/Tests/UIKitTests/UINavigationBarExtensionTests.swift
+++ b/Tests/UIKitTests/UINavigationBarExtensionTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
     
-class UINavigationBarExtensionsTests: XCTestCase {
+final class UINavigationBarExtensionsTests: XCTestCase {
     
     func testSetTitleFont() {
         let navigationBar = UINavigationBar()

--- a/Tests/UIKitTests/UINavigationControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UINavigationControllerExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
     
-class UINavigationControllerExtensionsTests: XCTestCase {
+final class UINavigationControllerExtensionsTests: XCTestCase {
 // This test is commented because we not sure if after the animation it already removed the viewcontroller from the array, it's something internal of UIKit that require a deeper looking.    
 //    func testPopViewController() {
 //        let navigationController = UINavigationController()

--- a/Tests/UIKitTests/UINavigationItemExtensionsTests.swift
+++ b/Tests/UIKitTests/UINavigationItemExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
     
-class UINavigationItemExtensionsTests: XCTestCase {
+final class UINavigationItemExtensionsTests: XCTestCase {
     
     func testReplaceTitle() {
         let navigationItem = UINavigationItem()

--- a/Tests/UIKitTests/UISearchBarExtensionsTests.swift
+++ b/Tests/UIKitTests/UISearchBarExtensionsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwifterSwift
 
 #if os(iOS)
-class UISearchBarExtensionsTests: XCTestCase {
+final class UISearchBarExtensionsTests: XCTestCase {
 	
 	func testSearchBar() {
 		let searchBar = UISearchBar()

--- a/Tests/UIKitTests/UISegmentedControlExtensionsTests.swift
+++ b/Tests/UIKitTests/UISegmentedControlExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UISegmentedControlExtensionsTests: XCTestCase {
+final class UISegmentedControlExtensionsTests: XCTestCase {
 
     func testSegmentTitles() {
         let segmentControl = UISegmentedControl()

--- a/Tests/UIKitTests/UISliderExtensionsTests.swift
+++ b/Tests/UIKitTests/UISliderExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UISliderExtensionsTests: XCTestCase {
+final class UISliderExtensionsTests: XCTestCase {
 
     func testCompletionCalledAnimated() {
         let slider = UISlider()

--- a/Tests/UIKitTests/UIStoryboardExtensionsTests.swift
+++ b/Tests/UIKitTests/UIStoryboardExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
     
-class UIStoryboardExtensionsTests: XCTestCase {
+final class UIStoryboardExtensionsTests: XCTestCase {
     
     func testInstantiateViewController() {
         let storyboard = UIStoryboard(name: "TestStoryboard", bundle: Bundle(for: UIStoryboardExtensionsTests.self))

--- a/Tests/UIKitTests/UISwitchExtensionsTests.swift
+++ b/Tests/UIKitTests/UISwitchExtensionsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwifterSwift
 
 #if os(iOS)
-class UISwitchExtensionsTests: XCTestCase {
+final class UISwitchExtensionsTests: XCTestCase {
 	
 	func testToggle() {
 		let frame = CGRect(x: 0, y: 0, width: 100, height: 30)

--- a/Tests/UIKitTests/UITabBarExtensionsTests.swift
+++ b/Tests/UIKitTests/UITabBarExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UITabBarExtensionsTests: XCTestCase {
+final class UITabBarExtensionsTests: XCTestCase {
 	
 	func testSetColors() {
 		let frame = CGRect(x: 0, y: 0, width: 300, height: 44)

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -10,7 +10,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class UITableViewExtensionsTests: XCTestCase {
+final class UITableViewExtensionsTests: XCTestCase {
 	
 	let tableView = UITableView()
 	let emptyTableView = UITableView()

--- a/Tests/UIKitTests/UITextFieldExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextFieldExtensionsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwifterSwift
 
 #if os(iOS) || os(tvOS)
-class UITextFieldExtensionsTests: XCTestCase {
+final class UITextFieldExtensionsTests: XCTestCase {
 	
 	func testIsEmpty() {
 		let textField = UITextField()

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwifterSwift
 
 #if os(iOS) || os(tvOS)
-class UITextViewExtensionsTests: XCTestCase {
+final class UITextViewExtensionsTests: XCTestCase {
 	
 	var textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
 	

--- a/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwifterSwift
     
-class UIViewControllerExtensionsTests: XCTestCase {
+final class UIViewControllerExtensionsTests: XCTestCase {
     
     class MockNotificationViewController: UIViewController {
         var notificationFired = false

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import SwifterSwift
 
 #if os(iOS) || os(tvOS)
-class UIViewExtensionsTests: XCTestCase {
+final class UIViewExtensionsTests: XCTestCase {
 	
 	func testBorderColor() {
 		let frame = CGRect(x: 0, y: 0, width: 100, height: 100)


### PR DESCRIPTION
This tackle #278 
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 4.
- [X] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
