### PR TITLE
Rewrite DateExtensions.swift

### DIFF
--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -103,7 +103,7 @@ public extension Date {
 	/// 	Date().month -> 1
 	///
 	/// 	var someDate = Date()
-	/// 	someDate.year = 10 // sets someDate's month to 10.
+	/// 	someDate.month = 10 // sets someDate's month to 10.
 	///
 	public var month: Int {
 		get {
@@ -112,7 +112,7 @@ public extension Date {
 		set {
 			let allowedRange = Calendar.current.range(of: .month, in: .year, for: self)!
 			guard allowedRange.contains(newValue) else { return }
-
+			
 			let currentMonth = Calendar.current.component(.month, from: self)
 			let monthsToAdd = newValue - currentMonth
 			if let date = Calendar.current.date(byAdding: .month, value: monthsToAdd, to: self) {
@@ -157,7 +157,7 @@ public extension Date {
 	/// 	Date().hour -> 17 // 5 pm
 	///
 	/// 	var someDate = Date()
-	/// 	someDate.day = 13 // sets someDate's hour to 1 pm.
+	/// 	someDate.hour = 13 // sets someDate's hour to 1 pm.
 	///
 	public var hour: Int {
 		get {
@@ -166,7 +166,7 @@ public extension Date {
 		set {
 			let allowedRange = Calendar.current.range(of: .hour, in: .day, for: self)!
 			guard allowedRange.contains(newValue) else { return }
-
+			
 			let currentHour = Calendar.current.component(.hour, from: self)
 			let hoursToAdd = newValue - currentHour
 			if let date = Calendar.current.date(byAdding: .hour, value: hoursToAdd, to: self) {
@@ -203,7 +203,7 @@ public extension Date {
 	/// 	Date().second -> 55
 	///
 	/// 	var someDate = Date()
-	/// 	someDate. second = 15 // sets someDate's seconds to 15.
+	/// 	someDate.second = 15 // sets someDate's seconds to 15.
 	///
 	public var second: Int {
 		get {
@@ -225,6 +225,9 @@ public extension Date {
 	///
 	/// 	Date().nanosecond -> 981379985
 	///
+	/// 	var someDate = Date()
+	/// 	someDate.nanosecond = 981379985 // sets someDate's seconds to 981379985.
+	///
 	public var nanosecond: Int {
 		get {
 			return Calendar.current.component(.nanosecond, from: self)
@@ -232,13 +235,23 @@ public extension Date {
 		set {
 			let allowedRange = Calendar.current.range(of: .nanosecond, in: .second, for: self)!
 			guard allowedRange.contains(newValue) else { return }
-			if let date = Calendar.current.date(bySetting: .nanosecond, value: newValue, of: self) {
+			
+			let currentNanoseconds = Calendar.current.component(.nanosecond, from: self)
+			let nanosecondsToAdd = newValue - currentNanoseconds
+			
+			if let date = Calendar.current.date(byAdding: .nanosecond, value: nanosecondsToAdd, to: self) {
 				self = date
 			}
 		}
 	}
 	
 	/// SwifterSwift: Milliseconds.
+	///
+	/// 	Date().millisecond -> 68
+	///
+	/// 	var someDate = Date()
+	/// 	someDate.millisecond = 68 // sets someDate's nanosecond to 68000000.
+	///
 	public var millisecond: Int {
 		get {
 			return Calendar.current.component(.nanosecond, from: self) / 1000000
@@ -270,7 +283,7 @@ public extension Date {
 		return self < Date()
 	}
 	
-	/// SwifterSwift: Check if date is in today.
+	/// SwifterSwift: Check if date is within today.
 	///
 	/// 	Date().isInToday -> true
 	///
@@ -343,10 +356,11 @@ public extension Date {
 	/// 	date.nearestFiveMinutes // "5:45 PM"
 	///
 	public var nearestFiveMinutes: Date {
-		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: self)
 		let min = components.minute!
 		components.minute! = min % 5 < 3 ? min - min % 5 : min + 5 - (min % 5)
 		components.second = 0
+		components.nanosecond = 0
 		return Calendar.current.date(from: components)!
 	}
 	
@@ -364,6 +378,7 @@ public extension Date {
 		let min = components.minute!
 		components.minute? = min % 10 < 6 ? min - min % 10 : min + 10 - (min % 10)
 		components.second = 0
+		components.nanosecond = 0
 		return Calendar.current.date(from: components)!
 	}
 	
@@ -381,6 +396,7 @@ public extension Date {
 		let min = components.minute!
 		components.minute! = min % 15 < 8 ? min - min % 15 : min + 15 - (min % 15)
 		components.second = 0
+		components.nanosecond = 0
 		return Calendar.current.date(from: components)!
 	}
 	
@@ -398,6 +414,7 @@ public extension Date {
 		let min = components.minute!
 		components.minute! = min % 30 < 15 ? min - min % 30 : min + 30 - (min % 30)
 		components.second = 0
+		components.nanosecond = 0
 		return Calendar.current.date(from: components)!
 	}
 	
@@ -410,13 +427,17 @@ public extension Date {
 	/// 	date.nearestHour // "7:00 PM"
 	///
 	public var nearestHour: Date {
-		if minute >= 30 {
-			return beginning(of: .hour)!.adding(.hour, value: 1)
+		let min = Calendar.current.component(.minute, from: self)
+		let components: Set<Calendar.Component> = [.year, .month, .day, .hour]
+		let date = Calendar.current.date(from: Calendar.current.dateComponents(components, from: self))!
+		
+		if min < 30 {
+			return date
 		}
-		return beginning(of: .hour)!
+		return Calendar.current.date(byAdding: .hour, value: 1, to: date)!
 	}
 	
-	/// SwifterSwift: Time zone used by system.
+	/// SwifterSwift: Time zone used currently by system.
 	///
 	///		Date().timeZone -> Europe/Istanbul (current)
 	///
@@ -487,12 +508,13 @@ public extension Date {
 		case .nanosecond:
 			let allowedRange = Calendar.current.range(of: .nanosecond, in: .second, for: self)!
 			guard allowedRange.contains(value) else { return nil }
-			return Calendar.current.date(bySetting: .nanosecond, value: value, of: self)
+			let currentNanoseconds = Calendar.current.component(.nanosecond, from: self)
+			let nanosecondsToAdd = value - currentNanoseconds
+			return Calendar.current.date(byAdding: .nanosecond, value: nanosecondsToAdd, to: self)
 			
 		case .second:
 			let allowedRange = Calendar.current.range(of: .second, in: .minute, for: self)!
 			guard allowedRange.contains(value) else { return nil }
-			
 			let currentSeconds = Calendar.current.component(.second, from: self)
 			let secondsToAdd = value - currentSeconds
 			return Calendar.current.date(byAdding: .second, value: secondsToAdd, to: self)
@@ -546,37 +568,38 @@ public extension Date {
 	/// - Parameter component: calendar component to get date at the beginning of.
 	/// - Returns: date at the beginning of calendar component (if applicable).
 	public func beginning(of component: Calendar.Component) -> Date? {
-		switch component {
-		case .second:
-			return Calendar.current.date(from:
-				Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self))
-			
-		case .minute:
-			return Calendar.current.date(from:
-				Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self))
-			
-		case .hour:
-			return Calendar.current.date(from:
-				Calendar.current.dateComponents([.year, .month, .day, .hour], from: self))
-			
-		case .day:
+		
+		if component == .day {
 			return Calendar.current.startOfDay(for: self)
-			
-		case .weekOfYear, .weekOfMonth:
-			return Calendar.current.date(from:
-				Calendar.current.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self))
-			
-		case .month:
-			return Calendar.current.date(from:
-				Calendar.current.dateComponents([.year, .month], from: self))
-			
-		case .year:
-			return Calendar.current.date(from:
-				Calendar.current.dateComponents([.year], from: self))
-			
-		default:
-			return nil
 		}
+		
+		var components: Set<Calendar.Component> {
+			switch component {
+			case .second:
+				return [.year, .month, .day, .hour, .minute, .second]
+				
+			case .minute:
+				return [.year, .month, .day, .hour, .minute]
+				
+			case .hour:
+				return [.year, .month, .day, .hour]
+				
+			case .weekOfYear, .weekOfMonth:
+				return [.yearForWeekOfYear, .weekOfYear]
+				
+			case .month:
+				return [.year, .month]
+				
+			case .year:
+				return [.year]
+				
+			default:
+				return []
+			}
+		}
+		
+		guard !components.isEmpty else { return nil }
+		return Calendar.current.date(from: Calendar.current.dateComponents(components, from: self))
 	}
 	
 	/// SwifterSwift: Date at the end of calendar component.
@@ -643,6 +666,17 @@ public extension Date {
 		}
 	}
 	
+	/// SwifterSwift: Check if date is in current given calendar component.
+	///
+	/// 	Date().isInCurrent(.day) -> true
+	/// 	Date().isInCurrent(.year) -> true
+	///
+	/// - Parameter component: calendar component to check.
+	/// - Returns: true if date is in current given calendar component.
+	public func isInCurrent(_ component: Calendar.Component) -> Bool {
+		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: component)
+	}
+	
 	/// SwifterSwift: Date string from date.
 	///
 	/// 	Date().dateString(ofStyle: .short) -> "1/12/17"
@@ -673,17 +707,6 @@ public extension Date {
 		dateFormatter.timeStyle = style
 		dateFormatter.dateStyle = style
 		return dateFormatter.string(from: self)
-	}
-	
-	/// SwifterSwift: Check if date is in current given calendar component.
-	///
-	/// 	Date().isInCurrent(.day) -> true
-	/// 	Date().isInCurrent(.year) -> true
-	///
-	/// - Parameter component: calendar component to check.
-	/// - Returns: true if date is in current given calendar component.
-	public func isInCurrent(_ component: Calendar.Component) -> Bool {
-		return calendar.isDate(self, equalTo: Date(), toGranularity: component)
 	}
 	
 	/// SwifterSwift: Time string from date
@@ -757,7 +780,7 @@ public extension Date {
 	/// - Parameter date: date to compate self to.
 	/// - Returns: number of seconds between self and given date.
 	public func secondsSince(_ date: Date) -> Double {
-		return self.timeIntervalSince(date)
+		return timeIntervalSince(date)
 	}
 	
 	/// SwifterSwift: get number of minutes between two date
@@ -765,7 +788,7 @@ public extension Date {
 	/// - Parameter date: date to compate self to.
 	/// - Returns: number of minutes between self and given date.
 	public func minutesSince(_ date: Date) -> Double {
-		return self.timeIntervalSince(date)/60
+		return timeIntervalSince(date)/60
 	}
 	
 	/// SwifterSwift: get number of hours between two date
@@ -773,7 +796,7 @@ public extension Date {
 	/// - Parameter date: date to compate self to.
 	/// - Returns: number of hours between self and given date.
 	public func hoursSince(_ date: Date) -> Double {
-		return self.timeIntervalSince(date)/3600
+		return timeIntervalSince(date)/3600
 	}
 	
 	/// SwifterSwift: get number of days between two date
@@ -781,23 +804,22 @@ public extension Date {
 	/// - Parameter date: date to compate self to.
 	/// - Returns: number of days between self and given date.
 	public func daysSince(_ date: Date) -> Double {
-		return self.timeIntervalSince(date)/(3600*24)
+		return timeIntervalSince(date)/(3600*24)
 	}
-    
-  /// SwifterSwift: check if a date is between two other dates
-  ///
-  /// - Parameters:
-  ///   - startDate: start date to compare self to.
-  ///   - endDate: endDate date to compare self to.
-  ///   - includeBounds: true if the start and end date should be included (default is false)
-  /// - Returns: true if the date is between the two given dates.
-  public func isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = false) -> Bool {
-      if includeBounds {
-          return startDate.compare(self).rawValue * self.compare(endDate).rawValue >= 0
-      } else {
-          return startDate.compare(self).rawValue * self.compare(endDate).rawValue > 0
-      }
-  }
+	
+	/// SwifterSwift: check if a date is between two other dates
+	///
+	/// - Parameters:
+	///   - startDate: start date to compare self to.
+	///   - endDate: endDate date to compare self to.
+	///   - includeBounds: true if the start and end date should be included (default is false)
+	/// - Returns: true if the date is between the two given dates.
+	public func isBetween(_ startDate: Date, _ endDate: Date, includeBounds: Bool = false) -> Bool {
+		if includeBounds {
+			return startDate.compare(self).rawValue * compare(endDate).rawValue >= 0
+		}
+		return startDate.compare(self).rawValue * compare(endDate).rawValue > 0
+	}
 	
 	/// SwifterSwift: check if a date is a number of date components of another date
 	///
@@ -806,12 +828,10 @@ public extension Date {
 	///   - component: Calendar.Component to use.
 	///   - date: Date to compare self to.
 	/// - Returns: true if the date is within a number of components of another date
-	
 	public func isWithin(_ value: UInt, _ component: Calendar.Component, of date: Date) -> Bool {
-		return calendar
-			.dateComponents([component], from: self, to: date)
-			.value(for: component)
-			.map { abs($0) <= value } ?? false
+		let components = Calendar.current.dateComponents([component], from: self, to: date)
+		let componentValue = components.value(for: component)!
+		return abs(componentValue) <= value
 	}
 }
 

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -51,13 +51,19 @@ public extension Date {
 	}
 	
 	/// SwifterSwift: Quarter.
+	///
+	///		Date().quarter -> 3 // date in third quarter of the year.
+	///
 	public var quarter: Int {
-		return Calendar.current.component(.quarter, from: self)
+		let month = Double(Calendar.current.component(.month, from: self))
+		let numberOfMonths = Double(Calendar.current.monthSymbols.count)
+		let numberOfMonthsInQuarter = numberOfMonths / 4
+		return Int(ceil(month/numberOfMonthsInQuarter))
 	}
 	
 	/// SwifterSwift: Week of year.
 	///
-	///		Date().weekOfYear -> 2 // second week in the current year.
+	///		Date().weekOfYear -> 2 // second week in the year.
 	///
 	public var weekOfYear: Int {
 		return Calendar.current.component(.weekOfYear, from: self)
@@ -65,7 +71,7 @@ public extension Date {
 	
 	/// SwifterSwift: Week of month.
 	///
-	///		Date().weekOfMonth -> 2 // second week in the current month.
+	///		Date().weekOfMonth -> 3 // date is in third week of the month.
 	///
 	public var weekOfMonth: Int {
 		return Calendar.current.component(.weekOfMonth, from: self)
@@ -83,6 +89,7 @@ public extension Date {
 			return Calendar.current.component(.year, from: self)
 		}
 		set {
+			guard newValue > 0 else { return }
 			let currentYear = Calendar.current.component(.year, from: self)
 			let yearsToAdd = newValue - currentYear
 			if let date = Calendar.current.date(byAdding: .year, value: yearsToAdd, to: self) {
@@ -103,7 +110,12 @@ public extension Date {
 			return Calendar.current.component(.month, from: self)
 		}
 		set {
-			if let date = Calendar.current.date(bySetting: .month, value: newValue, of: self) {
+			let allowedRange = Calendar.current.range(of: .month, in: .year, for: self)!
+			guard allowedRange.contains(newValue) else { return }
+
+			let currentMonth = Calendar.current.component(.month, from: self)
+			let monthsToAdd = newValue - currentMonth
+			if let date = Calendar.current.date(byAdding: .month, value: monthsToAdd, to: self) {
 				self = date
 			}
 		}
@@ -121,7 +133,12 @@ public extension Date {
 			return Calendar.current.component(.day, from: self)
 		}
 		set {
-			if let date = Calendar.current.date(bySetting: .day, value: newValue, of: self) {
+			let allowedRange = Calendar.current.range(of: .day, in: .month, for: self)!
+			guard allowedRange.contains(newValue) else { return }
+			
+			let currentDay = Calendar.current.component(.day, from: self)
+			let daysToAdd = newValue - currentDay
+			if let date = Calendar.current.date(byAdding: .day, value: daysToAdd, to: self) {
 				self = date
 			}
 		}
@@ -132,14 +149,7 @@ public extension Date {
 	/// 	Date().weekOfMonth -> 5 // fifth day in the current week.
 	///
 	public var weekday: Int {
-		get {
-			return Calendar.current.component(.weekday, from: self)
-		}
-		set {
-			if let date = Calendar.current.date(bySetting: .weekday, value: newValue, of: self) {
-				self = date
-			}
-		}
+		return Calendar.current.component(.weekday, from: self)
 	}
 	
 	/// SwifterSwift: Hour.
@@ -154,7 +164,12 @@ public extension Date {
 			return Calendar.current.component(.hour, from: self)
 		}
 		set {
-			if let date = Calendar.current.date(bySetting: .hour, value: newValue, of: self) {
+			let allowedRange = Calendar.current.range(of: .hour, in: .day, for: self)!
+			guard allowedRange.contains(newValue) else { return }
+
+			let currentHour = Calendar.current.component(.hour, from: self)
+			let hoursToAdd = newValue - currentHour
+			if let date = Calendar.current.date(byAdding: .hour, value: hoursToAdd, to: self) {
 				self = date
 			}
 		}
@@ -172,7 +187,9 @@ public extension Date {
 			return Calendar.current.component(.minute, from: self)
 		}
 		set {
-			guard newValue >= 0 && newValue < 60 else { return }
+			let allowedRange = Calendar.current.range(of: .minute, in: .hour, for: self)!
+			guard allowedRange.contains(newValue) else { return }
+			
 			let currentMinutes = Calendar.current.component(.minute, from: self)
 			let minutesToAdd = newValue - currentMinutes
 			if let date = Calendar.current.date(byAdding: .minute, value: minutesToAdd, to: self) {
@@ -193,7 +210,12 @@ public extension Date {
 			return Calendar.current.component(.second, from: self)
 		}
 		set {
-			if let date = Calendar.current.date(bySetting: .second, value: newValue, of: self) {
+			let allowedRange = Calendar.current.range(of: .second, in: .minute, for: self)!
+			guard allowedRange.contains(newValue) else { return }
+			
+			let currentSeconds = Calendar.current.component(.second, from: self)
+			let secondsToAdd = newValue - currentSeconds
+			if let date = Calendar.current.date(byAdding: .second, value: secondsToAdd, to: self) {
 				self = date
 			}
 		}
@@ -208,6 +230,8 @@ public extension Date {
 			return Calendar.current.component(.nanosecond, from: self)
 		}
 		set {
+			let allowedRange = Calendar.current.range(of: .nanosecond, in: .second, for: self)!
+			guard allowedRange.contains(newValue) else { return }
 			if let date = Calendar.current.date(bySetting: .nanosecond, value: newValue, of: self) {
 				self = date
 			}
@@ -221,6 +245,9 @@ public extension Date {
 		}
 		set {
 			let ns = newValue * 1000000
+			let allowedRange = Calendar.current.range(of: .nanosecond, in: .second, for: self)!
+			guard allowedRange.contains(ns) else { return }
+			
 			if let date = Calendar.current.date(bySetting: .nanosecond, value: ns, of: self) {
 				self = date
 			}
@@ -278,17 +305,17 @@ public extension Date {
 	}
 	
 	/// SwifterSwift: Check if date is within the current week.
-	public var isInThisWeek: Bool {
+	public var isInCurrentWeek: Bool {
 		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: .weekOfYear)
 	}
 	
 	/// SwifterSwift: Check if date is within the current month.
-	public var isInThisMonth: Bool {
+	public var isInCurrentMonth: Bool {
 		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: .month)
 	}
 	
 	/// SwifterSwift: Check if date is within the current year.
-	public var isInThisYear: Bool {
+	public var isInCurrentYear: Bool {
 		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: .year)
 	}
 	
@@ -333,7 +360,7 @@ public extension Date {
 	/// 	date.nearestTenMinutes // "5:50 PM"
 	///
 	public var nearestTenMinutes: Date {
-		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: self)
 		let min = components.minute!
 		components.minute? = min % 10 < 6 ? min - min % 10 : min + 10 - (min % 10)
 		components.second = 0
@@ -350,7 +377,7 @@ public extension Date {
 	/// 	date.nearestQuarterHour // "5:45 PM"
 	///
 	public var nearestQuarterHour: Date {
-		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: self)
 		let min = components.minute!
 		components.minute! = min % 15 < 8 ? min - min % 15 : min + 15 - (min % 15)
 		components.second = 0
@@ -367,7 +394,7 @@ public extension Date {
 	/// 	date.nearestHalfHour // "7:00 PM"
 	///
 	public var nearestHalfHour: Date {
-		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+		var components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: self)
 		let min = components.minute!
 		components.minute! = min % 30 < 15 ? min - min % 30 : min + 30 - (min % 30)
 		components.second = 0
@@ -438,7 +465,9 @@ public extension Date {
 	///   - component: component type.
 	///   - value: multiples of compnenet to add.
 	public mutating func add(_ component: Calendar.Component, value: Int) {
-		self = adding(component, value: value)
+		if let date = Calendar.current.date(byAdding: component, value: value, to: self) {
+			self = date
+		}
 	}
 	
 	/// SwifterSwift: Date by changing value of calendar component.
@@ -453,8 +482,58 @@ public extension Date {
 	///   - component: component type.
 	///   - value: new value of compnenet to change.
 	/// - Returns: original date after changing given component to given value.
-	public func changing(_ component: Calendar.Component, value: Int) -> Date? {
-		return Calendar.current.date(bySetting: component, value: value, of: self)
+	public func changing(_ component: Calendar.Component, value: Int) -> Date? {		
+		switch component {
+		case .nanosecond:
+			let allowedRange = Calendar.current.range(of: .nanosecond, in: .second, for: self)!
+			guard allowedRange.contains(value) else { return nil }
+			return Calendar.current.date(bySetting: .nanosecond, value: value, of: self)
+			
+		case .second:
+			let allowedRange = Calendar.current.range(of: .second, in: .minute, for: self)!
+			guard allowedRange.contains(value) else { return nil }
+			
+			let currentSeconds = Calendar.current.component(.second, from: self)
+			let secondsToAdd = value - currentSeconds
+			return Calendar.current.date(byAdding: .second, value: secondsToAdd, to: self)
+			
+		case .minute:
+			let allowedRange = Calendar.current.range(of: .minute, in: .hour, for: self)!
+			guard allowedRange.contains(value) else { return nil }
+			let currentMinutes = Calendar.current.component(.minute, from: self)
+			let minutesToAdd = value - currentMinutes
+			return Calendar.current.date(byAdding: .minute, value: minutesToAdd, to: self)
+			
+		case .hour:
+			let allowedRange = Calendar.current.range(of: .hour, in: .day, for: self)!
+			guard allowedRange.contains(value) else { return nil }
+			let currentHour = Calendar.current.component(.hour, from: self)
+			let hoursToAdd = value - currentHour
+			return Calendar.current.date(byAdding: .hour, value: hoursToAdd, to: self)
+			
+		case .day:
+			let allowedRange = Calendar.current.range(of: .day, in: .month, for: self)!
+			guard allowedRange.contains(value) else { return nil }
+			let currentDay = Calendar.current.component(.day, from: self)
+			let daysToAdd = value - currentDay
+			return Calendar.current.date(byAdding: .day, value: daysToAdd, to: self)
+			
+		case .month:
+			let allowedRange = Calendar.current.range(of: .month, in: .year, for: self)!
+			guard allowedRange.contains(value) else { return nil }
+			let currentMonth = Calendar.current.component(.month, from: self)
+			let monthsToAdd = value - currentMonth
+			return Calendar.current.date(byAdding: .month, value: monthsToAdd, to: self)
+			
+		case .year:
+			guard value > 0 else { return nil }
+			let currentYear = Calendar.current.component(.year, from: self)
+			let yearsToAdd = value - currentYear
+			return Calendar.current.date(byAdding: .year, value: yearsToAdd, to: self)
+			
+		default:
+			return Calendar.current.date(bySetting: component, value: value, of: self)
+		}
 	}
 	
 	/// SwifterSwift: Data at the beginning of calendar component.

--- a/Sources/Extensions/Foundation/Deprecated/FoundationDeprecated.swift
+++ b/Sources/Extensions/Foundation/Deprecated/FoundationDeprecated.swift
@@ -1,0 +1,31 @@
+//
+//  FoundationDeprecated.swift
+//  SwifterSwift
+//
+//  Created by Omar Albeik on 11/8/17.
+//  Copyright © 2017 SwifterSwift
+//
+
+import Foundation
+
+public extension Date {
+	
+	@available(*, deprecated: 4.1.0, message: "Use isInCurrentWeek instead", renamed: "isInCurrentWeek")
+	/// SwifterSwift: Check if date is within the current week.
+	public var isInThisWeek: Bool {
+		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: .weekOfYear)
+	}
+	
+	@available(*, deprecated: 4.1.0, message: "Use isInCurrentMonth instead", renamed: "isInCurrentMonth")
+	/// SwifterSwift: Check if date is within the current month.
+	public var isInThisMonth: Bool {
+		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: .month)
+	}
+	
+	@available(*, deprecated: 4.1.0, message: "Use isInCurrentYear instead", renamed: "isInCurrentYear")
+	/// SwifterSwift: Check if date is within the current year.
+	public var isInThisYear: Bool {
+		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: .year)
+	}
+	
+}

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		07263D5D1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
-		07263D5E1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
-		07263D5F1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
-		07263D601FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
+		0713066F1FB597920023A9D8 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */; };
+		071306701FB597920023A9D8 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */; };
+		071306711FB597920023A9D8 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */; };
+		071306721FB597920023A9D8 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */; };
 		0726D7771F7C199E0028CAB5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */; };
 		0726D77A1F7C24830028CAB5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */; };
 		0726D77B1F7C24840028CAB5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */; };
@@ -362,6 +362,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationDeprecated.swift; sourceTree = "<group>"; };
 		07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationDeprecated.swift; sourceTree = "<group>"; };
 		0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensions.swift; sourceTree = "<group>"; };
@@ -539,10 +540,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		07263D5B1FB3174D003CE515 /* Deprecated */ = {
+		071306651FB596600023A9D8 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
 				07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		0713066D1FB5977F0023A9D8 /* Deprecated */ = {
+			isa = PBXGroup;
+			children = (
+				0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */,
 			);
 			path = Deprecated;
 			sourceTree = "<group>";
@@ -599,6 +608,7 @@
 				07898B8D1F278E6300558C97 /* Sources */,
 				07C50CF21F5EAF7B00F46E5A /* Tests */,
 				07898B5E1F278D7600558C97 /* Products */,
+				071306651FB596600023A9D8 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -653,6 +663,7 @@
 		07B7F1651F5EB41600E6F910 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				0713066D1FB5977F0023A9D8 /* Deprecated */,
 				70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */,
 				07B7F16A1F5EB41600E6F910 /* DataExtensions.swift */,
 				07B7F16B1F5EB41600E6F910 /* DateExtensions.swift */,
@@ -1223,6 +1234,7 @@
 				07B7F19D1F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
 				07B7F21A1F5EB43C00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F2331F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
+				0713066F1FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F1971F5EB42000E6F910 /* UIImageExtensions.swift in Sources */,
 				077BA08A1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
@@ -1238,7 +1250,6 @@
 				07B7F2101F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F2141F5EB43C00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F19E1F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
-				07263D5D1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				07B7F20F1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F19C1F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1A51F5EB42000E6F910 /* UITextViewExtensions.swift in Sources */,
@@ -1282,6 +1293,7 @@
 				07B7F1B31F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
 				07B7F2081F5EB43C00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F2391F5EB45200E6F910 /* NSAttributedStringExtensions.swift in Sources */,
+				071306701FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F1AD1F5EB42000E6F910 /* UIImageExtensions.swift in Sources */,
 				077BA08B1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
@@ -1297,7 +1309,6 @@
 				07B7F1FE1F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F2021F5EB43C00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F1B41F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
-				07263D5E1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				07B7F1FD1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1B21F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1BB1F5EB42000E6F910 /* UITextViewExtensions.swift in Sources */,
@@ -1341,6 +1352,7 @@
 				07B7F1C91F5EB42200E6F910 /* UISearchBarExtensions.swift in Sources */,
 				07B7F1F61F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F22D1F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
+				071306711FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F1C31F5EB42200E6F910 /* UIImageExtensions.swift in Sources */,
 				077BA08C1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				9D4914851F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
@@ -1356,7 +1368,6 @@
 				07B7F1EC1F5EB43B00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F1F01F5EB43B00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F1CA1F5EB42200E6F910 /* UISegmentedControlExtensions.swift in Sources */,
-				07263D5F1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				07B7F1EB1F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1C81F5EB42200E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1D11F5EB42200E6F910 /* UITextViewExtensions.swift in Sources */,
@@ -1395,8 +1406,8 @@
 				07B7F21C1F5EB43E00E6F910 /* SwifterSwift.swift in Sources */,
 				07B7F1D91F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1E41F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
-				07263D601FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				9D4914861F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
+				071306721FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F2271F5EB44600E6F910 /* NSViewExtensions.swift in Sources */,
 				07B7F2211F5EB44600E6F910 /* CGFloatExtensions.swift in Sources */,
 			);

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07263D5D1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
+		07263D5E1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
+		07263D5F1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
+		07263D601FB3175F003CE515 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */; };
 		0726D7771F7C199E0028CAB5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */; };
 		0726D77A1F7C24830028CAB5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */; };
 		0726D77B1F7C24840028CAB5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */; };
@@ -351,6 +355,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationDeprecated.swift; sourceTree = "<group>"; };
 		0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensions.swift; sourceTree = "<group>"; };
 		074EAF1E1F7BA74600C74636 /* UIFontExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionsTest.swift; sourceTree = "<group>"; };
@@ -525,6 +530,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		07263D5B1FB3174D003CE515 /* Deprecated */ = {
+			isa = PBXGroup;
+			children = (
+				07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */,
+			);
+			path = Deprecated;
+			sourceTree = "<group>";
+		};
 		0726D7751F7C19880028CAB5 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
@@ -631,6 +644,7 @@
 		07B7F1651F5EB41600E6F910 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				07263D5B1FB3174D003CE515 /* Deprecated */,
 				07B7F16A1F5EB41600E6F910 /* DataExtensions.swift */,
 				07B7F16B1F5EB41600E6F910 /* DateExtensions.swift */,
 				07B7F1731F5EB41600E6F910 /* LocaleExtensions.swift */,
@@ -975,7 +989,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0910;
 				ORGANIZATIONNAME = SwifterSwift;
 				TargetAttributes = {
 					07898B5C1F278D7600558C97 = {
@@ -1213,6 +1227,7 @@
 				07B7F2101F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F2141F5EB43C00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F19E1F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
+				07263D5D1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				07B7F20F1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F19C1F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1A51F5EB42000E6F910 /* UITextViewExtensions.swift in Sources */,
@@ -1270,6 +1285,7 @@
 				07B7F1FE1F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F2021F5EB43C00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F1B41F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
+				07263D5E1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				07B7F1FD1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1B21F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1BB1F5EB42000E6F910 /* UITextViewExtensions.swift in Sources */,
@@ -1327,6 +1343,7 @@
 				07B7F1EC1F5EB43B00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F1F01F5EB43B00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F1CA1F5EB42200E6F910 /* UISegmentedControlExtensions.swift in Sources */,
+				07263D5F1FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				07B7F1EB1F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1C81F5EB42200E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1D11F5EB42200E6F910 /* UITextViewExtensions.swift in Sources */,
@@ -1364,6 +1381,7 @@
 				07B7F21C1F5EB43E00E6F910 /* SwifterSwift.swift in Sources */,
 				07B7F1D91F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1E41F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
+				07263D601FB3175F003CE515 /* FoundationDeprecated.swift in Sources */,
 				9D4914861F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
 				07B7F2271F5EB44600E6F910 /* NSViewExtensions.swift in Sources */,
 				07B7F2211F5EB44600E6F910 /* CGFloatExtensions.swift in Sources */,
@@ -1539,8 +1557,33 @@
 		07898B561F278CF900558C97 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -1548,6 +1591,29 @@
 		07898B571F278CF900558C97 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SWIFT_VERSION = 4.0;

--- a/Tests/FoundationTests/CalendarExtensionTest.swift
+++ b/Tests/FoundationTests/CalendarExtensionTest.swift
@@ -11,10 +11,6 @@ import XCTest
 
 class CalendarExtensionTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-    }
-    
     func testNumberOfDaysInAMonth() {
         let calendar = Calendar(identifier: .gregorian)
         let longMonths = [1, 3, 5, 7, 8, 10, 12]
@@ -32,4 +28,5 @@ class CalendarExtensionTests: XCTestCase {
         XCTAssert(calendar.numberOfDaysInMonth(for: febDate) == 28)
         XCTAssert(calendar.numberOfDaysInMonth(for: leapYearDate) == 29)
     }
+	
 }

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -57,37 +57,18 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date.era, 1)
 	}
 	
-	func testYear() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.year, 1970)
-		
-		date.year = 2000
-		XCTAssertEqual(date.year, 2000)
-		
-		date.year = 2017
-		XCTAssertEqual(date.year, 2017)
-		
-		date.year = 1988
-		XCTAssertEqual(date.year, 1988)
-	}
-	
 	func testQuarter() {
-		let date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.quarter, 0)
-	}
-	
-	func testMonth() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.month, 1)
-		
-		date.month = 2
-		XCTAssertEqual(date.month, 2)
-		
-		date.month = 14
-		XCTAssertEqual(date.month, 2)
-		
-		date.month = 1
-		XCTAssertEqual(date.month, 1)
+		let date1 = Date(timeIntervalSince1970: 0)
+		XCTAssertEqual(date1.quarter, 1)
+
+		let date2 = Calendar.current.date(byAdding: .month, value: 4, to: date1)
+		XCTAssertEqual(date2?.quarter, 2)
+
+		let date3 = Calendar.current.date(byAdding: .month, value: 8, to: date1)
+		XCTAssertEqual(date3?.quarter, 3)
+
+		let date4 = Calendar.current.date(byAdding: .month, value: 11, to: date1)
+		XCTAssertEqual(date4?.quarter, 4)
 	}
 	
 	func testWeekOfYear() {
@@ -112,106 +93,203 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(originalDate?.weekOfMonth, 1)
 	}
 	
-	func testWeekday() {
-		var date = Date(timeIntervalSince1970: 0)
-		date.weekday = 1
-		XCTAssertEqual(date.weekday, 1)
+	func testYear() {
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.year, 1970)
 		
-		date.weekday = -1
-		XCTAssertEqual(date.weekday, 1)
+		var isLowerComponentsValid: Bool {
+			guard date.month == 1 else { return false }
+			guard date.day == 2 else { return false }
+			guard date.hour == 3 else { return false }
+			guard date.minute == 46 else { return false }
+			guard date.second == 40 else { return false }
+			guard date.nanosecond == 123450040 else { return false }
+			return true
+		}
 		
-		date.weekday = 10
-		XCTAssertEqual(date.weekday, 1)
+		date.year = 2000
+		XCTAssertEqual(date.year, 2000)
+		XCTAssert(isLowerComponentsValid)
 		
-		date.weekday = 7
-		XCTAssertEqual(date.weekday, 7)
+		date.year = 2017
+		XCTAssertEqual(date.year, 2017)
+		XCTAssert(isLowerComponentsValid)
 		
-		date.weekday = 5
-		XCTAssertEqual(date.weekday, 5)
+		date.year = 1988
+		XCTAssertEqual(date.year, 1988)
+		XCTAssert(isLowerComponentsValid)
+		
+		date.year = -100
+		XCTAssertEqual(date.year, 1988)
+		XCTAssert(isLowerComponentsValid)
+		
+		date.year = 0
+		XCTAssertEqual(date.year, 1988)
+		XCTAssert(isLowerComponentsValid)
+	}
+	
+	func testMonth() {
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.month, 1)
+		
+		var isLowerComponentsValid: Bool {
+			guard date.day == 2 else { return false }
+			guard date.hour == 3 else { return false }
+			guard date.minute == 46 else { return false }
+			guard date.second == 40 else { return false }
+			guard date.nanosecond == 123450040 else { return false }
+			return true
+		}
+		
+		date.month = 2
+		XCTAssert(isLowerComponentsValid)
+
+		date.month = 14
+		XCTAssertEqual(date.month, 2)
+		XCTAssert(isLowerComponentsValid)
+		
+		date.month = 1
+		XCTAssertEqual(date.month, 1)
+		XCTAssert(isLowerComponentsValid)
+		
+		date.month = 0
+		XCTAssertEqual(date.month, 1)
+		XCTAssert(isLowerComponentsValid)
+		
+		date.month = -3
+		XCTAssertEqual(date.month, 1)
+		XCTAssert(isLowerComponentsValid)
 	}
 	
 	func testDay() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.day, 1)
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.day, 2)
 		
-		date.day = -3
-		XCTAssertEqual(date.day, 1)
-		
-		date.day = 45
-		XCTAssertEqual(date.day, 1)
+		var isLowerComponentsValid: Bool {
+			guard date.hour == 3 else { return false }
+			guard date.minute == 46 else { return false }
+			guard date.second == 40 else { return false }
+			guard date.nanosecond == 123450040 else { return false }
+			return true
+		}
 		
 		date.day = 4
 		XCTAssertEqual(date.day, 4)
-		
+		XCTAssert(isLowerComponentsValid)
+
 		date.day = 1
 		XCTAssertEqual(date.day, 1)
+		XCTAssert(isLowerComponentsValid)
+
+		date.day = 0
+		XCTAssertEqual(date.day, 1)
+		XCTAssert(isLowerComponentsValid)
+
+		date.day = -3
+		XCTAssertEqual(date.day, 1)
+		XCTAssert(isLowerComponentsValid)
+
+		date.day = 45
+		XCTAssertEqual(date.day, 1)
+		XCTAssert(isLowerComponentsValid)
+	}
+	
+	func testWeekday() {
+		let date = Date(timeIntervalSince1970: 100000)
+		XCTAssertEqual(date.weekday, 6)
 	}
 	
 	func testHour() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.hour, 0)
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.hour, 3)
+		
+		var isLowerComponentsValid: Bool {
+			guard date.minute == 46 else { return false }
+			guard date.second == 40 else { return false }
+			guard date.nanosecond == 123450040 else { return false }
+			return true
+		}
 		
 		date.hour = -3
-		XCTAssertEqual(date.hour, 0)
+		XCTAssertEqual(date.hour, 3)
+		XCTAssert(isLowerComponentsValid)
 		
 		date.hour = 25
-		XCTAssertEqual(date.hour, 0)
-		
+		XCTAssertEqual(date.hour, 3)
+		XCTAssert(isLowerComponentsValid)
+
 		date.hour = 4
 		XCTAssertEqual(date.hour, 4)
-		
+		XCTAssert(isLowerComponentsValid)
+
 		date.hour = 1
 		XCTAssertEqual(date.hour, 1)
+		XCTAssert(isLowerComponentsValid)
 	}
 	
 	func testMinute() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.minute, 0)
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.minute, 46)
+		
+		var isLowerComponentsValid: Bool {
+			guard date.second == 40 else { return false }
+			guard date.nanosecond == 123450040 else { return false }
+			return true
+		}
 		
 		date.minute = -3
-		XCTAssertEqual(date.minute, 0)
-		
+		XCTAssertEqual(date.minute, 46)
+		XCTAssert(isLowerComponentsValid)
+
 		date.minute = 71
-		XCTAssertEqual(date.minute, 0)
-		
+		XCTAssertEqual(date.minute, 46)
+		XCTAssert(isLowerComponentsValid)
+
 		date.minute = 4
 		XCTAssertEqual(date.minute, 4)
-		
+		XCTAssert(isLowerComponentsValid)
+
 		date.minute = 1
 		XCTAssertEqual(date.minute, 1)
+		XCTAssert(isLowerComponentsValid)
 	}
 	
 	func testSecond() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.second, 0)
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.second, 40)
+		
+		var isLowerComponentsValid: Bool {
+			guard date.nanosecond == 123450040 else { return false }
+			return true
+		}
 		
 		date.second = -3
-		XCTAssertEqual(date.second, 0)
-		
+		XCTAssertEqual(date.second, 40)
+		XCTAssert(isLowerComponentsValid)
+
 		date.second = 71
-		XCTAssertEqual(date.second, 0)
-		
+		XCTAssertEqual(date.second, 40)
+		XCTAssert(isLowerComponentsValid)
+
 		date.second = 12
 		XCTAssertEqual(date.second, 12)
-		
+		XCTAssert(isLowerComponentsValid)
+
 		date.second = 1
 		XCTAssertEqual(date.second, 1)
+		XCTAssert(isLowerComponentsValid)
 	}
 	
 	func testNanosecond() {
-		var date = Date(timeIntervalSince1970: 0)
-		XCTAssertEqual(date.nanosecond, 0)
+		var date = Date(timeIntervalSince1970: 100000.123450040)
+		XCTAssertEqual(date.nanosecond, 123450040)
 		
 		date.nanosecond = -3
-		XCTAssertEqual(date.nanosecond, 0)
+		XCTAssertEqual(date.nanosecond, 123450040)
 		
 		date.nanosecond = 10000
 		XCTAssert(date.nanosecond >= 1000)
 		XCTAssert(date.nanosecond <= 100000)
-		
-		date.nanosecond = 100
-		XCTAssert(date.nanosecond >= 10)
-		XCTAssert(date.nanosecond <= 1000)
 	}
 	
 	func testMillisecond() {
@@ -280,25 +358,25 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date.isInWeekday, !Calendar.current.isDateInWeekend(date))
 	}
 	
-	func testIsInThisWeek() {
+	func testIsInCurrentWeek() {
 		let date = Date()
-		XCTAssert(date.isInThisWeek)
+		XCTAssert(date.isInCurrentWeek)
 		let dateOneYearFromNow = date.adding(.year, value: 1)
-		XCTAssertFalse(dateOneYearFromNow.isInThisWeek)
+		XCTAssertFalse(dateOneYearFromNow.isInCurrentWeek)
 	}
 	
-	func testIsInThisMonth() {
+	func testIsInCurrentMonth() {
 		let date = Date()
-		XCTAssert(date.isInThisMonth)
+		XCTAssert(date.isInCurrentMonth)
 		let dateOneYearFromNow = date.adding(.year, value: 1)
-		XCTAssertFalse(dateOneYearFromNow.isInThisMonth)
+		XCTAssertFalse(dateOneYearFromNow.isInCurrentMonth)
 	}
 	
-	func testIsInThisYear() {
+	func testIsInCurrentYear() {
 		let date = Date()
-		XCTAssert(date.isInThisYear)
+		XCTAssert(date.isInCurrentYear)
 		let dateOneYearFromNow = date.adding(.year, value: 1)
-		XCTAssertFalse(dateOneYearFromNow.isInThisYear)
+		XCTAssertFalse(dateOneYearFromNow.isInCurrentYear)
 	}
 	
 	func testIso8601String() {
@@ -311,11 +389,11 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date.nearestFiveMinutes, date)
 		
 		let date2 = date.adding(.minute, value: 4) // adding 4 minutes
-		XCTAssertNotEqual(date2.nearestFiveMinutes, date)
-		XCTAssertEqual(date2.nearestFiveMinutes, date.adding(.minute, value: 5))
+		XCTAssertNotEqual(date2.nearestFiveMinutes, date2)
+		XCTAssertEqual(date2.nearestFiveMinutes, date2.adding(.minute, value: 1))
 		
 		let date3 = date.adding(.minute, value: 7) // adding 7 minutes
-		XCTAssertEqual(date3.nearestFiveMinutes, date.adding(.minute, value: 5))
+		XCTAssertEqual(date3.nearestFiveMinutes, date3.adding(.minute, value: -2))
 		
 		let date4 = date.adding(.hour, value: 1).adding(.minute, value: 2) // adding 1 hour and 2 minutes
 		XCTAssertEqual(date4.nearestFiveMinutes, date.adding(.hour, value: 1))
@@ -389,40 +467,45 @@ final class DateExtensionsTests: XCTestCase {
 	func testAdding() {
 		let date = Date(timeIntervalSince1970: 3610) // Jan 1, 1970, 3:00:10 AM
 		
+		XCTAssertEqual(date.adding(.second, value: 0), date)
 		let date1 = date.adding(.second, value: 10)
 		XCTAssertEqual(date1.second, date.second + 10)
 		XCTAssertEqual(date1.adding(.second, value: -10), date)
 		
+		XCTAssertEqual(date.adding(.minute, value: 0), date)
 		let date2 = date.adding(.minute, value: 10)
 		XCTAssertEqual(date2.minute, date.minute + 10)
 		XCTAssertEqual(date2.adding(.minute, value: -10), date)
 		
+		XCTAssertEqual(date.adding(.hour, value: 0), date)
 		let date3 = date.adding(.hour, value: 2)
 		XCTAssertEqual(date3.hour, date.hour + 2)
 		XCTAssertEqual(date3.adding(.hour, value: -2), date)
 		
+		XCTAssertEqual(date.adding(.day, value: 0), date)
 		let date4 = date.adding(.day, value: 2)
 		XCTAssertEqual(date4.day, date.day + 2)
 		XCTAssertEqual(date4.adding(.day, value: -2), date)
 		
+		XCTAssertEqual(date.adding(.weekOfYear, value: 0), date)
 		let date5 = date.adding(.weekOfYear, value: 1)
 		XCTAssertEqual(date5.day, date.day + 7)
 		XCTAssertEqual(date5.adding(.weekOfYear, value: -1), date)
 		
+		XCTAssertEqual(date.adding(.weekOfMonth, value: 0), date)
 		let date6 = date.adding(.weekOfMonth, value: 1)
 		XCTAssertEqual(date6.day, date.day + 7)
 		XCTAssertEqual(date6.adding(.weekOfMonth, value: -1), date)
 		
+		XCTAssertEqual(date.adding(.month, value: 0), date)
 		let date7 = date.adding(.month, value: 2)
 		XCTAssertEqual(date7.month, date.month + 2)
 		XCTAssertEqual(date7.adding(.month, value: -2), date)
 		
+		XCTAssertEqual(date.adding(.year, value: 0), date)
 		let date8 = date.adding(.year, value: 4)
 		XCTAssertEqual(date8.year, date.year + 4)
 		XCTAssertEqual(date8.adding(.year, value: -4), date)
-		
-		XCTAssertEqual(date.adding(.calendar, value: 10), date)
-		
 	}
 	
 	func testAdd() {
@@ -431,12 +514,16 @@ final class DateExtensionsTests: XCTestCase {
 		date.second = 10
 		date.add(.second, value: -1)
 		XCTAssertEqual(date.second, 9)
+		date.add(.second, value: 0)
+		XCTAssertEqual(date.second, 9)
 		
 		date.add(.second, value: 1)
 		XCTAssertEqual(date.second, 10)
 		
 		date.minute = 10
 		date.add(.minute, value: -1)
+		XCTAssertEqual(date.minute, 9)
+		date.add(.minute, value: 0)
 		XCTAssertEqual(date.minute, 9)
 		
 		date.add(.minute, value: 1)
@@ -445,12 +532,16 @@ final class DateExtensionsTests: XCTestCase {
 		date.hour = 10
 		date.add(.hour, value: -1)
 		XCTAssertEqual(date.hour, 9)
+		date.add(.hour, value: 0)
+		XCTAssertEqual(date.hour, 9)
 		
 		date.add(.hour, value: 1)
 		XCTAssertEqual(date.hour, 10)
 		
 		date.day = 10
 		date.add(.day, value: -1)
+		XCTAssertEqual(date.day, 9)
+		date.add(.day, value: 0)
 		XCTAssertEqual(date.day, 9)
 		
 		date.add(.day, value: 1)
@@ -459,12 +550,16 @@ final class DateExtensionsTests: XCTestCase {
 		date.month = 10
 		date.add(.month, value: -1)
 		XCTAssertEqual(date.month, 9)
+		date.add(.month, value: 0)
+		XCTAssertEqual(date.month, 9)
 		
 		date.add(.month, value: 1)
 		XCTAssertEqual(date.month, 10)
 		
 		date = Date()
 		date.add(.year, value: -1)
+		XCTAssertEqual(date.year, 2016)
+		date.add(.year, value: 0)
 		XCTAssertEqual(date.year, 2016)
 		
 		date.add(.year, value: 1)
@@ -474,6 +569,10 @@ final class DateExtensionsTests: XCTestCase {
 	func testChanging() {
 		let date = Date(timeIntervalSince1970: 0)
 		
+		XCTAssertNil(date.changing(.nanosecond, value: -10))
+		XCTAssertNotNil(date.changing(.nanosecond, value: 123450040))
+		XCTAssertEqual(date.changing(.nanosecond, value: 123450040)?.nanosecond, 123450040)
+
 		XCTAssertNil(date.changing(.second, value: -10))
 		XCTAssertNil(date.changing(.second, value: 70))
 		XCTAssertNotNil(date.changing(.second, value: 20))
@@ -499,8 +598,14 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertNotNil(date.changing(.month, value: 6))
 		XCTAssertEqual(date.changing(.month, value: 6)?.month, 6)
 		
+		XCTAssertNil(date.changing(.year, value: -2))
+		XCTAssertNil(date.changing(.year, value: 0))
 		XCTAssertNotNil(date.changing(.year, value: 2015))
 		XCTAssertEqual(date.changing(.year, value: 2015)?.year, 2015)
+		
+		let date1 = Date()
+		let date2 = date1.changing(.weekOfYear, value: 10)
+		XCTAssertEqual(date2, Calendar.current.date(bySetting: .weekOfYear, value: 10, of: date1))
 	}
 	
 	func testBeginning() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -814,23 +814,26 @@ final class DateExtensionsTests: XCTestCase {
 		let date1 = Date(timeIntervalSince1970: 60 * 60 * 24) // 1970-01-01T00:00:00.000Z
 		let date2 = date1.addingTimeInterval(60 * 60) // 1970-01-01T00:01:00.000Z, one hour later than date1
 		
-		//The regular
+		// The regular
 		XCTAssertFalse(date1.isWithin(1, .second, of: date2))
 		XCTAssertFalse(date1.isWithin(1, .minute, of: date2))
 		XCTAssert(date1.isWithin(1, .hour, of: date2))
 		XCTAssert(date1.isWithin(1, .day, of: date2))
 		
-		//The other way around
+		// The other way around
 		XCTAssertFalse(date2.isWithin(1, .second, of: date1))
 		XCTAssertFalse(date2.isWithin(1, .minute, of: date1))
 		XCTAssert(date2.isWithin(1, .hour, of: date1))
 		XCTAssert(date2.isWithin(1, .day, of: date1))
 		
-		//With itself
+		// With itself
 		XCTAssert(date1.isWithin(1, .second, of: date1))
 		XCTAssert(date1.isWithin(1, .minute, of: date1))
 		XCTAssert(date1.isWithin(1, .hour, of: date1))
 		XCTAssert(date1.isWithin(1, .day, of: date1))
+		
+		// Invalid
+		XCTAssertFalse(Date().isWithin(1, .calendar, of: Date()))
 	}
 	
 	func testNewDateFromComponenets() {


### PR DESCRIPTION
- Fixed a bug in `year` where setting year was resetting all smaller components to zero.
- Fixed a bug in `month` where setting month was resetting all smaller components to zero.
- Fixed a bug in `day` where setting day was resetting all smaller components to zero.
- Fixed a bug in `hour` where setting hour was resetting all smaller components to zero.
- Fixed a bug in `minute` where setting minute was resetting all smaller components to zero.
- Fixed a bug in `second` where setting second was resetting all smaller components to zero.
- Added validation to setters for properties above.
- Fixed the above bugs in `changing` method as well.
- Fixed a bug where `quarter` was returning 1 always.
- `weekday` is now get-only property.
- `isInThisWeek` has been renamed to `isInCurrentWeek`.
- `isInThisMonth` has been renamed to `isInCurrentMonth`.
- `isInThisYear` has been renamed to `isInCurrentYear`.
- Added more tests to edge cases.