### PR TITLE
Improve Array.sum() and Array.average()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,8 @@ All notable changes to this project will be documented in this file.
 > N/A
 >
 > ### Enhancements
-> - **Array**
->   - Improved performance of the `sum()` function.
-> - New **Data** extensions
->   - Added `chunks(of:)` to split a `Data` instance into preset sized chunks.
->
+> N/A
+> 
 > ### Bugfixes
 > N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ All notable changes to this project will be documented in this file.
 > N/A
 >
 > ### Enhancements
-> N/A
+> - **Array**
+>   - Improved performance of the `sum()` function.
+> - New **Data** extensions
+>   - Added `chunks(of:)` to split a `Data` instance into preset sized chunks.
 >
 > ### Bugfixes
 > N/A
-
 
 # v4.0.1
 

--- a/Sources/Extensions/Foundation/DataExtensions.swift
+++ b/Sources/Extensions/Foundation/DataExtensions.swift
@@ -39,7 +39,7 @@ public extension Data {
     /// - Returns: An array with each individual data chunk
     public func chunks(of size: Int) -> [Data] {
         if size <= 0 {
-            fatalError("Chunk size cannot be 0 or lower")
+            return [self]
         }
         let size = Swift.min(size, self.count)
         var data = self

--- a/Sources/Extensions/Foundation/DataExtensions.swift
+++ b/Sources/Extensions/Foundation/DataExtensions.swift
@@ -32,5 +32,27 @@ public extension Data {
 	public func string(encoding: String.Encoding) -> String? {
 		return String(data: self, encoding: encoding)
 	}
-	
+    
+    /// SwifterSwift: Split a Data instance into sized chunks.
+    ///
+    /// - Parameter size: Int chunk size
+    /// - Returns: An array with each individual data chunk
+    public func chunks(of size: Int) -> [Data] {
+        if size <= 0 {
+            fatalError("Chunk size cannot be 0 or lower")
+        }
+        let size = Swift.min(size, self.count)
+        var data = self
+        var chunks = [Data]()
+        while true {
+            let chunkSize = Swift.min(size, data.count)
+            let chunkData = data.subdata(in: 0..<chunkSize)
+            chunks.append(chunkData)
+            if chunkSize == data.count {
+                break
+            }
+            data = data.advanced(by: chunkSize)
+        }
+        return chunks
+    }
 }

--- a/Sources/Extensions/Foundation/DataExtensions.swift
+++ b/Sources/Extensions/Foundation/DataExtensions.swift
@@ -32,27 +32,4 @@ public extension Data {
 	public func string(encoding: String.Encoding) -> String? {
 		return String(data: self, encoding: encoding)
 	}
-    
-    /// SwifterSwift: Split a Data instance into sized chunks.
-    ///
-    /// - Parameter size: Int chunk size
-    /// - Returns: An array with each individual data chunk
-    public func chunks(of size: Int) -> [Data] {
-        if size <= 0 {
-            return [self]
-        }
-        let size = Swift.min(size, self.count)
-        var data = self
-        var chunks = [Data]()
-        while true {
-            let chunkSize = Swift.min(size, data.count)
-            let chunkData = data.subdata(in: 0..<chunkSize)
-            chunks.append(chunkData)
-            if chunkSize == data.count {
-                break
-            }
-            data = data.advanced(by: chunkSize)
-        }
-        return chunks
-    }
 }

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -17,7 +17,11 @@ public extension Array where Element: Numeric {
 	///
 	/// - Returns: sum of the array's elements.
 	public func sum() -> Element {
-        return self.reduce(0 as Element, +)
+        var total: Element = 0
+        for i in 0..<count {
+            total += self[i]
+        }
+        return total
 	}
 	
 }
@@ -32,7 +36,10 @@ public extension Array where Element: FloatingPoint {
 	/// - Returns: average of the array's elements.
 	public func average() -> Element {
         guard !isEmpty else { return 0 }
-        let total: Element = sum()
+        var total: Element = 0
+        for i in 0..<count {
+            total += self[i]
+        }
         return total / Element(count)
 	}
 

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -13,13 +13,11 @@ public extension Array where Element: Numeric {
 	
 	/// SwifterSwift: Sum of all elements in array.
 	///
-	///		[1, 2, 3, 4, 5].sum -> 15
+	///		[1, 2, 3, 4, 5].sum() -> 15
 	///
 	/// - Returns: sum of the array's elements.
 	public func sum() -> Element {
-        var total: Element = 0
-        forEach { total += $0 }
-        return total
+        return self.reduce(0 as Element, +)
 	}
 	
 }
@@ -29,13 +27,12 @@ public extension Array where Element: FloatingPoint {
 	
 	/// SwifterSwift: Average of all elements in array.
 	///
-	///		[1.2, 2.3, 4.5, 3.4, 4.5].average = 3.18
+	///		[1.2, 2.3, 4.5, 3.4, 4.5].average() = 3.18
 	///
 	/// - Returns: average of the array's elements.
 	public func average() -> Element {
         guard !isEmpty else { return 0 }
-        var total: Element = 0
-        forEach { total += $0 }
+        let total: Element = sum()
         return total / Element(count)
 	}
 

--- a/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-iOS.xcscheme
+++ b/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      language = "en"
+      region = "US"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>

--- a/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-macOS.xcscheme
+++ b/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-macOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      language = "en"
+      region = "US"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -57,7 +58,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      language = "en"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-tvOS.xcscheme
+++ b/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-tvOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      language = "en"
+      region = "US"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>

--- a/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-watchOS.xcscheme
+++ b/SwifterSwift.xcodeproj/xcshareddata/xcschemes/SwifterSwift-watchOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      language = "en"
+      region = "US"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>

--- a/Tests/FoundationTests/DataExtensionsTests.swift
+++ b/Tests/FoundationTests/DataExtensionsTests.swift
@@ -24,25 +24,4 @@ final class DataExtensionsTests: XCTestCase {
         XCTAssertNotNil(bytes)
         XCTAssertEqual(bytes?.count, 5)
     }
-
-    func testChunks() {
-        let string = "This is a test, where we just want to create some sort of data."
-        let data = string.data(using: .utf8)!
-
-        let chunkSize = 10
-        let size = data.count
-        let chunks = data.chunks(of: chunkSize)
-        let totalChunksSize = chunks.map { $0.count }.reduce(0, +)
-        
-        // The size of all the chunks combined should be equal to the initial data size
-        XCTAssertEqual(size, totalChunksSize)
-
-        // Each chunk cannot be larger in size then `chunkSize`
-        chunks.forEach { XCTAssertLessThanOrEqual($0.count, chunkSize) }
-
-        // Test to see if the combined data chunks again form the exact same string
-        var newData = Data()
-        chunks.forEach { newData.append($0) }
-        XCTAssertEqual(string, String(data: newData, encoding: .utf8))
-    }
 }

--- a/Tests/FoundationTests/DataExtensionsTests.swift
+++ b/Tests/FoundationTests/DataExtensionsTests.swift
@@ -24,4 +24,21 @@ final class DataExtensionsTests: XCTestCase {
         XCTAssertNotNil(bytes)
         XCTAssertEqual(bytes?.count, 5)
     }
+
+    func testChunks() {
+        let string = "This is a test, where we just want to create some sort of data."
+        let data = string.data(using: .utf8)!
+
+        let chunkSize = 10
+        let size = data.count
+        let chunks = data.chunks(of: chunkSize)
+        let totalChunksSize = chunks.map { $0.count }.reduce(0, +)
+        XCTAssertEqual(size, totalChunksSize)
+        chunks.forEach { XCTAssertLessThanOrEqual($0.count, chunkSize) }
+
+        // Test of the combined chunks again form the same string
+        var newData = Data()
+        chunks.forEach { newData.append($0) }
+        XCTAssertEqual(string, String(data: newData, encoding: .utf8))
+    }
 }

--- a/Tests/FoundationTests/DataExtensionsTests.swift
+++ b/Tests/FoundationTests/DataExtensionsTests.swift
@@ -33,10 +33,14 @@ final class DataExtensionsTests: XCTestCase {
         let size = data.count
         let chunks = data.chunks(of: chunkSize)
         let totalChunksSize = chunks.map { $0.count }.reduce(0, +)
+        
+        // The size of all the chunks combined should be equal to the initial data size
         XCTAssertEqual(size, totalChunksSize)
+
+        // Each chunk cannot be larger in size then `chunkSize`
         chunks.forEach { XCTAssertLessThanOrEqual($0.count, chunkSize) }
 
-        // Test of the combined chunks again form the same string
+        // Test to see if the combined data chunks again form the exact same string
         var newData = Data()
         chunks.forEach { newData.append($0) }
         XCTAssertEqual(string, String(data: newData, encoding: .utf8))

--- a/Tests/SwiftStdlibTests/SignedNumericExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SignedNumericExtensionsTests.swift
@@ -17,7 +17,6 @@ class SignedNumericExtensionsTests: XCTestCase {
 	
 	func testAsLocaleCurrency() {
 		let number: Double = 3.2
-		print(number.asLocaleCurrency)
 		XCTAssertEqual(number.asLocaleCurrency, "$3.20")
 	}
 	


### PR DESCRIPTION
300% speed improvement.

```swift
import Foundation

extension Array where Element: Numeric {
    func sum() -> Element {
        var total: Element = 0
        forEach { total += $0 }
        return total
    }

    func sumReduce() -> Element {
        return self.reduce(0 as Element, +)
    }
}

let ar = Array(0..<100_000)

var startTime = CFAbsoluteTimeGetCurrent()
print("sum()")
print("  = \(ar.sum())")
print("  in \(CFAbsoluteTimeGetCurrent() - startTime)s")
print("")

startTime = CFAbsoluteTimeGetCurrent()
print("sumReduce()")
print("  = \(ar.sumReduce())")
print("  in \(CFAbsoluteTimeGetCurrent() - startTime)s")
```

Which would  result in:

```
sum()
  = 4999950000
  in 6.78056800365448s

sumReduce()
  = 4999950000
  in 0.0268669724464417s
```