### PR TITLE
operators for NSPredicate

### DIFF
--- a/Sources/Extensions/Foundation/NSPredicateExtensions.swift
+++ b/Sources/Extensions/Foundation/NSPredicateExtensions.swift
@@ -65,7 +65,7 @@ public extension NSPredicate {
     ///   - lhs: NSPredicate.
     ///   - rhs: NSPredicate.
     /// - Returns: NSCompoundPredicate
-    static public func ^ (lhs: NSPredicate, rhs: NSPredicate) -> NSCompoundPredicate {
+    static public func | (lhs: NSPredicate, rhs: NSPredicate) -> NSCompoundPredicate {
         return lhs.or(rhs)
     }
     

--- a/Sources/Extensions/Foundation/NSPredicateExtensions.swift
+++ b/Sources/Extensions/Foundation/NSPredicateExtensions.swift
@@ -38,3 +38,44 @@ public extension NSPredicate {
     }
     
 }
+
+// MARK: - Operators
+public extension NSPredicate {
+    
+    /// SwifterSwift: Returns a new predicate formed by NOT-ing the predicate.
+    /// - Parameters: rhs: NSPredicate to convert.
+    /// - Returns: NSCompoundPredicate
+    static public prefix func ! (rhs: NSPredicate) -> NSCompoundPredicate {
+        return rhs.not
+    }
+    
+    /// SwifterSwift: Returns a new predicate formed by AND-ing the argument to the predicate.
+    ///
+    /// - Parameters:
+    ///   - lhs: NSPredicate.
+    ///   - rhs: NSPredicate.
+    /// - Returns: NSCompoundPredicate
+    static public func + (lhs: NSPredicate, rhs: NSPredicate) -> NSCompoundPredicate {
+        return lhs.and(rhs)
+    }
+    
+    /// SwifterSwift: Returns a new predicate formed by OR-ing the argument to the predicate.
+    ///
+    /// - Parameters:
+    ///   - lhs: NSPredicate.
+    ///   - rhs: NSPredicate.
+    /// - Returns: NSCompoundPredicate
+    static public func ^ (lhs: NSPredicate, rhs: NSPredicate) -> NSCompoundPredicate {
+        return lhs.or(rhs)
+    }
+    
+    /// SwifterSwift: Returns a new predicate formed by remove the argument to the predicate.
+    ///
+    /// - Parameters:
+    ///   - lhs: NSPredicate.
+    ///   - rhs: NSPredicate.
+    /// - Returns: NSCompoundPredicate
+    static public func - (lhs: NSPredicate, rhs: NSPredicate) -> NSCompoundPredicate {
+        return lhs + !rhs
+    }
+}

--- a/Tests/FoundationTests/NSPredicateExtensionsTests.swift
+++ b/Tests/FoundationTests/NSPredicateExtensionsTests.swift
@@ -39,4 +39,41 @@ final class NSPredicateExtensionsTests: XCTestCase {
             XCTAssertEqual(subpredicates, [predicate1, predicate2])
         }
     }
+    
+    func testOperatorNot() {
+        let predicate = NSPredicate(format: "a < 7")
+        let notPredicate = !predicate
+        XCTAssert(notPredicate.compoundPredicateType == .not)
+        if let subpredicates = notPredicate.subpredicates as? [NSPredicate] {
+            XCTAssertEqual(subpredicates, [predicate])
+        }
+    }
+    
+    func testOperatorAndPredicate() {
+        let predicate1 = NSPredicate(format: "a < 7")
+        let predicate2 = NSPredicate(format: "a > 3")
+        let andPredicate = predicate1 + predicate2
+        XCTAssert(andPredicate.compoundPredicateType == .and)
+        if let subpredicates = andPredicate.subpredicates as? [NSPredicate] {
+            XCTAssertEqual(subpredicates, [predicate1, predicate2])
+        }
+    }
+    
+    func testOperatorOrPredicate() {
+        let predicate1 = NSPredicate(format: "a < 7")
+        let predicate2 = NSPredicate(format: "a > 3")
+        let orPredicate = predicate1 ^ predicate2
+        XCTAssert(orPredicate.compoundPredicateType == .or)
+        if let subpredicates = orPredicate.subpredicates as? [NSPredicate] {
+            XCTAssertEqual(subpredicates, [predicate1, predicate2])
+        }
+    }
+    
+    func testOperatorSubPredicate() {
+        let predicate1 = NSPredicate(format: "SELF BETWEEN{1,5}")
+        let predicate2 = NSPredicate(format: "SELF BETWEEN{3,6}")
+        let subPredicate = predicate1 - predicate2
+        XCTAssert(subPredicate.evaluate(with: 2))
+        XCTAssertFalse(subPredicate.evaluate(with: 4))
+    }
 }

--- a/Tests/FoundationTests/NSPredicateExtensionsTests.swift
+++ b/Tests/FoundationTests/NSPredicateExtensionsTests.swift
@@ -62,7 +62,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
     func testOperatorOrPredicate() {
         let predicate1 = NSPredicate(format: "a < 7")
         let predicate2 = NSPredicate(format: "a > 3")
-        let orPredicate = predicate1 ^ predicate2
+        let orPredicate = predicate1 | predicate2
         XCTAssert(orPredicate.compoundPredicateType == .or)
         if let subpredicates = orPredicate.subpredicates as? [NSPredicate] {
             XCTAssertEqual(subpredicates, [predicate1, predicate2])


### PR DESCRIPTION
support
!NSPredicate(format: "SELF BETWEEN{1,5}")
NSPredicate(format: "SELF BETWEEN{1,5}") + NSPredicate(format: "SELF BETWEEN{3,6}")
NSPredicate(format: "SELF BETWEEN{1,5}") - NSPredicate(format: "SELF BETWEEN{3,6}")
NSPredicate(format: "SELF BETWEEN{1,5}") ^ NSPredicate(format: "SELF BETWEEN{3,6}")

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.