### PR TITLE
Removing shuffle and shuffled equatable Element constraint.

### DIFF
--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -404,34 +404,34 @@ public extension Array {
 	public mutating func rotate(by places: Int) {
 		self = rotated(by: places)
 	}
+    
+    /// SwifterSwift: Shuffle array. (Using Fisher-Yates Algorithm)
+    ///
+    ///        [1, 2, 3, 4, 5].shuffle() // shuffles array
+    ///
+    public mutating func shuffle() {
+        //http://stackoverflow.com/questions/37843647/shuffle-array-swift-3
+        guard count > 1 else { return }
+        for index in startIndex..<endIndex - 1 {
+            let randomIndex = Int(arc4random_uniform(UInt32(endIndex - index))) + index
+            if index != randomIndex { swapAt(index, randomIndex) }
+        }
+    }
+    
+    /// SwifterSwift: Shuffled version of array. (Using Fisher-Yates Algorithm)
+    ///
+    ///        [1, 2, 3, 4, 5].shuffled // return a shuffled version from given array e.g. [2, 4, 1, 3, 5].
+    ///
+    /// - Returns: the array with its elements shuffled.
+    public func shuffled() -> [Element] {
+        var array = self
+        array.shuffle()
+        return array
+    }
 }
 
 // MARK: - Methods (Equatable)
 public extension Array where Element: Equatable {
-	
-	/// SwifterSwift: Shuffle array. (Using Fisher-Yates Algorithm)
-	///
-	///		[1, 2, 3, 4, 5].shuffle() // shuffles array
-	///
-	public mutating func shuffle() {
-		//http://stackoverflow.com/questions/37843647/shuffle-array-swift-3
-		guard count > 1 else { return }
-		for index in startIndex..<endIndex - 1 {
-			let randomIndex = Int(arc4random_uniform(UInt32(endIndex - index))) + index
-			if index != randomIndex { swapAt(index, randomIndex) }
-		}
-	}
-	
-	/// SwifterSwift: Shuffled version of array. (Using Fisher-Yates Algorithm)
-	///
-	///		[1, 2, 3, 4, 5].shuffled // return a shuffled version from given array e.g. [2, 4, 1, 3, 5].
-	///
-	/// - Returns: the array with its elements shuffled.
-	public func shuffled() -> [Element] {
-		var array = self
-		array.shuffle()
-		return array
-	}
 	
 	/// SwifterSwift: Check if array contains an array of elements.
 	///


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
