### PR TITLE
Adding padStart/padEnd and byPaddingStart/byPaddingEnd String extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
     - Add `padStart(lenght:with:)` and `padEnd(lenght:with:)` to pad the string to a lenght on the start or end.
     - Add `paddingStart(lenght:with:)` and `paddingEnd(lenght:with:)` to return a padding string to a lenght on the start or end. 
       [#300](https://github.com/SwifterSwift/SwifterSwift/pull/300) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+ - New **NSImage** extensions
+   -    Add `scaled(toMaxSize:)` to scale image to maximum size with respect to aspect ratio [#291](https://github.com/SwifterSwift/SwifterSwift/pull/291) by [buddax2](https://github.com/buddax2).
+ - **Optional**
+   - Add optional assignment operator `??=` [#296](https://github.com/SwifterSwift/SwifterSwift/pull/296) by [buddax2](https://github.com/buddax2).
+
 > ### Bugfixes
 > N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ All notable changes to this project will be documented in this file.
 >
 
 ### Enhancements
- - New **String** extensions: [#300](https://github.com/SwifterSwift/SwifterSwift/pull/300) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+ - New **String** extensions
     - Add `padStart(lenght:with:)` and `padEnd(lenght:with:)` to pad the string to a lenght on the start or end.
     - Add `paddingStart(lenght:with:)` and `paddingEnd(lenght:with:)` to return a padding string to a lenght on the start or end. 
-
+      [#300](https://github.com/SwifterSwift/SwifterSwift/pull/300) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 > ### Bugfixes
 > N/A
 
@@ -33,10 +33,11 @@ N/A
   - Corrected some typos in README. [#263](https://github.com/SwifterSwift/SwifterSwift/pull/263) by [nick3399](https://github.com/nick3399).
 - New **String** extensions
   - Add `localized(comment:)` to returns a localized string, with an optional comment for translators. [#269](https://github.com/SwifterSwift/SwifterSwift/pull/269) by [Vyax](https://github.com/Vyax).
-- New **NSPredicate** extensions: [#273](https://github.com/SwifterSwift/SwifterSwift/pull/273) by [Vyax](https://github.com/Vyax).
+- New **NSPredicate** extensions
   - Add `not` to returns a new predicate formed by NOT-ing the predicate.
   - Add `and(_ predicate: NSPredicate)` to returns a new predicate formed by AND-ing the argument to the predicate.
   - Add `or(_ predicate: NSPredicate)` to returns a new predicate formed by OR-ing the argument to the predicate.
+    [#273](https://github.com/SwifterSwift/SwifterSwift/pull/273) by [Vyax](https://github.com/Vyax).
 - New **UILabel** extensions
   - Add `convenience init(text: String?)` to initialize a UILabel with text. [#271](https://github.com/SwifterSwift/SwifterSwift/pull/271) by [Vyax](https://github.com/Vyax).
 - New **Bool** extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ All notable changes to this project will be documented in this file.
 > ### API Breaking
 > N/A
 >
-> ### Enhancements
-> N/A
-> 
+
+### Enhancements
+ - New **String** extensions: [#300](https://github.com/SwifterSwift/SwifterSwift/pull/300) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+    - Add `padStart(lenght:with:)` and `padEnd(lenght:with:)` to pad the string to a lenght on the start or end.
+    - Add `byPaddingStart(lenght:with:)` and `byPaddingEnd(lenght:with:)` to return a padding string to a lenght on the start or end. 
+
 > ### Bugfixes
 > N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
  - New **String** extensions: [#300](https://github.com/SwifterSwift/SwifterSwift/pull/300) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
     - Add `padStart(lenght:with:)` and `padEnd(lenght:with:)` to pad the string to a lenght on the start or end.
-    - Add `byPaddingStart(lenght:with:)` and `byPaddingEnd(lenght:with:)` to return a padding string to a lenght on the start or end. 
+    - Add `paddingStart(lenght:with:)` and `paddingEnd(lenght:with:)` to return a padding string to a lenght on the start or end. 
 
 > ### Bugfixes
 > N/A

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -820,18 +820,24 @@ public extension String {
 	
     /// SwifterSwift: Pad string to fit the length parameter size with another string in the start.
     ///
+    ///   "hue".padStart(10) -> "       hue"
+    ///   "hue".padStart(10, with: "br") -> "brbrbrbhue"
+    ///
     /// - Parameter length: The target length to pad.
     /// - Parameter string: Pad string. Default is " ".
     public mutating func padStart(_ length: Int, with string: String = " ") {
-        self = byPaddingStart(length, with: string)
+        self = paddingStart(length, with: string)
     }
     
     /// SwifterSwift: Returns a string by padding to fit the length parameter size with another string in the start.
     ///
+    ///   "hue".paddingStart(10) -> "       hue"
+    ///   "hue".paddingStart(10, with: "br") -> "brbrbrbhue"
+    ///
     /// - Parameter length: The target length to pad.
     /// - Parameter string: Pad string. Default is " ".
     /// - Returns: The string with the padding on the start.
-    public func byPaddingStart(_ length: Int, with string: String = " ") -> String {
+    public func paddingStart(_ length: Int, with string: String = " ") -> String {
         
         guard count < length else { return self }
         
@@ -849,18 +855,24 @@ public extension String {
     
     /// SwifterSwift: Pad string to fit the length parameter size with another string in the start.
     ///
+    ///   "hue".padEnd(10) -> "hue       "
+    ///   "hue".padEnd(10, with: "br") -> "huebrbrbrb"
+    ///
     /// - Parameter length: The target length to pad.
     /// - Parameter string: Pad string. Default is " ".
     public mutating func padEnd(_ length: Int, with string: String = " ") {
-        self = byPaddingEnd(length, with: string)
+        self = paddingEnd(length, with: string)
     }
     
     /// SwifterSwift: Returns a string by padding to fit the length parameter size with another string in the end.
     ///
+    ///   "hue".paddingEnd(10) -> "hue       "
+    ///   "hue".paddingEnd(10, with: "br") -> "huebrbrbrb"
+    ///
     /// - Parameter length: The target length to pad.
     /// - Parameter string: Pad string. Default is " ".
     /// - Returns: The string with the padding on the end.
-    public func byPaddingEnd(_ length: Int, with string: String = " ") -> String {
+    public func paddingEnd(_ length: Int, with string: String = " ") -> String {
         guard count < length else { return self }
         
         let padLength = length - count

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -812,12 +812,71 @@ public extension String {
 	///
 	/// - Parameter pattern: Pattern to verify.
 	/// - Returns: true if string matches the pattern.
-	func matches(pattern: String) -> Bool {
+	public func matches(pattern: String) -> Bool {
 		return range(of: pattern,
 		             options: String.CompareOptions.regularExpression,
 		             range: nil, locale: nil) != nil
 	}
 	
+    /// SwifterSwift: Pad string to fit the length parameter size with another string in the start.
+    ///
+    /// - Parameter length: The target length to pad.
+    /// - Parameter string: Pad string. Default is " ".
+    public mutating func padStart(_ length: Int, with string: String = " ") {
+        self = byPaddingStart(length, with: string)
+    }
+    
+    /// SwifterSwift: Returns a string by padding to fit the length parameter size with another string in the start.
+    ///
+    /// - Parameter length: The target length to pad.
+    /// - Parameter string: Pad string. Default is " ".
+    /// - Returns: The string with the padding on the start.
+    public func byPaddingStart(_ length: Int, with string: String = " ") -> String {
+        
+        let str = self
+        guard str.count < length else { return str }
+        
+        let padLength = length - str.count
+        if padLength < string.count {
+            return string[string.startIndex..<string.index(string.startIndex, offsetBy: padLength)] + str
+        } else {
+            var padding = string
+            while padding.count < padLength {
+                padding.append(string)
+            }
+            return padding[padding.startIndex..<padding.index(padding.startIndex, offsetBy: padLength)] + str
+        }
+    }
+    
+    /// SwifterSwift: Pad string to fit the length parameter size with another string in the start.
+    ///
+    /// - Parameter length: The target length to pad.
+    /// - Parameter string: Pad string. Default is " ".
+    public mutating func padEnd(_ length: Int, with string: String = " ") {
+        self = byPaddingEnd(length, with: string)
+    }
+    
+    /// SwifterSwift: Returns a string by padding to fit the length parameter size with another string in the end.
+    ///
+    /// - Parameter length: The target length to pad.
+    /// - Parameter string: Pad string. Default is " ".
+    /// - Returns: The string with the padding on the end.
+    public func byPaddingEnd(_ length: Int, with string: String = " ") -> String {
+        let str = self
+        guard str.count < length else { return str }
+        
+        let padLength = length - str.count
+        if padLength < string.count {
+            return str + string[string.startIndex..<string.index(string.startIndex, offsetBy: padLength)]
+        } else {
+            var padding = string
+            while padding.count < padLength {
+                padding.append(string)
+            }
+            return str + padding[padding.startIndex..<padding.index(padding.startIndex, offsetBy: padLength)]
+        }
+    }
+
 }
 
 // MARK: - Operators

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -833,18 +833,17 @@ public extension String {
     /// - Returns: The string with the padding on the start.
     public func byPaddingStart(_ length: Int, with string: String = " ") -> String {
         
-        let str = self
-        guard str.count < length else { return str }
+        guard count < length else { return self }
         
-        let padLength = length - str.count
+        let padLength = length - count
         if padLength < string.count {
-            return string[string.startIndex..<string.index(string.startIndex, offsetBy: padLength)] + str
+            return string[string.startIndex..<string.index(string.startIndex, offsetBy: padLength)] + self
         } else {
             var padding = string
             while padding.count < padLength {
                 padding.append(string)
             }
-            return padding[padding.startIndex..<padding.index(padding.startIndex, offsetBy: padLength)] + str
+            return padding[padding.startIndex..<padding.index(padding.startIndex, offsetBy: padLength)] + self
         }
     }
     
@@ -862,18 +861,17 @@ public extension String {
     /// - Parameter string: Pad string. Default is " ".
     /// - Returns: The string with the padding on the end.
     public func byPaddingEnd(_ length: Int, with string: String = " ") -> String {
-        let str = self
-        guard str.count < length else { return str }
+        guard count < length else { return self }
         
-        let padLength = length - str.count
+        let padLength = length - count
         if padLength < string.count {
-            return str + string[string.startIndex..<string.index(string.startIndex, offsetBy: padLength)]
+            return self + string[string.startIndex..<string.index(string.startIndex, offsetBy: padLength)]
         } else {
             var padding = string
             while padding.count < padLength {
                 padding.append(string)
             }
-            return str + padding[padding.startIndex..<padding.index(padding.startIndex, offsetBy: padLength)]
+            return self + padding[padding.startIndex..<padding.index(padding.startIndex, offsetBy: padLength)]
         }
     }
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -591,23 +591,23 @@ final class StringExtensionsTests: XCTestCase {
 		XCTAssertEqual("Swift is amazing".wordCount(), 3)
 	}
     
-    func testByPaddingStart() {
-        XCTAssertEqual("str".byPaddingStart(10), "       str")
-        XCTAssertEqual("str".byPaddingStart(10, with: "br"), "brbrbrbstr")
-        XCTAssertEqual("str".byPaddingStart(5, with: "brazil"), "brstr")
-        XCTAssertEqual("str".byPaddingStart(6, with: "a"), "aaastr")
-        XCTAssertEqual("str".byPaddingStart(6, with: "abc"), "abcstr")
-        XCTAssertEqual("str".byPaddingStart(2), "str")
+    func testPaddingStart() {
+        XCTAssertEqual("str".paddingStart(10), "       str")
+        XCTAssertEqual("str".paddingStart(10, with: "br"), "brbrbrbstr")
+        XCTAssertEqual("str".paddingStart(5, with: "brazil"), "brstr")
+        XCTAssertEqual("str".paddingStart(6, with: "a"), "aaastr")
+        XCTAssertEqual("str".paddingStart(6, with: "abc"), "abcstr")
+        XCTAssertEqual("str".paddingStart(2), "str")
 
     }
     
-    func testByPaddingEnd() {
-        XCTAssertEqual("str".byPaddingEnd(10), "str       ")
-        XCTAssertEqual("str".byPaddingEnd(10, with: "br"), "strbrbrbrb")
-        XCTAssertEqual("str".byPaddingEnd(5, with: "brazil"), "strbr")
-        XCTAssertEqual("str".byPaddingEnd(6, with: "a"), "straaa")
-        XCTAssertEqual("str".byPaddingEnd(6, with: "abc"), "strabc")
-        XCTAssertEqual("str".byPaddingEnd(2), "str")
+    func testPaddingEnd() {
+        XCTAssertEqual("str".paddingEnd(10), "str       ")
+        XCTAssertEqual("str".paddingEnd(10, with: "br"), "strbrbrbrb")
+        XCTAssertEqual("str".paddingEnd(5, with: "brazil"), "strbr")
+        XCTAssertEqual("str".paddingEnd(6, with: "a"), "straaa")
+        XCTAssertEqual("str".paddingEnd(6, with: "abc"), "strabc")
+        XCTAssertEqual("str".paddingEnd(2), "str")
     }
 
     func testPadStart() {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -590,5 +590,75 @@ final class StringExtensionsTests: XCTestCase {
 	func testWordsCount() {
 		XCTAssertEqual("Swift is amazing".wordCount(), 3)
 	}
+    
+    func testByPaddingStart() {
+        XCTAssertEqual("str".byPaddingStart(10), "       str")
+        XCTAssertEqual("str".byPaddingStart(10, with: "br"), "brbrbrbstr")
+        XCTAssertEqual("str".byPaddingStart(5, with: "brazil"), "brstr")
+        XCTAssertEqual("str".byPaddingStart(6, with: "a"), "aaastr")
+        XCTAssertEqual("str".byPaddingStart(6, with: "abc"), "abcstr")
+        XCTAssertEqual("str".byPaddingStart(2), "str")
 
+    }
+    
+    func testByPaddingEnd() {
+        XCTAssertEqual("str".byPaddingEnd(10), "str       ")
+        XCTAssertEqual("str".byPaddingEnd(10, with: "br"), "strbrbrbrb")
+        XCTAssertEqual("str".byPaddingEnd(5, with: "brazil"), "strbr")
+        XCTAssertEqual("str".byPaddingEnd(6, with: "a"), "straaa")
+        XCTAssertEqual("str".byPaddingEnd(6, with: "abc"), "strabc")
+        XCTAssertEqual("str".byPaddingEnd(2), "str")
+    }
+
+    func testPadStart() {
+        var str: String = "str"
+        str.padStart(10)
+        XCTAssertEqual(str, "       str")
+
+        str = "str"
+        str.padStart(10, with: "br")
+        XCTAssertEqual(str, "brbrbrbstr")
+
+        str = "str"
+        str.padStart(5, with: "brazil")
+        XCTAssertEqual(str, "brstr")
+
+        str = "str"
+        str.padStart(6, with: "a")
+        XCTAssertEqual(str, "aaastr")
+        
+        str = "str"
+        str.padStart(6, with: "abc")
+        XCTAssertEqual(str, "abcstr")
+
+        str = "str"
+        str.padStart(2)
+        XCTAssertEqual(str, "str")
+    }
+    
+    func testPadEnd() {
+        var str: String = "str"
+        str.padEnd(10)
+        XCTAssertEqual(str, "str       ")
+        
+        str = "str"
+        str.padEnd(10, with: "br")
+        XCTAssertEqual(str, "strbrbrbrb")
+        
+        str = "str"
+        str.padEnd(5, with: "brazil")
+        XCTAssertEqual(str, "strbr")
+        
+        str = "str"
+        str.padEnd(6, with: "a")
+        XCTAssertEqual(str, "straaa")
+        
+        str = "str"
+        str.padEnd(6, with: "abc")
+        XCTAssertEqual(str, "strabc")
+        
+        str = "str"
+        str.padEnd(2)
+        XCTAssertEqual(str, "str")
+    }
 }


### PR DESCRIPTION

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
