### PR TITLE
Add lighten and darken methods to Color extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ N/A
   - added `numberOfDaysInMonth` to get number of days in the month for a specified date. [#311](https://github.com/SwifterSwift/SwifterSwift/pull/311) by [chaithanyaprathyush](https://github.com/chaithanyaprathyush).
 - New **Color** tests
   - added tests for `cgFloatComponents`. [#297](https://github.com/SwifterSwift/SwifterSwift/pull/297) by [stupergenius](https://github.com/stupergenius).
+  - added `lighten(by percentage:)` and `darken(by percentage:)` methods to change the hue of a color. [#325](https://github.com/SwifterSwift/SwifterSwift/pull/325) by [oettingerj](https://github.com/oettingerj).
 - New **CGColor** tests
   - added tests for `uiColor` and `nsColor`. [#281](https://github.com/SwifterSwift/SwifterSwift/pull/281) by [c1phr](https://github.com/c1phr)
 - New **Date** tests

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -251,7 +251,7 @@ public extension Color {
     /// - Returns: A new Color that has been adjusted in hue by the given percentage
     public func adjust(by percentage: CGFloat) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0;
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         self.getRed(&r, green: &g, blue: &b, alpha: &a)
         return Color(red: max(min(r + percentage, 1.0), 0),
                        green: max(min(g + percentage, 1.0), 0),

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -252,14 +252,11 @@ public extension Color {
     public func adjust(by percentage: CGFloat) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0;
-        if(self.getRed(&r, green: &g, blue: &b, alpha: &a)) {
-            return Color(red: max(min(r + percentage, 1.0), 0),
-                           green: max(min(g + percentage, 1.0), 0),
-                           blue: max(min(b + percentage, 1.0), 0),
-                           alpha: a)
-        } else {
-            return self
-        }
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return Color(red: max(min(r + percentage, 1.0), 0),
+                       green: max(min(g + percentage, 1.0), 0),
+                       blue: max(min(b + percentage, 1.0), 0),
+                       alpha: a)
     }
 }
 

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -226,7 +226,12 @@ public extension Color {
     /// - Returns: A lightened color
     public func lighten(by percentage: CGFloat = 0.2) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
-        return self.adjust(by: abs(percentage) )
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return Color(red: min(r + percentage, 1.0),
+                     green: min(g + percentage, 1.0),
+                     blue: min(b + percentage, 1.0),
+                     alpha: a)
     }
     
     /// SwifterSwift: Darken a color
@@ -238,7 +243,12 @@ public extension Color {
     /// - Returns: A darkened color
     public func darken(by percentage: CGFloat = 0.2) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
-        return self.adjust(by: -1 * abs(percentage) )
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return Color(red: max(r - percentage, 0),
+                     green: max(g - percentage, 0),
+                     blue: max(b - percentage, 0),
+                     alpha: a)
     }
     
     /// SwifterSwift: Adjust the hue of a color

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -220,11 +220,11 @@ public extension Color {
     /// SwifterSwift: Lighten a color
     ///
     ///     let color = Color(red: r, green: g, blue: b, alpha: a)
-    ///     let lighterColor: Color = color.lighter(by: 20)
+    ///     let lighterColor: Color = color.lighten(by: 0.2)
     ///
     /// - Parameter percentage: Percentage by which to lighten the color
     /// - Returns: A lightened color
-    public func lighter(by percentage: CGFloat = 20.0) -> Color {
+    public func lighten(by percentage: CGFloat = 0.2) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
         return self.adjust(by: abs(percentage) )
     }
@@ -232,11 +232,11 @@ public extension Color {
     /// SwifterSwift: Darken a color
     ///
     ///     let color = Color(red: r, green: g, blue: b, alpha: a)
-    ///     let darkerColor: Color = color.darker(by: 20)
+    ///     let darkerColor: Color = color.darken(by: 0.2)
     ///
     /// - Parameter percentage: Percentage by which to darken the color
     /// - Returns: A darkened color
-    public func darker(by percentage: CGFloat = 20.0) -> Color {
+    public func darken(by percentage: CGFloat = 0.2) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
         return self.adjust(by: -1 * abs(percentage) )
     }
@@ -244,8 +244,8 @@ public extension Color {
     /// SwifterSwift: Adjust the hue of a color
     ///
     ///     let color = Color(red: r, green: g, blue: b, alpha: a)
-    ///     let lighterColor: Color = color.adjust(by: 20)
-    ///     let darkerColor: Color = color.adjust(by: -20)
+    ///     let lighterColor: Color = color.adjust(by: 0.2)
+    ///     let darkerColor: Color = color.adjust(by: -0.2)
     ///
     /// - Parameter percentage: Percentage to adjust the hue of the color
     /// - Returns: A new Color that has been adjusted in hue by the given percentage
@@ -253,9 +253,9 @@ public extension Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0;
         if(self.getRed(&r, green: &g, blue: &b, alpha: &a)) {
-            return Color(red: max(min(r + percentage/100, 1.0), 0),
-                           green: max(min(g + percentage/100, 1.0), 0),
-                           blue: max(min(b + percentage/100, 1.0), 0),
+            return Color(red: max(min(r + percentage, 1.0), 0),
+                           green: max(min(g + percentage, 1.0), 0),
+                           blue: max(min(b + percentage, 1.0), 0),
                            alpha: a)
         } else {
             return self

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -214,8 +214,53 @@ public extension Color {
 		let a = level1*a1 + level2*a2
 		
 		return Color(red: r, green: g, blue: b, alpha: a)
+        
 	}
-	
+    
+    /// SwifterSwift: Lighten a color
+    ///
+    ///     let color = Color(red: r, green: g, blue: b, alpha: a)
+    ///     let lighterColor: Color = color.lighter(by: 20)
+    ///
+    /// - Parameter percentage: Percentage by which to lighten the color
+    /// - Returns: A lightened color
+    public func lighter(by percentage: CGFloat = 20.0) -> Color {
+        // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
+        return self.adjust(by: abs(percentage) )
+    }
+    
+    /// SwifterSwift: Darken a color
+    ///
+    ///     let color = Color(red: r, green: g, blue: b, alpha: a)
+    ///     let darkerColor: Color = color.darker(by: 20)
+    ///
+    /// - Parameter percentage: Percentage by which to darken the color
+    /// - Returns: A darkened color
+    public func darker(by percentage: CGFloat = 20.0) -> Color {
+        // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
+        return self.adjust(by: -1 * abs(percentage) )
+    }
+    
+    /// SwifterSwift: Adjust the hue of a color
+    ///
+    ///     let color = Color(red: r, green: g, blue: b, alpha: a)
+    ///     let lighterColor: Color = color.adjust(by: 20)
+    ///     let darkerColor: Color = color.adjust(by: -20)
+    ///
+    /// - Parameter percentage: Percentage to adjust the hue of the color
+    /// - Returns: A new Color that has been adjusted in hue by the given percentage
+    public func adjust(by percentage: CGFloat) -> Color {
+        // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0;
+        if(self.getRed(&r, green: &g, blue: &b, alpha: &a)) {
+            return Color(red: max(min(r + percentage/100, 1.0), 0),
+                           green: max(min(g + percentage/100, 1.0), 0),
+                           blue: max(min(b + percentage/100, 1.0), 0),
+                           alpha: a)
+        } else {
+            return self
+        }
+    }
 }
 
 // MARK: - Initializers

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -250,24 +250,6 @@ public extension Color {
                      blue: max(b - percentage, 0),
                      alpha: a)
     }
-    
-    /// SwifterSwift: Adjust the hue of a color
-    ///
-    ///     let color = Color(red: r, green: g, blue: b, alpha: a)
-    ///     let lighterColor: Color = color.adjust(by: 0.2)
-    ///     let darkerColor: Color = color.adjust(by: -0.2)
-    ///
-    /// - Parameter percentage: Percentage to adjust the hue of the color
-    /// - Returns: A new Color that has been adjusted in hue by the given percentage
-    public func adjust(by percentage: CGFloat) -> Color {
-        // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        self.getRed(&r, green: &g, blue: &b, alpha: &a)
-        return Color(red: max(min(r + percentage, 1.0), 0),
-                       green: max(min(g + percentage, 1.0), 0),
-                       blue: max(min(b + percentage, 1.0), 0),
-                       alpha: a)
-    }
 }
 
 // MARK: - Initializers

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -271,6 +271,34 @@ final class ColorExtensionsTests: XCTestCase {
 		blendColor = Color.blend(color1, intensity1: 1.0, with: color2, intensity2: 0.0)
 		XCTAssertEqual(blendColor, color1)
 	}
+    
+    func testLighter() {
+        let color = Color.blue
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: nil)
+        
+        let lighterColor = color.lighter(by: 30)
+        var lightR: CGFloat = 0, lightG: CGFloat = 0, lightB: CGFloat = 0
+        lighterColor.getRed(&lightR, green: &lightG, blue: &lightB, alpha: nil)
+        
+        XCTAssertEqual(lightR, min(r + 0.3, 1.0))
+        XCTAssertEqual(lightG, min(g + 0.3, 1.0))
+        XCTAssertEqual(lightB, min(b + 0.3, 1.0))
+    }
+    
+    func testDarker() {
+        let color = Color.blue
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: nil)
+        
+        let darkerColor = color.darker(by: 30)
+        var darkR: CGFloat = 0, darkG: CGFloat = 0, darkB: CGFloat = 0
+        darkerColor.getRed(&darkR, green: &darkG, blue: &darkB, alpha: nil)
+        
+        XCTAssertEqual(darkR, max(r - 0.3, 0))
+        XCTAssertEqual(darkG, max(g - 0.3, 0))
+        XCTAssertEqual(darkB, max(b - 0.3, 0))
+    }
 	
 	// MARK: - Test initializers
 	func testInit() {

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -272,12 +272,12 @@ final class ColorExtensionsTests: XCTestCase {
 		XCTAssertEqual(blendColor, color1)
 	}
     
-    func testLighter() {
+    func testLighten() {
         let color = Color.blue
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
         color.getRed(&r, green: &g, blue: &b, alpha: nil)
         
-        let lighterColor = color.lighter(by: 30)
+        let lighterColor = color.lighten(by: 0.3)
         var lightR: CGFloat = 0, lightG: CGFloat = 0, lightB: CGFloat = 0
         lighterColor.getRed(&lightR, green: &lightG, blue: &lightB, alpha: nil)
         
@@ -286,12 +286,12 @@ final class ColorExtensionsTests: XCTestCase {
         XCTAssertEqual(lightB, min(b + 0.3, 1.0))
     }
     
-    func testDarker() {
+    func testDarken() {
         let color = Color.blue
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
         color.getRed(&r, green: &g, blue: &b, alpha: nil)
         
-        let darkerColor = color.darker(by: 30)
+        let darkerColor = color.darken(by: 0.3)
         var darkR: CGFloat = 0, darkG: CGFloat = 0, darkB: CGFloat = 0
         darkerColor.getRed(&darkR, green: &darkG, blue: &darkB, alpha: nil)
         


### PR DESCRIPTION
#324: Added Color extension methods to lighten and darken colors

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
