### PR TITLE
Add extension to Calendar for number of days in year and number of months in year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file.
    -    Add `scaled(toMaxSize:)` to scale image to maximum size with respect to aspect ratio [#291](https://github.com/SwifterSwift/SwifterSwift/pull/291) by [buddax2](https://github.com/buddax2).
  - **Optional**
    - Add optional assignment operator `??=` [#296](https://github.com/SwifterSwift/SwifterSwift/pull/296) by [buddax2](https://github.com/buddax2).
+ - **Calendar**
+   - Add `numberOfDaysInMonth` [#311](https://github.com/SwifterSwift/SwifterSwift/pull/311) by [chaithanyaprathyush](https://github.com/chaithanyaprathyush).
+   - Add `numberOfMonthsInYear` [#315](https://github.com/SwifterSwift/SwifterSwift/pull/315) by [kaphacius](https://github.com/kaphacius).
+   - Add `numberOfDaysInYear` [#315](https://github.com/SwifterSwift/SwifterSwift/pull/315) by [kaphacius](https://github.com/kaphacius).
 
 > ### Bugfixes
 > N/A

--- a/Sources/Extensions/Foundation/CalendarExtensions.swift
+++ b/Sources/Extensions/Foundation/CalendarExtensions.swift
@@ -20,4 +20,23 @@ public extension Calendar {
     public func numberOfDaysInMonth(for date: Date) -> Int {
         return range(of: .day, in: .month, for: date)?.count ?? 0
     }
+    
+    /// SwifterSwift: Return the number of days in the year for specified 'Date'.
+    ///
+    /// - Parameter date: the date from which the year is obtained
+    /// - Returns: number of days in the year of 'date'
+    public func numberOfDaysInYear(for date: Date) -> Int {
+        return range(of: .day, in: .year, for: date)?.count ?? 0
+    }
+    
+    /// SwifterSwift: Return the number of months in a year for specified 'date'
+    ///
+    ///         let calendar = Calendar(identifier: .gregorian)
+    ///         calendar.numberOfMonthsInYear(for: Date()) -> 12
+    ///
+    /// - Parameter date: the date from which the year is obtained
+    /// - Returns: number of days in the year of 'date'
+    public func numberOfMonthsInYear(for date: Date) -> Int {
+        return range(of: .month, in: .year, for: date)?.count ?? 0
+    }
 }

--- a/Tests/FoundationTests/CalendarExtensionTest.swift
+++ b/Tests/FoundationTests/CalendarExtensionTest.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class CalendarExtensionTests: XCTestCase {
     
-    func testNumberOfDaysInAMonth() {
+    func testNumberOfDaysInMonth() {
         let calendar = Calendar(identifier: .gregorian)
         let longMonths = [1, 3, 5, 7, 8, 10, 12]
         let shortMonths = [4, 6, 9, 11]
@@ -28,5 +28,34 @@ class CalendarExtensionTests: XCTestCase {
         XCTAssert(calendar.numberOfDaysInMonth(for: febDate) == 28)
         XCTAssert(calendar.numberOfDaysInMonth(for: leapYearDate) == 29)
     }
-	
+    
+    func testNumberOfMonthsInYear() {
+        let gregorian = Calendar(identifier: .gregorian)
+        let hebrew = Calendar(identifier: .hebrew)
+        let ethiopic = Calendar(identifier: .ethiopicAmeteMihret)
+        let today = Date()
+        
+        XCTAssert(gregorian.numberOfMonthsInYear(for: today) == 12)
+        XCTAssert(hebrew.numberOfMonthsInYear(for: today) == 13)
+        XCTAssert(ethiopic.numberOfMonthsInYear(for: today) == 13)
+    }
+    
+    func testNumberOfDaysInYear() {
+        let gregorian = Calendar(identifier: .gregorian)
+        let gregorianLeapYearComps = DateComponents(year:2016, month: 2)
+        let gregorianLeapYear = gregorian.date(from: gregorianLeapYearComps)!
+        let gregorianNonLeapYearComps = DateComponents(year:2015, month: 2)
+        let gregorianNonLeapYear = gregorian.date(from: gregorianNonLeapYearComps)!
+        
+        XCTAssert(gregorian.numberOfDaysInYear(for: gregorianLeapYear) == 366)
+        XCTAssert(gregorian.numberOfDaysInYear(for: gregorianNonLeapYear) == 365)
+        
+        let chinese = Calendar(identifier: .chinese)
+        let chineseLeapYearComps = DateComponents(year: 2000, month: 2)
+        let chineseLeapYear = chinese.date(from: chineseLeapYearComps)!
+        let chineseNonLeapYearComps = DateComponents(year: 1999, month: 2)
+        let chineseNonLeapYear = chinese.date(from: chineseNonLeapYearComps)!
+        XCTAssert(chinese.numberOfDaysInYear(for: chineseLeapYear) == 384)
+        XCTAssert(chinese.numberOfDaysInYear(for: chineseNonLeapYear) == 354)
+    }
 }


### PR DESCRIPTION
2 extensions, apparently days in year and months in year can vary a lot (especially in chinese and hebrew calendars)

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
