### PR TITLE
Add test for Date.isBetween

### DIFF
--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -655,6 +655,17 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date2.daysSince(date1), 1)
 		XCTAssertEqual(date1.daysSince(date2), -1)
 	}
+  
+  func testIsBetween() {
+    let date1 = Date(timeIntervalSince1970: 0)
+    let date2 = date1.addingTimeInterval(60)
+    let date3 = date2.addingTimeInterval(60)
+    
+    XCTAssert(date2.isBetween(date1, date3))
+    XCTAssertFalse(date1.isBetween(date2, date3))
+    XCTAssert(date1.isBetween(date1, date2, includeBounds: true))
+    XCTAssertFalse(date1.isBetween(date1, date2))
+  }
 	
 	func testNewDateFromComponenets() {
 		let date = Date(calendar: Date().calendar, timeZone: Date().timeZone, era: Date().era, year: Date().year, month: Date().month, day: Date().day, hour: Date().hour, minute: Date().minute, second: Date().second, nanosecond: Date().nanosecond)


### PR DESCRIPTION
Added a missing test for Date.isBetween extension method

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
