### PR TITLE
Remove cross references #294

### DIFF
--- a/Sources/Extensions/Foundation/DataExtensions.swift
+++ b/Sources/Extensions/Foundation/DataExtensions.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
-#if os(macOS)
-	import Cocoa
-#else
-	import UIKit
-#endif
+import Foundation
 
 // MARK: - Properties
 public extension Data {

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -788,7 +788,7 @@ public extension Date {
 	public init?(iso8601String: String) {
 		// https://github.com/justinmakaila/NSDate-ISO-8601/blob/master/NSDateISO8601.swift
 		let dateFormatter = DateFormatter()
-		dateFormatter.locale = .posix
+		dateFormatter.locale = Locale(identifier: "en_US_POSIX")
 		dateFormatter.timeZone = TimeZone.current
 		dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 		if let date = dateFormatter.date(from: iso8601String) {

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -85,10 +85,12 @@ public extension Color {
 	
 	/// SwifterSwift: Hexadecimal value string (read-only).
 	public var hexString: String {
-		let r = rgbComponents.red
-		let g = rgbComponents.green
-		let b = rgbComponents.blue
-		return String(format: "#%02X%02X%02X", r, g, b)
+        let components: [Int] = {
+            let c = cgColor.components!
+            let components = c.count == 4 ? c : [c[0], c[0], c[0], c[1]]
+            return components.map { Int($0 * 255.0) }
+        }()
+        return String(format: "#%02X%02X%02X", components[0], components[1], components[2])
 	}
 	
 	/// SwifterSwift: Short hexadecimal value string (read-only, if applicable).
@@ -101,7 +103,16 @@ public extension Color {
 	
 	/// SwifterSwift: Short hexadecimal value string, or full hexadecimal string if not possible (read-only).
 	public var shortHexOrHexString: String {
-		return shortHexString ?? hexString
+        let components: [Int] = {
+            let c = cgColor.components!
+            let components = c.count == 4 ? c : [c[0], c[0], c[0], c[1]]
+            return components.map { Int($0 * 255.0) }
+        }()
+        let hexString = String(format: "#%02X%02X%02X", components[0], components[1], components[2])
+        let string = hexString.replacingOccurrences(of: "#", with: "")
+        let chrs = Array(string.characters)
+        guard chrs[0] == chrs[1], chrs[2] == chrs[3], chrs[4] == chrs[5] else { return hexString }
+        return "#\(chrs[0])\(chrs[2])\(chrs[4])"
 	}
 	
 	/// SwifterSwift: Alpha of Color (read-only).
@@ -118,19 +129,42 @@ public extension Color {
 	
 	/// SwifterSwift: Get UInt representation of a Color (read-only).
 	public var uInt: UInt {
-		let c = self.cgFloatComponents
+        let c: [CGFloat] = {
+            let c = cgColor.components!
+            return c.count == 4 ? c : [c[0], c[0], c[0], c[1]]
+        }()
 		
 		var colorAsUInt32: UInt32 = 0
-		colorAsUInt32 += UInt32(c.red * 255.0) << 16
-		colorAsUInt32 += UInt32(c.green * 255.0) << 8
-		colorAsUInt32 += UInt32(c.blue * 255.0)
+		colorAsUInt32 += UInt32(c[0] * 255.0) << 16
+		colorAsUInt32 += UInt32(c[1] * 255.0) << 8
+		colorAsUInt32 += UInt32(c[2] * 255.0)
 		
 		return UInt(colorAsUInt32)
 	}
 	
 	/// SwifterSwift: Get color complementary (read-only, if applicable).
 	public var complementary: Color? {
-		return Color.init(complementaryFor: self)
+        let colorSpaceRGB = CGColorSpaceCreateDeviceRGB()
+        let convertColorToRGBSpace: ((_ color: Color) -> Color?) = { color -> Color? in
+            if self.cgColor.colorSpace!.model == CGColorSpaceModel.monochrome {
+                let oldComponents = self.cgColor.components
+                let components: [CGFloat] = [ oldComponents![0], oldComponents![0], oldComponents![0], oldComponents![1]]
+                let colorRef = CGColor(colorSpace: colorSpaceRGB, components: components)
+                let colorOut = Color(cgColor: colorRef!)
+                return colorOut
+            } else {
+                return self
+            }
+        }
+        
+        let c = convertColorToRGBSpace(self)
+        guard let componentColors = c?.cgColor.components else { return nil }
+        
+        let r: CGFloat = sqrt(pow(255.0, 2.0) - pow((componentColors[0]*255), 2.0))/255
+        let g: CGFloat = sqrt(pow(255.0, 2.0) - pow((componentColors[1]*255), 2.0))/255
+        let b: CGFloat = sqrt(pow(255.0, 2.0) - pow((componentColors[2]*255), 2.0))/255
+        
+        return UIColor(red: r, green: g, blue: b, alpha: 1.0)
 	}
 	
 }
@@ -156,20 +190,26 @@ public extension Color {
 		guard level1 > 0 else { return color2 }
 		guard level2 > 0 else { return color1 }
 		
-		let components1 = color1.cgFloatComponents
-		let components2 = color2.cgFloatComponents
+        let components1: [CGFloat] = {
+            let c = color1.cgColor.components!
+            return c.count == 4 ? c : [c[0], c[0], c[0], c[1]]
+        }()
+        let components2: [CGFloat] = {
+            let c = color2.cgColor.components!
+            return c.count == 4 ? c : [c[0], c[0], c[0], c[1]]
+        }()
 		
-		let r1 = components1.red
-		let r2 = components2.red
+		let r1 = components1[0]
+		let r2 = components2[0]
 		
-		let g1 = components1.green
-		let g2 = components2.green
+		let g1 = components1[1]
+		let g2 = components2[1]
 		
-		let b1 = components1.blue
-		let b2 = components2.blue
+		let b1 = components1[2]
+		let b2 = components2[2]
 		
-		let a1 = color1.alpha
-		let a2 = color2.alpha
+		let a1 = color1.cgColor.alpha
+		let a2 = color2.cgColor.alpha
 		
 		let r = level1*r1 + level2*r2
 		let g = level1*g1 + level2*g2
@@ -242,11 +282,14 @@ public extension Color {
 		
 		guard let hexValue = Int(string, radix: 16) else { return nil }
 		
-		var trans = transparency
-		if trans < 0 { trans = 0 }
-		if trans > 1 { trans = 1 }
-		
-		self.init(hex: Int(hexValue), transparency: trans)
+        var trans = transparency
+        if trans < 0 { trans = 0 }
+        if trans > 1 { trans = 1 }
+        
+        let red = (hexValue >> 16) & 0xff
+        let green = (hexValue >> 8) & 0xff
+        let blue = hexValue & 0xff
+        self.init(red: red, green: green, blue: blue, transparency: trans)
 	}
 	
 	/// SwifterSwift: Create Color from a complementary of a Color (if applicable).

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -25,11 +25,7 @@ public extension Color {
 		let r = Int(arc4random_uniform(255))
 		let g = Int(arc4random_uniform(255))
 		let b = Int(arc4random_uniform(255))
-		#if os(macOS)
-			return NSColor(red: r, green: g, blue: b)!
-		#else
-			return UIColor(red: r, green: g, blue: b)!
-		#endif
+        return Color(red: r, green: g, blue: b)!
 	}
 	
 	/// SwifterSwift: RGB components for a Color (between 0 and 255).
@@ -164,7 +160,7 @@ public extension Color {
         let g: CGFloat = sqrt(pow(255.0, 2.0) - pow((componentColors[1]*255), 2.0))/255
         let b: CGFloat = sqrt(pow(255.0, 2.0) - pow((componentColors[2]*255), 2.0))/255
         
-        return UIColor(red: r, green: g, blue: b, alpha: 1.0)
+        return Color(red: r, green: g, blue: b, alpha: 1.0)
 	}
 	
 }

--- a/Sources/Extensions/SwiftStdlib/IntExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/IntExtensions.swift
@@ -56,7 +56,7 @@ public extension Int {
 		var sign: String {
 			return self >= 0 ? "" : "-"
 		}
-		let abs = self.abs
+		let abs = Swift.abs(self)
 		if abs == 0 {
 			return "0k"
 		} else if abs >= 0 && abs < 1000 {

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -390,7 +390,9 @@ public extension String {
             let count = $0[$1] ?? 0
             $0[$1] = count + 1
         }.max { $0.1 < $1.1 }?.0
-        return mostCommon?.string ?? ""
+        
+        guard let character = mostCommon else { return "" }
+        return String(character)
 	}
 	
 	/// SwifterSwift: Reversed string.

--- a/Sources/Extensions/UIKit/UITabBarExtensions.swift
+++ b/Sources/Extensions/UIKit/UITabBarExtensions.swift
@@ -40,7 +40,19 @@ public extension UITabBar {
 		
 		if let selectedbg = selectedBackground {
 			let rect = CGSize(width: frame.width/CGFloat(barItems.count), height: frame.height)
-			selectionIndicatorImage = UIImage(color: selectedbg, size: rect)
+            selectionIndicatorImage = { (color: UIColor, size: CGSize) -> UIImage in
+                UIGraphicsBeginImageContextWithOptions(size, false, 1)
+                color.setFill()
+                UIRectFill(CGRect(x: 0, y: 0, width: size.width, height: size.height))
+                guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
+                    return UIImage()
+                }
+                UIGraphicsEndImageContext()
+                guard let aCgImage = image.cgImage else {
+                    return UIImage()
+                }
+                return UIImage(cgImage: aCgImage)
+            }(selectedbg, rect)
 		}
 		
 		if let itemColor = item {
@@ -49,7 +61,30 @@ public extension UITabBar {
 				guard let image = barItem.image else {
 					continue
 				}
-				barItem.image = image.filled(withColor: itemColor).withRenderingMode(.alwaysOriginal)
+                
+                barItem.image = { (image: UIImage, color: UIColor) -> UIImage in
+                    UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
+                    color.setFill()
+                    guard let context = UIGraphicsGetCurrentContext() else {
+                        return image
+                    }
+                    
+                    context.translateBy(x: 0, y: image.size.height)
+                    context.scaleBy(x: 1.0, y: -1.0)
+                    context.setBlendMode(CGBlendMode.normal)
+                    
+                    let rect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+                    guard let mask = image.cgImage else {
+                        return image
+                    }
+                    context.clip(to: rect, mask: mask)
+                    context.fill(rect)
+                    
+                    let newImage = UIGraphicsGetImageFromCurrentImageContext()!
+                    UIGraphicsEndImageContext()
+                    return newImage
+                }(image, itemColor).withRenderingMode(.alwaysOriginal)
+                
 				barItem.setTitleTextAttributes([.foregroundColor: itemColor], for: .normal)
 				if let selected = selectedItem {
 					barItem.setTitleTextAttributes([.foregroundColor: selected], for: .selected)

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -248,7 +248,7 @@ public extension UIView {
 	///   - radius: shadow radius (default is 3).
 	///   - offset: shadow offset (default is .zero).
 	///   - opacity: shadow opacity (default is 0.5).
-	public func addShadow(ofColor color: UIColor = UIColor(hex: 0x137992)!, radius: CGFloat = 3, offset: CGSize = .zero, opacity: Float = 0.5) {
+	public func addShadow(ofColor color: UIColor = UIColor(red:0.07, green:0.47, blue:0.57, alpha:1.0), radius: CGFloat = 3, offset: CGSize = .zero, opacity: Float = 0.5) {
 		layer.shadowColor = color.cgColor
 		layer.shadowOffset = offset
 		layer.shadowRadius = radius

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -21,6 +21,31 @@ import XCTest
 #endif
 
 final class ColorExtensionsTests: XCTestCase {
+    
+    // MARK: - Test properties
+    func testCGFloatComponents() {
+        XCTAssertEqual(Color.red.cgFloatComponents.red, 1.0)
+        XCTAssertEqual(Color.red.cgFloatComponents.green, 0.0)
+        XCTAssertEqual(Color.red.cgFloatComponents.blue, 0.0)
+        
+        XCTAssertEqual(Color.green.cgFloatComponents.red, 0.0)
+        XCTAssertEqual(Color.green.cgFloatComponents.green, 1.0)
+        XCTAssertEqual(Color.green.cgFloatComponents.blue, 0.0)
+
+        XCTAssertEqual(Color.blue.cgFloatComponents.red, 0.0)
+        XCTAssertEqual(Color.blue.cgFloatComponents.green, 0.0)
+        XCTAssertEqual(Color.blue.cgFloatComponents.blue, 1.0)
+
+        XCTAssertEqual(Color.black.cgFloatComponents.red, 0.0)
+        XCTAssertEqual(Color.black.cgFloatComponents.green, 0.0)
+        XCTAssertEqual(Color.black.cgFloatComponents.blue, 0.0)
+
+        XCTAssertEqual(Color.white.cgFloatComponents.red, 1.0)
+        XCTAssertEqual(Color.white.cgFloatComponents.green, 1.0)
+        XCTAssertEqual(Color.white.cgFloatComponents.blue, 1.0)
+
+        XCTAssertEqual(Int(Color(hex: 0x12FFFF)!.cgFloatComponents.red * 255.0), 0x12)
+    }
 	
 	// MARK: - Test properties
 	func testRgbComponents() {


### PR DESCRIPTION
## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.

## Description
If I understood #294 correctly, then this should take care of cross-file references at least. I'm not sure of the issue with #286 since none of my findings include any UIKit extension references in the Foundation/Swift extension groups.

What this does _not_ do, currently, is intra-file references to other extensions since this is a difficult one to automate (see below). Specifically, I'm wondering if examples like in [NSAttributedString](https://github.com/SwifterSwift/SwifterSwift/blob/master/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift#L51) would need to be refactored (since extensions like `.bolded` use the helper method `applying`)? Or if just examples like [NSURL](https://github.com/SwifterSwift/SwifterSwift/blob/master/Sources/Extensions/Foundation/URLExtensions.swift#L37) should be refactored since it's a public extension method that proxies to another? Some guidance here would be appreciated.

Side note: I created a small script that tries to compile each source file individually and emits any errors from the swift compiler to help automate this process. Perhaps this could be cleaned up and added to the Danger file with a nicer report (likely as a separate enhancement PR)?

```bash
#!/bin/sh

platformName="$1"

if [ "$platformName" == "" ]; then
	platformName="ios"
fi

if [ "$platformName" == "ios" ]; then
	for sourceFile in Sources/Extensions/**/*.swift; do
		swiftc -target arm64-apple-ios11.0 \
			-sdk $(xcrun --sdk iphoneos --show-sdk-path) \
			-emit-object $sourceFile \
			-o "${sourceFile%.*}.o"
		rm -f "${sourceFile%.*}.o"
		if [ ! $? -eq 0 ]; then
			echo "$sourceFile could not compile"
		fi
	done
fi

if [ "$platformName" == "macos" ]; then
	for sourceFile in Sources/Extensions/**/*.swift; do
		swiftc -target x86_64-apple-macos10.11 \
			-sdk $(xcrun --sdk macosx --show-sdk-path) \
			-emit-object $sourceFile \
			-o "${sourceFile%.*}.o"
		rm -f "${sourceFile%.*}.o"
		if [ ! $? -eq 0 ]; then
			echo "$sourceFile could not compile"
		fi
	done
fi
```