### PR TITLE
Add scaled(toMaxSize:NSSize) to NSImage, including a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ All notable changes to this project will be documented in this file.
 > ### Enhancements
 > - New **NSImage** extensions
 >   -	Add `scaled(toMaxSize:)` to scale image to maximum size with respect to aspect ratio [#291](https://github.com/SwifterSwift/SwifterSwift/pull/291) by [buddax2](https://github.com/buddax2).
-> 
+> - **Optional**
+>   - Add optional assignment operator `??=` [#296](https://github.com/SwifterSwift/SwifterSwift/pull/296) by [buddax2](https://github.com/buddax2).
+>
 > ### Bugfixes
 > N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 > N/A
 >
 > ### Enhancements
-> N/A
+> - New **NSImage** extensions
+>   -	Add `scaled(toMaxSize:)` to scale image to maximum size with respect to aspect ratio [#291](https://github.com/SwifterSwift/SwifterSwift/pull/291) by [buddax2](https://github.com/buddax2).
 > 
 > ### Bugfixes
 > N/A

--- a/Sources/Extensions/AppKit/NSImageExtensions.swift
+++ b/Sources/Extensions/AppKit/NSImageExtensions.swift
@@ -15,21 +15,20 @@ extension NSImage {
     ///
     /// - Parameter toMaxSize: maximum size
     /// - Returns: scaled NSImage
-    public func scaled(toMaxSize:NSSize) -> NSImage {
-        var ratio:Float = 0.0
+    public func scaled(toMaxSize: NSSize) -> NSImage {
+        var ratio: Float = 0.0
         let imageWidth = Float(self.size.width)
         let imageHeight = Float(self.size.height)
         let maxWidth = Float(toMaxSize.width)
         let maxHeight = Float(toMaxSize.height)
         
         // Get ratio (landscape or portrait)
-        if (imageWidth > imageHeight) {
+        if imageWidth > imageHeight {
             // Landscape
-            ratio = maxWidth / imageWidth;
-        }
-        else {
+            ratio = maxWidth / imageWidth
+        } else {
             // Portrait
-            ratio = maxHeight / imageHeight;
+            ratio = maxHeight / imageHeight
         }
         
         // Calculate new size based on the ratio
@@ -37,10 +36,10 @@ extension NSImage {
         let newHeight = imageHeight * ratio
         
         // Create a new NSSize object with the newly calculated size
-        let newSize:NSSize = NSSize(width: Int(newWidth), height: Int(newHeight))
+        let newSize: NSSize = NSSize(width: Int(newWidth), height: Int(newHeight))
         
         // Cast the NSImage to a CGImage
-        var imageRect:CGRect = CGRect(x:0, y:0, width:self.size.width, height:self.size.height)
+        var imageRect: CGRect = CGRect(x: 0, y: 0, width: self.size.width, height: self.size.height)
         let imageRef = self.cgImage(forProposedRect: &imageRect, context: nil, hints: nil)
         
         // Create NSImage from the CGImage using the new size

--- a/Sources/Extensions/AppKit/NSImageExtensions.swift
+++ b/Sources/Extensions/AppKit/NSImageExtensions.swift
@@ -1,0 +1,54 @@
+//
+//  NSImageExtensions.swift
+//  SwifterSwift-macOS
+//
+//  Created by BUDDAx2 on 20.10.2017.
+//
+
+#if os(macOS)
+import AppKit
+
+// MARK: - Methods
+extension NSImage {
+    
+    /// SwifterSwift: NSImage scaled to maximum size with respect to aspect ratio
+    ///
+    /// - Parameter toMaxSize: maximum size
+    /// - Returns: scaled NSImage
+    public func scaled(toMaxSize:NSSize) -> NSImage {
+        var ratio:Float = 0.0
+        let imageWidth = Float(self.size.width)
+        let imageHeight = Float(self.size.height)
+        let maxWidth = Float(toMaxSize.width)
+        let maxHeight = Float(toMaxSize.height)
+        
+        // Get ratio (landscape or portrait)
+        if (imageWidth > imageHeight) {
+            // Landscape
+            ratio = maxWidth / imageWidth;
+        }
+        else {
+            // Portrait
+            ratio = maxHeight / imageHeight;
+        }
+        
+        // Calculate new size based on the ratio
+        let newWidth = imageWidth * ratio
+        let newHeight = imageHeight * ratio
+        
+        // Create a new NSSize object with the newly calculated size
+        let newSize:NSSize = NSSize(width: Int(newWidth), height: Int(newHeight))
+        
+        // Cast the NSImage to a CGImage
+        var imageRect:CGRect = CGRect(x:0, y:0, width:self.size.width, height:self.size.height)
+        let imageRef = self.cgImage(forProposedRect: &imageRect, context: nil, hints: nil)
+        
+        // Create NSImage from the CGImage using the new size
+        let imageWithNewSize = NSImage(cgImage: imageRef!, size: newSize)
+        
+        // Return the new image
+        return imageWithNewSize
+    }
+}
+
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -315,6 +315,8 @@
 		182698AC1F8AB46E0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AD1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
+		278CA08D1F9A9232004918BD /* NSImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA08C1F9A9232004918BD /* NSImageExtensions.swift */; };
+		278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */; };
 		9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914851F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
@@ -461,6 +463,8 @@
 		07C50D2A1F5EB03200F46E5A /* NSViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtensionsTests.swift; sourceTree = "<group>"; };
 		07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedNumericExtensionsTests.swift; sourceTree = "<group>"; };
 		185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGColorExtensionsTests.swift; sourceTree = "<group>"; };
+		278CA08C1F9A9232004918BD /* NSImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensions.swift; sourceTree = "<group>"; };
+		278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensionsTests.swift; sourceTree = "<group>"; };
 		9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensions.swift; sourceTree = "<group>"; };
 		9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -619,6 +623,7 @@
 			isa = PBXGroup;
 			children = (
 				07B7F1641F5EB41600E6F910 /* NSViewExtensions.swift */,
+				278CA08C1F9A9232004918BD /* NSImageExtensions.swift */,
 			);
 			path = AppKit;
 			sourceTree = "<group>";
@@ -743,6 +748,7 @@
 			isa = PBXGroup;
 			children = (
 				07C50D2A1F5EB03200F46E5A /* NSViewExtensionsTests.swift */,
+				278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */,
 			);
 			path = AppKitTests;
 			sourceTree = "<group>";
@@ -1346,6 +1352,7 @@
 				077BA08D1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				07B7F1E31F5EB43B00E6F910 /* SignedNumericExtensions.swift in Sources */,
 				07B7F2241F5EB44600E6F910 /* CLLocationExtensions.swift in Sources */,
+				278CA08D1F9A9232004918BD /* NSImageExtensions.swift in Sources */,
 				07B7F1E21F5EB43B00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				07B7F1E51F5EB43B00E6F910 /* URLExtensions.swift in Sources */,
 				077BA0921F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
@@ -1490,6 +1497,7 @@
 				07C50D7B1F5EB05100F46E5A /* FloatExtensionsTests.swift in Sources */,
 				07C50D7F1F5EB05100F46E5A /* StringExtensionsTests.swift in Sources */,
 				07C50D7A1F5EB05100F46E5A /* DoubleExtensionsTests.swift in Sources */,
+				278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */,
 				182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */,
 				077BA0A01F6BEA4A00D9C4AC /* URLRequestExtensionsTests.swift in Sources */,
 				07C50D801F5EB05100F46E5A /* URLExtensionsTests.swift in Sources */,

--- a/Tests/AppKitTests/NSImageExtensionsTests.swift
+++ b/Tests/AppKitTests/NSImageExtensionsTests.swift
@@ -19,11 +19,7 @@ final class NSImageExtensionsTests: XCTestCase {
         
         let scaledImage = image!.scaled(toMaxSize: NSSize(width: 150, height: 150))
         XCTAssertNotNil(scaledImage)
-        if scaledImage.size.width > scaledImage.size.height {
-            XCTAssertEqual(scaledImage.size.width, 150)
-        } else {
-            XCTAssertEqual(scaledImage.size.height, 150)
-        }
+        XCTAssertEqual(scaledImage.size.width, 150)
     }
     
 }

--- a/Tests/AppKitTests/NSImageExtensionsTests.swift
+++ b/Tests/AppKitTests/NSImageExtensionsTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 final class NSImageExtensionsTests: XCTestCase {
     
-    func testScaledToHeight() {
+    func testScaledToMaxSize() {
         let bundle = Bundle.init(for: NSImageExtensionsTests.self)
         let image = bundle.image(forResource: NSImage.Name(rawValue: "TestImage"))
         XCTAssertNotNil(image)

--- a/Tests/AppKitTests/NSImageExtensionsTests.swift
+++ b/Tests/AppKitTests/NSImageExtensionsTests.swift
@@ -21,8 +21,7 @@ final class NSImageExtensionsTests: XCTestCase {
         XCTAssertNotNil(scaledImage)
         if scaledImage.size.width > scaledImage.size.height {
             XCTAssertEqual(scaledImage.size.width, 150)
-        }
-        else {
+        } else {
             XCTAssertEqual(scaledImage.size.height, 150)
         }
     }

--- a/Tests/AppKitTests/NSImageExtensionsTests.swift
+++ b/Tests/AppKitTests/NSImageExtensionsTests.swift
@@ -1,0 +1,32 @@
+//
+//  NSImageExtensionsTests.swift
+//  SwifterSwift-macOSTests
+//
+//  Created by BUDDAx2 on 20.10.2017.
+//
+
+#if os(macOS)
+    
+import XCTest
+@testable import SwifterSwift
+
+final class NSImageExtensionsTests: XCTestCase {
+    
+    func testScaledToHeight() {
+        let bundle = Bundle.init(for: NSImageExtensionsTests.self)
+        let image = bundle.image(forResource: NSImage.Name(rawValue: "TestImage"))
+        XCTAssertNotNil(image)
+        
+        let scaledImage = image!.scaled(toMaxSize: NSSize(width: 150, height: 150))
+        XCTAssertNotNil(scaledImage)
+        if scaledImage.size.width > scaledImage.size.height {
+            XCTAssertEqual(scaledImage.size.width, 150)
+        }
+        else {
+            XCTAssertEqual(scaledImage.size.height, 150)
+        }
+    }
+    
+}
+
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a function to NSImage to be able to scale an image to some maximum size. It could be useful for creating thumbnails.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.