### PR TITLE
Modified UIViewController Extension to support dismissing keyboard when child view is tapped

### DIFF
--- a/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -43,6 +43,19 @@ public extension UIViewController {
 	public func removeNotificationsObserver() {
 		NotificationCenter.default.removeObserver(self)
 	}
+    
+    /// SwiftierSwift: Hide keyboard when the anywhere in the view controller is tapped
+    public func hideKeyboardWhenTapped() {
+        let tap : UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        self.view.addGestureRecognizer(tap)
+    }
+    
+    
+    /// SwiftierSwift: Fileprivate func to dismiss the keyboard once the view is tapped if hideKeyboardWhenTapped has been called
+    @objc fileprivate func dismissKeyboard() {
+        self.view.endEditing(true)
+    }
 	
 }
 #endif

--- a/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -44,7 +44,7 @@ public extension UIViewController {
 		NotificationCenter.default.removeObserver(self)
 	}
     
-    /// SwiftierSwift: Hide keyboard when the anywhere in the view controller is tapped
+    /// SwifterSwift: Hide keyboard when the anywhere in the view controller is tapped
     public func hideKeyboardWhenTapped() {
         let tap : UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When the ```hideKeyboardWhenTapped``` method is called on a ViewController, it's child view (the root view) will have a ```UITapGestureRecognizer``` added to it that detects taps on the view. When tapped, the keyboard (if shown) will be dismissed. This can be helpful in messaging-based applications as tapping outside of the keyboard/```inputAccessoryView``` should close the keyboard.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.