### PR TITLE
Add dateString(withFormat:) to DateExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ N/A
 ### Enhancements
 - New **NSImage** extensions:
   - added `write(to url: URL, fileType type: _, compressionFactor: _)` to write NSImage to url. [#320](https://github.com/SwifterSwift/SwifterSwift/pulls/320) by [omaralbeik](https://github.com/omaralbeik).
-
+- New **Date** extensions
+  - added `string(withFormat format: String)` method to get a string from a date with the given format
+  
 ### Bugfixes
 N/A
 

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -685,7 +685,7 @@ public extension Date {
 	///
 	/// - Parameter format: Date format (default is "dd/MM/yyyy").
 	/// - Returns: date string.
-	public func string(withFormat format: String = "dd/MM/yyyy HH:mm") -> String 
+	public func string(withFormat format: String = "dd/MM/yyyy HH:mm") -> String {
 		let dateFormatter = DateFormatter()
 		dateFormatter.dateFormat = format
 		return dateFormatter.string(from: self)

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -676,6 +676,20 @@ public extension Date {
 	public func isInCurrent(_ component: Calendar.Component) -> Bool {
 		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: component)
 	}
+    
+    /// SwifterSwift: Date string from date.
+    ///
+    ///      Date().dateString(withFormat: "dd/MM/yyyy") -> "1/12/17"
+    ///     Date().dateString(withFormat: "HH:mm") -> "23:50"
+    ///     Date().dateString(withFormat: "dd/MM/yyyy HH:mm") -> "1/12/17 23:50"
+    ///
+    /// - Parameter format: Date format (default is "dd/MM/yyyy").
+    /// - Returns: date string.
+    public func dateString(withFormat format: String = "dd/MM/yyyy") -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = format
+        return dateFormatter.string(from: self)
+    }
 	
 	/// SwifterSwift: Date string from date.
 	///

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -676,21 +676,21 @@ public extension Date {
 	public func isInCurrent(_ component: Calendar.Component) -> Bool {
 		return Calendar.current.isDate(self, equalTo: Date(), toGranularity: component)
 	}
-    
-    /// SwifterSwift: Date string from date.
-    ///
-    ///      Date().dateString(withFormat: "dd/MM/yyyy") -> "1/12/17"
-    ///     Date().dateString(withFormat: "HH:mm") -> "23:50"
-    ///     Date().dateString(withFormat: "dd/MM/yyyy HH:mm") -> "1/12/17 23:50"
-    ///
-    /// - Parameter format: Date format (default is "dd/MM/yyyy").
-    /// - Returns: date string.
-    public func string(withFormat format: String = "dd/MM/yyyy HH:mm") -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = format
-        return dateFormatter.string(from: self)
-    }
-	
+
+	/// SwifterSwift: Date string from date.
+	///
+	///     Date().string(withFormat: "dd/MM/yyyy") -> "1/12/17"
+	///     Date().string(withFormat: "HH:mm") -> "23:50"
+	///     Date().string(withFormat: "dd/MM/yyyy HH:mm") -> "1/12/17 23:50"
+	///
+	/// - Parameter format: Date format (default is "dd/MM/yyyy").
+	/// - Returns: date string.
+	public func string(withFormat format: String = "dd/MM/yyyy HH:mm") -> String 
+		let dateFormatter = DateFormatter()
+		dateFormatter.dateFormat = format
+		return dateFormatter.string(from: self)
+	}
+
 	/// SwifterSwift: Date string from date.
 	///
 	/// 	Date().dateString(ofStyle: .short) -> "1/12/17"

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -685,7 +685,7 @@ public extension Date {
     ///
     /// - Parameter format: Date format (default is "dd/MM/yyyy").
     /// - Returns: date string.
-    public func dateString(withFormat format: String = "dd/MM/yyyy") -> String {
+    public func string(withFormat format: String = "dd/MM/yyyy HH:mm") -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = format
         return dateFormatter.string(from: self)

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -688,6 +688,17 @@ final class DateExtensionsTests: XCTestCase {
 		
 		formatter.dateStyle = .full
 		XCTAssertEqual(date.dateString(ofStyle: .full), formatter.string(from: date))
+        
+        formatter.dateStyle = .none
+        
+        formatter.dateFormat = "dd/MM/yyyy"
+        XCTAssertEqual(date.dateString(withFormat: "dd/MM/yyyy"), formatter.string(from: date))
+        
+        formatter.dateFormat = "HH:mm"
+        XCTAssertEqual(date.dateString(withFormat: "HH:mm"), formatter.string(from: date))
+        
+        formatter.dateFormat = "dd/MM/yyyy HH:mm"
+        XCTAssertEqual(date.dateString(withFormat: "dd/MM/yyyy HH:mm"), formatter.string(from: date))
 	}
 	
 	func testDateTimeString() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -692,13 +692,16 @@ final class DateExtensionsTests: XCTestCase {
         formatter.dateStyle = .none
         
         formatter.dateFormat = "dd/MM/yyyy"
-        XCTAssertEqual(date.dateString(withFormat: "dd/MM/yyyy"), formatter.string(from: date))
+        XCTAssertEqual(date.string(withFormat: "dd/MM/yyyy"), formatter.string(from: date))
         
         formatter.dateFormat = "HH:mm"
-        XCTAssertEqual(date.dateString(withFormat: "HH:mm"), formatter.string(from: date))
+        XCTAssertEqual(date.string(withFormat: "HH:mm"), formatter.string(from: date))
         
         formatter.dateFormat = "dd/MM/yyyy HH:mm"
-        XCTAssertEqual(date.dateString(withFormat: "dd/MM/yyyy HH:mm"), formatter.string(from: date))
+        XCTAssertEqual(date.string(withFormat: "dd/MM/yyyy HH:mm"), formatter.string(from: date))
+        
+        formatter.dateFormat = "iiiii"
+        XCTAssertEqual(date.string(withFormat: "iiiii"), formatter.string(from: date))
 	}
 	
 	func testDateTimeString() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -689,19 +689,19 @@ final class DateExtensionsTests: XCTestCase {
 		formatter.dateStyle = .full
 		XCTAssertEqual(date.dateString(ofStyle: .full), formatter.string(from: date))
         
-        formatter.dateStyle = .none
-        
-        formatter.dateFormat = "dd/MM/yyyy"
-        XCTAssertEqual(date.string(withFormat: "dd/MM/yyyy"), formatter.string(from: date))
-        
-        formatter.dateFormat = "HH:mm"
-        XCTAssertEqual(date.string(withFormat: "HH:mm"), formatter.string(from: date))
-        
-        formatter.dateFormat = "dd/MM/yyyy HH:mm"
-        XCTAssertEqual(date.string(withFormat: "dd/MM/yyyy HH:mm"), formatter.string(from: date))
-        
-        formatter.dateFormat = "iiiii"
-        XCTAssertEqual(date.string(withFormat: "iiiii"), formatter.string(from: date))
+		formatter.dateStyle = .none
+
+		formatter.dateFormat = "dd/MM/yyyy"
+		XCTAssertEqual(date.string(withFormat: "dd/MM/yyyy"), formatter.string(from: date))
+
+		formatter.dateFormat = "HH:mm"
+		XCTAssertEqual(date.string(withFormat: "HH:mm"), formatter.string(from: date))
+
+		formatter.dateFormat = "dd/MM/yyyy HH:mm"
+		XCTAssertEqual(date.string(withFormat: "dd/MM/yyyy HH:mm"), formatter.string(from: date))
+
+		formatter.dateFormat = "iiiii"
+		XCTAssertEqual(date.string(withFormat: "iiiii"), formatter.string(from: date))
 	}
 	
 	func testDateTimeString() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
