### PR TITLE
Rename weekday to workweek

### DIFF
--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -273,7 +273,7 @@ public extension Date {
 	}
 	
 	/// SwifterSwift: Check if date is within a weekday period.
-	public var isInWeekday: Bool {
+	public var isInWorkweek: Bool {
 		return !Calendar.current.isDateInWeekend(self)
 	}
 	

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -273,7 +273,7 @@ public extension Date {
 	}
 	
 	/// SwifterSwift: Check if date is within a weekday period.
-	public var isInWorkweek: Bool {
+	public var isWorkday: Bool {
 		return !Calendar.current.isDateInWeekend(self)
 	}
 	

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -275,9 +275,9 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date.isInWeekend, Calendar.current.isDateInWeekend(date))
 	}
 	
-	func testisInWorkweek() {
+	func testisWorkday() {
 		let date = Date()
-		XCTAssertEqual(date.isInWorkweek, !Calendar.current.isDateInWeekend(date))
+		XCTAssertEqual(date.isWorkday, !Calendar.current.isDateInWeekend(date))
 	}
 	
 	func testIsInThisWeek() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -275,9 +275,9 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date.isInWeekend, Calendar.current.isDateInWeekend(date))
 	}
 	
-	func testIsInWeekday() {
+	func testisInWorkweek() {
 		let date = Date()
-		XCTAssertEqual(date.isInWeekday, !Calendar.current.isDateInWeekend(date))
+		XCTAssertEqual(date.isInWorkweek, !Calendar.current.isDateInWeekend(date))
 	}
 	
 	func testIsInThisWeek() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -275,7 +275,7 @@ final class DateExtensionsTests: XCTestCase {
 		XCTAssertEqual(date.isInWeekend, Calendar.current.isDateInWeekend(date))
 	}
 	
-	func testisWorkday() {
+	func testIsWorkday() {
 		let date = Date()
 		XCTAssertEqual(date.isWorkday, !Calendar.current.isDateInWeekend(date))
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.

As per [this wikipedia page](https://en.wikipedia.org/wiki/Workweek_and_weekend)

Another variant is `isAWorkday` or `isAWeekday`, but I think `isInWorkweek` works better with `isInWeekend`