### PR TITLE
Attributes getter for NSAttributedString Issue #333

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 N/A
 
 ### Enhancements
+- New **NSAttributedString**
+  - added `attributes' property to get the attributes that apply to a simple NSAttributedString [#333](https://github.com/SwifterSwift/SwifterSwift/issues/333) by [nathanbacon](https://github.com/nathanbacon).
 - Enhanced **Array** extensions:
   - `shuffle` and `shuffled` are no more constrained to Equatable. [#327](https://github.com/SwifterSwift/SwifterSwift/pull/327) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - New **String** extensions:

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -38,6 +38,11 @@ public extension NSAttributedString {
 	public var struckthrough: NSAttributedString {
 		return applying(attributes: [.strikethroughStyle: NSNumber(value: NSUnderlineStyle.styleSingle.rawValue as Int)])
 	}
+    
+    /// SwifterSwift: Dictionary of the attributes applied across the whole string
+    public var attributes: [NSAttributedStringKey: Any] {
+        return attributes(at: 0, effectiveRange: nil)
+    }
 }
 
 // MARK: - Methods

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -118,4 +118,31 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 		XCTAssertEqual(filteredAttributes.count, 1)
 	}
 	#endif
+    
+    #if !os(macOS)
+    func testAttributes() {
+        let attrString = NSAttributedString(string: "Test String").bolded.struckthrough.underlined.colored(with: UIColor.blue)
+        let attributes = attrString.attributes
+
+        XCTAssertEqual(attributes.count, 4)
+
+        let filteredAttributes = attributes.filter { (key, value) -> Bool in
+            switch(key) {
+            case NSAttributedStringKey.underlineStyle:
+                return (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue
+            case NSAttributedStringKey.strikethroughStyle:
+                return (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue
+            case NSAttributedStringKey.font:
+                return (value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize)
+            case NSAttributedStringKey.foregroundColor:
+                return (value as? UIColor) == .blue
+            default:
+                return false
+            }
+        }
+
+        XCTAssertEqual(filteredAttributes.count, 4)
+        
+    }
+    #endif
 }

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -127,7 +127,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         XCTAssertEqual(attributes.count, 4)
 
         let filteredAttributes = attributes.filter { (key, value) -> Bool in
-            switch(key) {
+            switch key {
             case NSAttributedStringKey.underlineStyle:
                 return (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue
             case NSAttributedStringKey.strikethroughStyle:

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -15,7 +15,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testBolded() {
 		let string = NSAttributedString(string: "Bolded")
 		let out = string.bolded
-		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let attributes = out.attributes
 
 		let filterClosure: (NSAttributedStringKey, Any) -> Bool = {key, value in
 			return (key == NSAttributedStringKey.font && ((value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize)))
@@ -30,7 +30,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testUnderlined() {
 		let string = NSAttributedString(string: "Underlined")
 		let out = string.underlined
-		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let attributes = out.attributes
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.underlineStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue)
 		}
@@ -43,7 +43,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testItalicized() {
 		let string = NSAttributedString(string: "Italicized")
 		let out = string.italicized
-		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let attributes = out.attributes
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.font && (value as? UIFont) == .italicSystemFont(ofSize: UIFont.systemFontSize))
 		}
@@ -56,7 +56,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testStruckthrough() {
 		let string = NSAttributedString(string: "Struck through")
 		let out = string.struckthrough
-		let attributes = out.attributes(at: 0, effectiveRange: nil)
+		let attributes = out.attributes
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.strikethroughStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue)
 		}
@@ -70,7 +70,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testColored() {
 		let string = NSAttributedString(string: "Colored")
 		var out = string.colored(with: .red)
-		var attributes = out.attributes(at: 0, effectiveRange: nil)
+		var attributes = out.attributes
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.foregroundColor && (value as? UIColor) == .red)
 		}
@@ -78,7 +78,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 		XCTAssertEqual(filteredAttributes.count, 1)
 
 		out = out.colored(with: .blue)
-		attributes = out.attributes(at: 0, effectiveRange: nil)
+		attributes = out.attributes
 		XCTAssertEqual(attributes[NSAttributedStringKey.foregroundColor] as? UIColor, UIColor.blue)
 		XCTAssertNotEqual(attributes[NSAttributedStringKey.foregroundColor] as? UIColor, .red)
 	}

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -15,7 +15,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testBolded() {
 		let string = NSAttributedString(string: "Bolded")
 		let out = string.bolded
-		let attributes = out.attributes
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
 
 		let filterClosure: (NSAttributedStringKey, Any) -> Bool = {key, value in
 			return (key == NSAttributedStringKey.font && ((value as? UIFont) == .boldSystemFont(ofSize: UIFont.systemFontSize)))
@@ -30,7 +30,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testUnderlined() {
 		let string = NSAttributedString(string: "Underlined")
 		let out = string.underlined
-		let attributes = out.attributes
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.underlineStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue)
 		}
@@ -43,7 +43,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testItalicized() {
 		let string = NSAttributedString(string: "Italicized")
 		let out = string.italicized
-		let attributes = out.attributes
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.font && (value as? UIFont) == .italicSystemFont(ofSize: UIFont.systemFontSize))
 		}
@@ -56,7 +56,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testStruckthrough() {
 		let string = NSAttributedString(string: "Struck through")
 		let out = string.struckthrough
-		let attributes = out.attributes
+		let attributes = out.attributes(at: 0, effectiveRange: nil)
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.strikethroughStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.styleSingle.rawValue)
 		}
@@ -70,7 +70,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	func testColored() {
 		let string = NSAttributedString(string: "Colored")
 		var out = string.colored(with: .red)
-		var attributes = out.attributes
+		var attributes = out.attributes(at: 0, effectiveRange: nil)
 		let filteredAttributes = attributes.filter { (key, value) -> Bool in
 			return (key == NSAttributedStringKey.foregroundColor && (value as? UIColor) == .red)
 		}
@@ -78,7 +78,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 		XCTAssertEqual(filteredAttributes.count, 1)
 
 		out = out.colored(with: .blue)
-		attributes = out.attributes
+		attributes = out.attributes(at: 0, effectiveRange: nil)
 		XCTAssertEqual(attributes[NSAttributedStringKey.foregroundColor] as? UIColor, UIColor.blue)
 		XCTAssertNotEqual(attributes[NSAttributedStringKey.foregroundColor] as? UIColor, .red)
 	}

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -119,7 +119,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 	}
 	#endif
     
-    #if !os(macOS)
+    #if !os(macOS) && !os(tvOS)
     func testAttributes() {
         let attrString = NSAttributedString(string: "Test String").bolded.struckthrough.underlined.colored(with: UIColor.blue)
         let attributes = attrString.attributes


### PR DESCRIPTION
This property gets the attributes of a simple NSAttributedString. It works by checking the attributes from the first character and assuming that applies for the rest of the string. Let me know if you'd take another approach. 
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
