### PR TITLE
UIDevice countryCode extension added

### DIFF
--- a/Sources/Extensions/UIKit/UIDeviceExtensions.swift
+++ b/Sources/Extensions/UIKit/UIDeviceExtensions.swift
@@ -10,7 +10,7 @@
 import UIKit
 public extension UIDevice {
     /// Show country code of current locale for device
-    static var countryCode: String? {
+    static var countryISOCode: String? {
         return (Locale.current as NSLocale).object(forKey: NSLocale.Key.countryCode) as? String
     }
 }

--- a/Sources/Extensions/UIKit/UIDeviceExtensions.swift
+++ b/Sources/Extensions/UIKit/UIDeviceExtensions.swift
@@ -1,0 +1,17 @@
+//
+//  UIDeviceExtensions.swift
+//  SwifterSwift
+//
+//  Created by Anton Novoselov on 31/12/2017.
+//  Copyright © 2017 SwifterSwift
+//
+
+#if os(iOS) || os(tvOS)
+import UIKit
+public extension UIDevice {
+    /// Show country code of current locale for device
+    static var countryCode: String? {
+        return (Locale.current as NSLocale).object(forKey: NSLocale.Key.countryCode) as? String
+    }
+}
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -321,6 +321,10 @@
 		182698AC1F8AB46E0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AD1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
+		18E0232E1FF90619003A3EA4 /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0232D1FF90619003A3EA4 /* UIDeviceExtensions.swift */; };
+		18E0232F1FF90693003A3EA4 /* UIDeviceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0232D1FF90619003A3EA4 /* UIDeviceExtensions.swift */; };
+		18E023341FF9071C003A3EA4 /* UIDeviceExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E023321FF906DD003A3EA4 /* UIDeviceExtensionsTests.swift */; };
+		18E023351FF9071F003A3EA4 /* UIDeviceExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E023321FF906DD003A3EA4 /* UIDeviceExtensionsTests.swift */; };
 		278CA08D1F9A9232004918BD /* NSImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA08C1F9A9232004918BD /* NSImageExtensions.swift */; };
 		278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */; };
 		70269A2B1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
@@ -484,6 +488,8 @@
 		07C50D2A1F5EB03200F46E5A /* NSViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtensionsTests.swift; sourceTree = "<group>"; };
 		07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedNumericExtensionsTests.swift; sourceTree = "<group>"; };
 		185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGColorExtensionsTests.swift; sourceTree = "<group>"; };
+		18E0232D1FF90619003A3EA4 /* UIDeviceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtensions.swift; sourceTree = "<group>"; };
+		18E023321FF906DD003A3EA4 /* UIDeviceExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtensionsTests.swift; sourceTree = "<group>"; };
 		278CA08C1F9A9232004918BD /* NSImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensions.swift; sourceTree = "<group>"; };
 		278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensionsTests.swift; sourceTree = "<group>"; };
 		70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensions.swift; sourceTree = "<group>"; };
@@ -690,6 +696,7 @@
 		07B7F1791F5EB41600E6F910 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				18E0232D1FF90619003A3EA4 /* UIDeviceExtensions.swift */,
 				07B7F17C1F5EB41600E6F910 /* UIAlertControllerExtensions.swift */,
 				07B7F17D1F5EB41600E6F910 /* UIBarButtonItemExtensions.swift */,
 				07B7F17E1F5EB41600E6F910 /* UIButtonExtensions.swift */,
