### PR TITLE
add optional assignment operator

### DIFF
--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -50,7 +50,7 @@ public extension Optional {
 // MARK: - Operators
 infix operator ??= : AssignmentPrecedence
 
-/// SwifterSwift: If `rhs` is not `nil`, assign it to `lhs`.
+/// SwifterSwift: Assign an optional value to a variable only if the value is not nil.
 ///
 ///     let someParameter: String? = nil
 ///     let parameters = [String:Any]() //Some parameters to be attached to a GET request

--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -46,3 +46,20 @@ public extension Optional {
 	}
 	
 }
+
+// MARK: - Operators
+infix operator ??= : AssignmentPrecedence
+
+/// SwifterSwift: If `rhs` is not `nil`, assign it to `lhs`.
+///
+///     let someParameter: String? = nil
+///     let parameters = [String:Any]() //Some parameters to be attached to a GET request
+///     parameters[someKey] ??= someParameter //It won't be added to the parameters dict
+///
+/// - Parameters:
+///   - lhs: Any?
+///   - rhs: Any?
+public func ??=<T>(lhs: inout T?, rhs: T?) {
+    guard let rhs = rhs else { return }
+    lhs = rhs
+}

--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -59,7 +59,7 @@ infix operator ??= : AssignmentPrecedence
 /// - Parameters:
 ///   - lhs: Any?
 ///   - rhs: Any?
-public func ??=<T>(lhs: inout T?, rhs: T?) {
+public func ??= <T>(lhs: inout T?, rhs: T?) {
     guard let rhs = rhs else { return }
     lhs = rhs
 }

--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+// MARK: - Operators
+infix operator ??= : AssignmentPrecedence
+
 public extension Optional {
 	
 	/// SwifterSwift: Get self of default value (if self is nil).
@@ -45,21 +48,17 @@ public extension Optional {
 		_ = self.map(block)
 	}
 	
-}
-
-// MARK: - Operators
-infix operator ??= : AssignmentPrecedence
-
-/// SwifterSwift: Assign an optional value to a variable only if the value is not nil.
-///
-///     let someParameter: String? = nil
-///     let parameters = [String:Any]() //Some parameters to be attached to a GET request
-///     parameters[someKey] ??= someParameter //It won't be added to the parameters dict
-///
-/// - Parameters:
-///   - lhs: Any?
-///   - rhs: Any?
-public func ??= <T>(lhs: inout T?, rhs: T?) {
-    guard let rhs = rhs else { return }
-    lhs = rhs
+    /// SwifterSwift: Assign an optional value to a variable only if the value is not nil.
+    ///
+    ///     let someParameter: String? = nil
+    ///     let parameters = [String:Any]() //Some parameters to be attached to a GET request
+    ///     parameters[someKey] ??= someParameter //It won't be added to the parameters dict
+    ///
+    /// - Parameters:
+    ///   - lhs: Any?
+    ///   - rhs: Any?
+    public static func ??= (lhs: inout Optional, rhs: Optional) {
+        guard let rhs = rhs else { return }
+        lhs = rhs
+    }
 }

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -35,4 +35,20 @@ final class OptionalExtensionsTests: XCTestCase {
 		}
 	}
 	
+    func testOptionalAssignment() {
+        let parameter1: String? = nil
+        let parameter2: String? = "foo"
+        
+        let key1: String = "key1"
+        let key2: String = "key2"
+        
+        var parameters = [String : String]()
+        
+        parameters[key1] ??= parameter1
+        parameters[key2] ??= parameter2
+        
+        XCTAssert(parameters[key1] == nil)
+        XCTAssertFalse(parameters[key1] != parameter1)
+        XCTAssert(parameters[key2] == parameter2)
+    }
 }

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -42,7 +42,7 @@ final class OptionalExtensionsTests: XCTestCase {
         let key1: String = "key1"
         let key2: String = "key2"
         
-        var parameters = [String : String]()
+        var parameters = [String: String]()
         
         parameters[key1] ??= parameter1
         parameters[key2] ??= parameter2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
add optional assignment operator: if `rhs` is not `nil`, assign it to `lhs`.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.