### PR TITLE
Closes #258 Add isWithin extension to Date

### DIFF
--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -714,6 +714,21 @@ public extension Date {
           return startDate.compare(self).rawValue * self.compare(endDate).rawValue > 0
       }
   }
+	
+	/// SwifterSwift: check if a date is a number of date components of another date
+	///
+	/// - Parameters:
+	///   - value: number of times component is used in creating range
+	///   - component: Calendar.Component to use.
+	///   - date: Date to compare self to.
+	/// - Returns: true if the date is within a number of components of another date
+	
+	public func isWithin(_ value: UInt, _ component: Calendar.Component, of date: Date) -> Bool {
+		return calendar
+			.dateComponents([component], from: self, to: date)
+			.value(for: component)
+			.map { abs($0) <= value } ?? false
+	}
 }
 
 // MARK: - Initializers

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -667,6 +667,29 @@ final class DateExtensionsTests: XCTestCase {
     XCTAssertFalse(date1.isBetween(date1, date2))
   }
 	
+	func testIsWithin() {
+		let date1 = Date(timeIntervalSince1970: 60 * 60 * 24) // 1970-01-01T00:00:00.000Z
+		let date2 = date1.addingTimeInterval(60 * 60) // 1970-01-01T00:01:00.000Z, one hour later than date1
+		
+		//The regular
+		XCTAssertFalse(date1.isWithin(1, .second, of: date2))
+		XCTAssertFalse(date1.isWithin(1, .minute, of: date2))
+		XCTAssert(date1.isWithin(1, .hour, of: date2))
+		XCTAssert(date1.isWithin(1, .day, of: date2))
+		
+		//The other way around
+		XCTAssertFalse(date2.isWithin(1, .second, of: date1))
+		XCTAssertFalse(date2.isWithin(1, .minute, of: date1))
+		XCTAssert(date2.isWithin(1, .hour, of: date1))
+		XCTAssert(date2.isWithin(1, .day, of: date1))
+		
+		//With itself
+		XCTAssert(date1.isWithin(1, .second, of: date1))
+		XCTAssert(date1.isWithin(1, .minute, of: date1))
+		XCTAssert(date1.isWithin(1, .hour, of: date1))
+		XCTAssert(date1.isWithin(1, .day, of: date1))
+	}
+	
 	func testNewDateFromComponenets() {
 		let date = Date(calendar: Date().calendar, timeZone: Date().timeZone, era: Date().era, year: Date().year, month: Date().month, day: Date().day, hour: Date().hour, minute: Date().minute, second: Date().second, nanosecond: Date().nanosecond)
 		XCTAssertNotNil(date)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
