### PR TITLE
add semicolons to lastIndex(of:) and firstIndex(of:) doc

### DIFF
--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -523,9 +523,9 @@ public extension Array where Element: Equatable {
 	
 	/// SwifterSwift: First index of a given item in an array.
 	///
-	///		[1, 2, 2, 3, 4, 2, 5].firstIndex(of 2) -> 1
-	///		[1.2, 2.3, 4.5, 3.4, 4.5].firstIndex(of 6.5) -> nil
-	///		["h", "e", "l", "l", "o"].firstIndex(of "l") -> 2
+	///		[1, 2, 2, 3, 4, 2, 5].firstIndex(of: 2) -> 1
+	///		[1.2, 2.3, 4.5, 3.4, 4.5].firstIndex(of: 6.5) -> nil
+	///		["h", "e", "l", "l", "o"].firstIndex(of: "l") -> 2
 	///
 	/// - Parameter item: item to check.
 	/// - Returns: first index of item in array (if exists).
@@ -538,9 +538,9 @@ public extension Array where Element: Equatable {
 	
 	/// SwifterSwift: Last index of element in array.
 	///
-	///		[1, 2, 2, 3, 4, 2, 5].lastIndex(of 2) -> 5
-	///		[1.2, 2.3, 4.5, 3.4, 4.5].lastIndex(of 6.5) -> nil
-	///		["h", "e", "l", "l", "o"].lastIndex(of "l") -> 3
+	///		[1, 2, 2, 3, 4, 2, 5].lastIndex(of: 2) -> 5
+	///		[1.2, 2.3, 4.5, 3.4, 4.5].lastIndex(of: 6.5) -> nil
+	///		["h", "e", "l", "l", "o"].lastIndex(of: "l") -> 3
 	///
 	/// - Parameter item: item to check.
 	/// - Returns: last index of item in array (if exists).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
