### PR TITLE
Applying attributes to regex patterns and substrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ N/A
   - `shuffle` and `shuffled` are no more constrained to Equatable. [#327](https://github.com/SwifterSwift/SwifterSwift/pull/327) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - New **String** extensions:
   - added `loremIpsum(ofLength: )` static function to return a lorem ipsum string. [#318](https://github.com/SwifterSwift/SwifterSwift/issues/318) by [omaralbeik](https://github.com/omaralbeik).
+- New **NSAttributedString** extensions:
+  - added `applying(attributes: , toRangesMatching: )`  function to return an attributed string with attributes applied to substrings matching the passed regex pattern by [nathanbacon](https://github.com/nathanbacon).
+  - added `applying(attributes: , toOccurrencesOf: )`  function to return an attributed string with attributes applied to substrings matching the passed string by [nathanbacon](https://github.com/nathanbacon).
 - New **UIDatePicker** extensions:
   - added `textColor` to get and set the text color of a UIDatePicker. [#328](https://github.com/SwifterSwift/SwifterSwift/issues/328) by [omaralbeik](https://github.com/omaralbeik).
 - New **NSImage** extensions:

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -74,13 +74,15 @@ public extension NSAttributedString {
 	}
 	#endif
     
-    /// SwifterSwift
+    /// SwifterSwift: Apply attributes to substrings matching a regular expression
     ///
     /// - Parameters:
     ///   - attributes: Dictionary of attributes
     ///   - pattern: a regular expression to target
     /// - Returns: An NSAttributedString with attributes applied to substrings matching the pattern
-    public func applying(attributes: [NSAttributedStringKey: Any], toRangesMatching pattern: NSRegularExpression) -> NSAttributedString {
+    public func applying(attributes: [NSAttributedStringKey: Any], toRangesMatching pattern: String) -> NSAttributedString {
+        guard let pattern = try? NSRegularExpression(pattern: pattern, options: []) else { return self }
+        
         let matches = pattern.matches(in: string, options: [], range: NSRange(0..<length))
         let result = NSMutableAttributedString(attributedString: self)
         
@@ -91,20 +93,18 @@ public extension NSAttributedString {
         return result
     }
 
-    /// SwifterSwift: Apply attributes to occurrences matching a given string
+    /// SwifterSwift: Apply attributes to occurrences of a given string
     ///
     /// - Parameters:
     ///   - attributes: Dictionary of attributes
     ///   - target: a subsequence string for the attributes to be applied to
     /// - Returns: An NSAttributedString with attributes applied on the target string
     public func applying<T: StringProtocol>(attributes: [NSAttributedStringKey: Any], toOccurrencesOf target: T) -> NSAttributedString {
-        
-        guard let target = target as? String, let pattern = try? NSRegularExpression(pattern: target, options: []) else {
-            return self
-        }
+        let pattern = "\\Q\(target)\\E"
         
         return applying(attributes: attributes, toRangesMatching: pattern)
     }
+
 }
 
 // MARK: - Operators

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -74,6 +74,12 @@ public extension NSAttributedString {
 	}
 	#endif
     
+    /// SwifterSwift
+    ///
+    /// - Parameters:
+    ///   - attributes: Dictionary of attributes
+    ///   - pattern: a regular expression to target
+    /// - Returns: An NSAttributedString with attributes applied to substrings matching the pattern
     public func applying(attributes: [NSAttributedStringKey: Any], toRangesMatching pattern: NSRegularExpression) -> NSAttributedString {
         let matches = pattern.matches(in: string, options: [], range: NSRange(0..<length))
         let result = NSMutableAttributedString(attributedString: self)
@@ -84,11 +90,20 @@ public extension NSAttributedString {
         
         return result
     }
-    
+
+    /// SwifterSwift: Apply attributes to occurrences matching a given string
+    ///
+    /// - Parameters:
+    ///   - attributes: Dictionary of attributes
+    ///   - target: a subsequence string for the attributes to be applied to
+    /// - Returns: An NSAttributedString with attributes applied on the target string
     public func applying<T: StringProtocol>(attributes: [NSAttributedStringKey: Any], toOccurrencesOf target: T) -> NSAttributedString {
-        let pattern = NSRegularExpression(pattern: target as! String, options: [])
         
+        guard let target = target as? String, let pattern = try? NSRegularExpression(pattern: target, options: []) else {
+            return self
+        }
         
+        return applying(attributes: attributes, toRangesMatching: pattern)
     }
 }
 

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -73,6 +73,23 @@ public extension NSAttributedString {
 		return applying(attributes: [.foregroundColor: color])
 	}
 	#endif
+    
+    public func applying(attributes: [NSAttributedStringKey: Any], toRangesMatching pattern: NSRegularExpression) -> NSAttributedString {
+        let matches = pattern.matches(in: string, options: [], range: NSRange(0..<length))
+        let result = NSMutableAttributedString(attributedString: self)
+        
+        for match in matches {
+            result.addAttributes(attributes, range: match.range)
+        }
+        
+        return result
+    }
+    
+    public func applying<T: StringProtocol>(attributes: [NSAttributedStringKey: Any], toOccurrencesOf target: T) -> NSAttributedString {
+        let pattern = NSRegularExpression(pattern: target as! String, options: [])
+        
+        
+    }
 }
 
 // MARK: - Operators

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -101,7 +101,7 @@ public extension NSAttributedString {
     /// - Returns: An NSAttributedString with attributes applied on the target string
     public func applying<T: StringProtocol>(attributes: [NSAttributedStringKey: Any], toOccurrencesOf target: T) -> NSAttributedString {
         let pattern = "\\Q\(target)\\E"
-        
+
         return applying(attributes: attributes, toRangesMatching: pattern)
     }
 

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -87,7 +87,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
     
     #if !os(macOS) && !os(tvOS)
     func testApplyingToRegex() {
-        let email = "steve.job@apple.com"
+        let email = "steve.jobs@apple.com"
         let testString = NSAttributedString(string: "Your email is \(email)!").bolded
         let attributes: [NSAttributedStringKey: Any] = [.underlineStyle: NSUnderlineStyle.styleSingle.rawValue, .foregroundColor: UIColor.blue]
         let pattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -97,29 +97,34 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         let attrAtBeginning = attrTestString.attributes(at: 0, effectiveRange: nil)
         XCTAssert(attrAtBeginning.count == 1)
         
+        var passed = false
         // iterate through each range of attributes
         attrTestString.enumerateAttributes(in: NSRange(0..<attrTestString.length), options: .longestEffectiveRangeNotRequired) { attrs, range, _ in
             
             let emailFromRange = attrTestString.attributedSubstring(from: range).string
             
-            // exit if
-            guard attrs.count > attrAtBeginning.count else {
-                XCTAssertNotEqual(emailFromRange, email)
-                return
-            }
+            // exit if there are not more attributes for the subsequence than what was there originally
+            guard attrs.count > attrAtBeginning.count else { return }
 
+            // confirm that the string with the applied attributes is the email
             XCTAssertEqual(emailFromRange, email)
+            
+            // the range contains the email, check to make sure the attributes are there and correct
             for attr in attrs {
                 if attr.key == .underlineStyle {
                     XCTAssertEqual(attr.value as? NSUnderlineStyle.RawValue, NSUnderlineStyle.styleSingle.rawValue)
+                    passed = true
                 } else if attr.key == .foregroundColor {
                     XCTAssertEqual(attr.value as? UIColor, UIColor.blue)
+                    passed = true
                 } else if attr.key == .font {
                     XCTAssertEqual((attr.value as? UIFont), .boldSystemFont(ofSize: UIFont.systemFontSize))
                 } else {
-                    XCTAssert(false)
+                    passed = false
                 }
             }
+            
+            XCTAssert(passed)
         }
     }
     
@@ -129,27 +134,37 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         let attrGreeting = NSAttributedString(string: greeting).italicized.applying(
             attributes: [.underlineStyle: NSUnderlineStyle.styleSingle.rawValue,
                          .foregroundColor: UIColor.red], toOccurrencesOf: name)
+        
         let attrAtBeginning = attrGreeting.attributes(at: 0, effectiveRange: nil)
+        // assert that there is only one attribute at beginning from italics
         XCTAssertEqual(attrAtBeginning.count, 1)
         
+        var passed = false
+        // iterate through each range of attributes
         attrGreeting.enumerateAttributes(in: NSRange(0..<attrGreeting.length), options: .longestEffectiveRangeNotRequired) { attrs, range, _ in
+            // exit if there are not more attributes for the subsequence than what was there originally
             guard attrs.count > attrAtBeginning.count else { return }
             
+            // confirm that the attributed string is the name
             let stringAtRange = attrGreeting.attributedSubstring(from: range).string
             XCTAssertEqual(stringAtRange, name)
             
             for attr in attrs {
                 if attr.key == .underlineStyle {
                     XCTAssertEqual(attr.value as? NSUnderlineStyle.RawValue, NSUnderlineStyle.styleSingle.rawValue)
+                    passed = true
                 } else if attr.key == .foregroundColor {
                     XCTAssertEqual(attr.value as? UIColor, UIColor.red)
+                    passed = true
                 } else if attr.key == .font {
                     XCTAssertEqual((attr.value as? UIFont), .italicSystemFont(ofSize: UIFont.systemFontSize))
                 } else {
-                    XCTAssert(false)
+                    passed = false
                 }
             }
         }
+        
+        XCTAssert(passed)
     }
     #endif
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
These methods apply attributes to regex patterns or substrings. They can be used to highlight emails/websites, names, etc...

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
