### PR TITLE
Date extensions

### DIFF
--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -958,11 +958,7 @@ public extension Date {
     public init?(integerLiteral value: Int) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"
-        
-        if let date = formatter.date(from: String(value)) {
-            self = date
-        } else {
-            return nil
-        }
+        guard let date = formatter.date(from: String(value)) else { return nil }
+        self = date
     }
 }

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -952,3 +952,11 @@ public extension Date {
 	}
 	
 }
+
+extension Date: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        self = formatter.date(from: String(value)) ?? Date()
+    }
+}

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -950,17 +950,19 @@ public extension Date {
 	public init(unixTimestamp: Double) {
 		self.init(timeIntervalSince1970: unixTimestamp)
 	}
-	
-}
-
-extension Date: ExpressibleByIntegerLiteral {
+    
     /// SwifterSwift: Create date object from Int literal
     ///
-    ///     let date = Date(inegerLiteral: 2017_12_25) // "2017-12-25 00:00:00 +0000"
+    ///     let date = Date(integerLiteral: 2017_12_25) // "2017-12-25 00:00:00 +0000"
     /// - Parameter value: Int value, e.g. 20171225, or 2017_12_25 etc.
-    public init(integerLiteral value: Int) {
+    public init?(integerLiteral value: Int) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"
-        self = formatter.date(from: String(value)) ?? Date()
+        
+        if let date = formatter.date(from: String(value)) {
+            self = date
+        } else {
+            return nil
+        }
     }
 }

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -954,6 +954,10 @@ public extension Date {
 }
 
 extension Date: ExpressibleByIntegerLiteral {
+    /// SwifterSwift: Create date object from Int literal
+    ///
+    ///     let date = Date(inegerLiteral: 2017_12_25) // "2017-12-25 00:00:00 +0000"
+    /// - Parameter value: Int value, e.g. 20171225, or 2017_12_25 etc.
     public init(integerLiteral value: Int) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -876,16 +876,14 @@ final class DateExtensionsTests: XCTestCase {
     
     func testNewDateFromIntegerLiteral() {
         let date = Date(integerLiteral: 2017_12_25)
-        XCTAssertEqual(String(describing: date), "2017-12-25 00:00:00 +0000")
         
-        let date1 = Date(integerLiteral: 222)
-        let currentDate = Date()
+        XCTAssertNotNil(date)
         
-        let calendar = Calendar.current
+        if let date = date {
+            XCTAssertEqual(String(describing: date), "2017-12-25 00:00:00 +0000")
+        }
         
-        XCTAssertEqual(calendar.component(.day, from: date1), calendar.component(.day, from: currentDate))
-        XCTAssertEqual(calendar.component(.month, from: date1), calendar.component(.month, from: currentDate))
-        XCTAssertEqual(calendar.component(.year, from: date1), calendar.component(.year, from: currentDate))
+        XCTAssertNil(Date(integerLiteral: 222))
     }
 	
     func testRandom() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -873,6 +873,11 @@ final class DateExtensionsTests: XCTestCase {
 		let dateFromUnixTimestamp = Date(unixTimestamp: 512)
 		XCTAssertEqual(date, dateFromUnixTimestamp)
 	}
+    
+    func testNewDateFromIntegerLiteral() {
+        let date = Date(integerLiteral: 2017_12_25)
+        XCTAssertEqual(String(describing: date), "2017-12-25 00:00:00 +0000")
+    }
 	
     func testRandom() {
         var randomDate = Date.random()

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -877,6 +877,15 @@ final class DateExtensionsTests: XCTestCase {
     func testNewDateFromIntegerLiteral() {
         let date = Date(integerLiteral: 2017_12_25)
         XCTAssertEqual(String(describing: date), "2017-12-25 00:00:00 +0000")
+        
+        let date1 = Date(integerLiteral: 222)
+        let currentDate = Date()
+        
+        let calendar = Calendar.current
+        
+        XCTAssertEqual(calendar.component(.day, from: date1), calendar.component(.day, from: currentDate))
+        XCTAssertEqual(calendar.component(.month, from: date1), calendar.component(.month, from: currentDate))
+        XCTAssertEqual(calendar.component(.year, from: date1), calendar.component(.year, from: currentDate))
     }
 	
     func testRandom() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added Date() extension - initiazlier using Ineger literal. Provides Date init from Int like 20171225, or 2017_12_25
    
    * New extension added to DateExtensions.swift
    * Test added to DateExtensionsTests.swift

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [] All extensions are declared as **public**.
