### PR TITLE
Add write() method to NSImage extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ All notable changes to this project will be documented in this file.
 > N/A
 
 
+# Next Release
+
+### API Breaking
+N/A
+
+### Enhancements
+- New **NSImage** extensions:
+  - added `write(to url: URL, fileType type: _, compressionFactor: _)` to write NSImage to url. [#320](https://github.com/SwifterSwift/SwifterSwift/pulls/320) by [omaralbeik](https://github.com/omaralbeik).
+
+### Bugfixes
+N/A
+
+
+
 # 4.1.0
 
 ### API Breaking

--- a/Sources/Extensions/AppKit/NSImageExtensions.swift
+++ b/Sources/Extensions/AppKit/NSImageExtensions.swift
@@ -49,6 +49,22 @@ extension NSImage {
         // Return the new image
         return imageWithNewSize
     }
+	
+	/// SwifterSwift: Write NSImage to url.
+	///
+	/// - Parameters:
+	///   - url: Desired file URL.
+	///   - type: Type of image (default is .jpeg).
+	///   - compressionFactor: used only for JPEG files. The value is a float between 0.0 and 1.0, with 1.0 resulting in no compression and 0.0 resulting in the maximum compression possible.
+	public func write(to url: URL, fileType type: NSBitmapImageRep.FileType = .jpeg, compressionFactor: NSNumber = 1.0) {
+		// https://stackoverflow.com/a/45042611/3882644
+		
+		guard let data = tiffRepresentation else { return }
+		guard let imageRep = NSBitmapImageRep(data: data) else { return }
+		
+		guard let imageData = imageRep.representation(using: type, properties: [.compressionFactor : compressionFactor]) else { return }
+		try? imageData.write(to: url)
+	}
 }
 
 #endif

--- a/Sources/Extensions/AppKit/NSImageExtensions.swift
+++ b/Sources/Extensions/AppKit/NSImageExtensions.swift
@@ -62,7 +62,7 @@ extension NSImage {
 		guard let data = tiffRepresentation else { return }
 		guard let imageRep = NSBitmapImageRep(data: data) else { return }
 		
-		guard let imageData = imageRep.representation(using: type, properties: [.compressionFactor : compressionFactor]) else { return }
+		guard let imageData = imageRep.representation(using: type, properties: [.compressionFactor: compressionFactor]) else { return }
 		try? imageData.write(to: url)
 	}
 }


### PR DESCRIPTION
Add `write(to url: URL, fileType type: _, compressionFactor: _)` method to write NSImage to url.

- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a CHANGELOG entry describing my changes.