### PR TITLE
DateExtensionsTests.swift fixed. currentYear - 1 is 2017 since today.

### DIFF
--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -556,16 +556,15 @@ final class DateExtensionsTests: XCTestCase {
 		date.add(.month, value: 1)
 		XCTAssertEqual(date.month, 10)
 		
-        var date1 = Date(integerLiteral: 2018_01_01)
-        XCTAssertNotNil(date1)
-        
-		date1!.add(.year, value: -1)
-		XCTAssertEqual(date1!.year, 2017)
-		date1!.add(.year, value: 0)
-		XCTAssertEqual(date1!.year, 2017)
+        date = Date(timeIntervalSince1970: 1514764800)
+
+		date.add(.year, value: -1)
+		XCTAssertEqual(date.year, 2017)
+		date.add(.year, value: 0)
+		XCTAssertEqual(date.year, 2017)
 		
-		date1!.add(.year, value: 1)
-		XCTAssertEqual(date1!.year, 2018)
+		date.add(.year, value: 1)
+		XCTAssertEqual(date.year, 2018)
 	}
 	
 	func testChanging() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -558,12 +558,12 @@ final class DateExtensionsTests: XCTestCase {
 		
 		date = Date()
 		date.add(.year, value: -1)
-		XCTAssertEqual(date.year, 2016)
+		XCTAssertEqual(date.year, 2017)
 		date.add(.year, value: 0)
-		XCTAssertEqual(date.year, 2016)
+		XCTAssertEqual(date.year, 2017)
 		
 		date.add(.year, value: 1)
-		XCTAssertEqual(date.year, 2017)
+		XCTAssertEqual(date.year, 2018)
 	}
 	
 	func testChanging() {

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -556,14 +556,16 @@ final class DateExtensionsTests: XCTestCase {
 		date.add(.month, value: 1)
 		XCTAssertEqual(date.month, 10)
 		
-		date = Date()
-		date.add(.year, value: -1)
-		XCTAssertEqual(date.year, 2017)
-		date.add(.year, value: 0)
-		XCTAssertEqual(date.year, 2017)
+        var date1 = Date(integerLiteral: 2018_01_01)
+        XCTAssertNotNil(date1)
+        
+		date1!.add(.year, value: -1)
+		XCTAssertEqual(date1!.year, 2017)
+		date1!.add(.year, value: 0)
+		XCTAssertEqual(date1!.year, 2017)
 		
-		date.add(.year, value: 1)
-		XCTAssertEqual(date.year, 2018)
+		date1!.add(.year, value: 1)
+		XCTAssertEqual(date1!.year, 2018)
 	}
 	
 	func testChanging() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I fixed issue in DateExtensionsTests.swift.
There're hardcoded values for date.add() method. I updated to actual values - 2017 (year-1), 2018 (current year)
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