@@ -765,6 +772,7 @@
 			isa = PBXGroup;
 			children = (
 				07C50D0E1F5EB03200F46E5A /* UIAlertControllerExtensionsTests.swift */,
+				18E023321FF906DD003A3EA4 /* UIDeviceExtensionsTests.swift */,
 				076AEC8C1FDB49480077D153 /* UIDatePickerExtensionsTests.swift */,
 				07C50D0F1F5EB03200F46E5A /* UIBarButtonExtensionsTests.swift */,
 				07C50D101F5EB03200F46E5A /* UIButtonExtensionsTests.swift */,
@@ -1254,6 +1262,7 @@
 				07B7F20D1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F19D1F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
 				07B7F21A1F5EB43C00E6F910 /* StringExtensions.swift in Sources */,
+				18E0232E1FF90619003A3EA4 /* UIDeviceExtensions.swift in Sources */,
 				07B7F2331F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				0713066F1FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F1971F5EB42000E6F910 /* UIImageExtensions.swift in Sources */,
@@ -1306,6 +1315,7 @@
 				07B7F1AA1F5EB42000E6F910 /* UIButtonExtensions.swift in Sources */,
 				07B7F2091F5EB43C00E6F910 /* URLExtensions.swift in Sources */,
 				07B7F1B11F5EB42000E6F910 /* UINavigationControllerExtensions.swift in Sources */,
+				18E0232F1FF90693003A3EA4 /* UIDeviceExtensions.swift in Sources */,
 				07B7F1B51F5EB42000E6F910 /* UISliderExtensions.swift in Sources */,
 				07B7F1A91F5EB42000E6F910 /* UIBarButtonItemExtensions.swift in Sources */,
 				07B7F1B81F5EB42000E6F910 /* UITabBarExtensions.swift in Sources */,
@@ -1460,6 +1470,7 @@
 				9D4914891F8515D100F3868F /* NSPredicateExtensionsTests.swift in Sources */,
 				07C50D571F5EB05000F46E5A /* ArrayExtensionsTests.swift in Sources */,
 				07C50D5F1F5EB05000F46E5A /* FloatExtensionsTests.swift in Sources */,
+				18E023341FF9071C003A3EA4 /* UIDeviceExtensionsTests.swift in Sources */,
 				07C50D371F5EB04700F46E5A /* UISegmentedControlExtensionsTests.swift in Sources */,
 				07C50D8E1F5EB06000F46E5A /* CGSizeExtensionsTests.swift in Sources */,
 				07C50D581F5EB05000F46E5A /* BoolExtensionsTests.swift in Sources */,
@@ -1507,6 +1518,7 @@
 				07C50D441F5EB04700F46E5A /* UICollectionViewExtensionsTests.swift in Sources */,
 				07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
 				07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
+				18E023351FF9071F003A3EA4 /* UIDeviceExtensionsTests.swift in Sources */,
 				07C50D451F5EB04700F46E5A /* ColorExtensionsTests.swift in Sources */,
 				07C50D491F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */,
 				07C50D561F5EB04700F46E5A /* UIViewExtensionsTests.swift in Sources */,

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -556,14 +556,15 @@ final class DateExtensionsTests: XCTestCase {
 		date.add(.month, value: 1)
 		XCTAssertEqual(date.month, 10)
 		
-		date = Date()
+        date = Date(timeIntervalSince1970: 1514764800)
+
 		date.add(.year, value: -1)
-		XCTAssertEqual(date.year, 2016)
+		XCTAssertEqual(date.year, 2017)
 		date.add(.year, value: 0)
-		XCTAssertEqual(date.year, 2016)
+		XCTAssertEqual(date.year, 2017)
 		
 		date.add(.year, value: 1)
-		XCTAssertEqual(date.year, 2017)
+		XCTAssertEqual(date.year, 2018)
 	}
 	
 	func testChanging() {

--- a/Tests/UIKitTests/UIDeviceExtensionsTests.swift
+++ b/Tests/UIKitTests/UIDeviceExtensionsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwifterSwift
 
 final class UIDeviceExtensionsTests: XCTestCase {
-    func testCountryCode() {
-        XCTAssertNotNil(UIDevice.countryCode)
+    func testCountryISOCode() {
+        XCTAssertNotNil(UIDevice.countryISOCode)
     }
 }

--- a/Tests/UIKitTests/UIDeviceExtensionsTests.swift
+++ b/Tests/UIKitTests/UIDeviceExtensionsTests.swift
@@ -1,0 +1,16 @@
+//
+//  UIDeviceExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Anton Novoselov on 31/12/2017.
+//  Copyright © 2017 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+final class UIDeviceExtensionsTests: XCTestCase {
+    func testCountryCode() {
+        XCTAssertNotNil(UIDevice.countryCode)
+    }
+}


### PR DESCRIPTION
Extension provides countryCode for current device as String

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
