### PR TITLE
Removing unused UIKit/Cocoa imports from some of the Stdlib and Found…

### DIFF
--- a/Sources/Extensions/Foundation/DataExtensions.swift
+++ b/Sources/Extensions/Foundation/DataExtensions.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 // MARK: - Properties
 public extension Data {

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 // MARK: - Properties
 public extension NSAttributedString {

--- a/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
@@ -7,11 +7,6 @@
 //
 
 import Foundation
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
 
 // MARK: - Properties
 public extension Double {

--- a/Sources/Extensions/SwiftStdlib/FloatExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/FloatExtensions.swift
@@ -7,11 +7,6 @@
 //
 
 import Foundation
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
 
 // MARK: - Properties
 public extension Float {

--- a/Sources/Extensions/SwiftStdlib/IntExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/IntExtensions.swift
@@ -7,11 +7,6 @@
 //
 
 import Foundation
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
 
 // MARK: - Properties
 public extension Int {

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -5,11 +5,7 @@
 //  Created by Omar Albeik on 8/5/16.
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 // MARK: - Properties
 public extension String {


### PR DESCRIPTION
Removing unused UIKit/Cocoa imports from some of the Stdlib and Foundation files
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [] New extensions are written in Swift 4.
- [] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
