### PR TITLE
Renamed indexes(of:) to indices(of:) in ArrayExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to this project will be documented in this file.
 # Next Release
 
 ### API Breaking
-N/A
+- **Array**
+  - `indexes(of:)` has been renamed to `indices(of:)`. 
 
 ### Enhancements
 - New **NSAttributedString**

--- a/Examples/Examples.md
+++ b/Examples/Examples.md
@@ -10,8 +10,8 @@ Here are some examples:
 // Remove duplicates from an array
 [1, 2, 3, 1, 3].removeDuplicates() -> [1, 2, 3]
 
-// Return all indexes of specified item
-["h", "e", "l", "l", "o"].indexes(of: "l") -> [2, 3]
+// Return all indices of specified item
+["h", "e", "l", "l", "o"].indices(of: "l") -> [2, 3]
 
 // Shuffle an array
 ["h", "e", "l", "l", "o"].shuffled() -> ["e", "l", "o", "l", "h"]

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -496,23 +496,6 @@ public extension Array where Element: Equatable {
 		}
 		return found
 	}
-	
-	/// SwifterSwift: All indexes of specified item.
-	///
-	///		[1, 2, 2, 3, 4, 2, 5].indexes(of 2) -> [1, 2, 5]
-	///		[1.2, 2.3, 4.5, 3.4, 4.5].indexes(of 2.3) -> [1]
-	///		["h", "e", "l", "l", "o"].indexes(of "l") -> [2, 3]
-	///
-	/// - Parameter item: item to check.
-	/// - Returns: an array with all indexes of the given item.
-    @available(*, deprecated: 4.1.1, message: "Use indices(of:) instead", renamed: "indices(of:)")
-	public func indexes(of item: Element) -> [Int] {
-		var indexes: [Int] = []
-		for index in startIndex..<endIndex where self[index] == item {
-			indexes.append(index)
-		}
-		return indexes
-	}
     
     /// SwifterSwift: All indices of specified item.
     ///

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -505,6 +505,7 @@ public extension Array where Element: Equatable {
 	///
 	/// - Parameter item: item to check.
 	/// - Returns: an array with all indexes of the given item.
+    @available(*, deprecated: 4.1.1, message: "Use indices(of:) instead", renamed: "indices(of:)")
 	public func indexes(of item: Element) -> [Int] {
 		var indexes: [Int] = []
 		for index in startIndex..<endIndex where self[index] == item {
@@ -512,6 +513,22 @@ public extension Array where Element: Equatable {
 		}
 		return indexes
 	}
+    
+    /// SwifterSwift: All indices of specified item.
+    ///
+    ///        [1, 2, 2, 3, 4, 2, 5].indices(of 2) -> [1, 2, 5]
+    ///        [1.2, 2.3, 4.5, 3.4, 4.5].indices(of 2.3) -> [1]
+    ///        ["h", "e", "l", "l", "o"].indices(of "l") -> [2, 3]
+    ///
+    /// - Parameter item: item to check.
+    /// - Returns: an array with all indices of the given item.
+    public func indices(of item: Element) -> [Int] {
+        var indices: [Int] = []
+        for index in startIndex..<endIndex where self[index] == item {
+            indices.append(index)
+        }
+        return indices
+    }
 	
 	/// SwifterSwift: Remove all instances of an item from array.
 	///

--- a/Sources/Extensions/SwiftStdlib/Deprecated/SwiftStdlibDeprecated.swift
+++ b/Sources/Extensions/SwiftStdlib/Deprecated/SwiftStdlibDeprecated.swift
@@ -82,3 +82,23 @@ extension String {
     }
 
 }
+
+// MARK: - Methods (Equatable)
+public extension Array where Element: Equatable {
+    /// SwifterSwift: All indexes of specified item.
+    ///
+    ///        [1, 2, 2, 3, 4, 2, 5].indexes(of 2) -> [1, 2, 5]
+    ///        [1.2, 2.3, 4.5, 3.4, 4.5].indexes(of 2.3) -> [1]
+    ///        ["h", "e", "l", "l", "o"].indexes(of "l") -> [2, 3]
+    ///
+    /// - Parameter item: item to check.
+    /// - Returns: an array with all indexes of the given item.
+    @available(*, deprecated: 4.1.1, message: "Use indices(of:) instead", renamed: "indices(of:)")
+    public func indexes(of item: Element) -> [Int] {
+        var indexes: [Int] = []
+        for index in startIndex..<endIndex where self[index] == item {
+            indexes.append(index)
+        }
+        return indexes
+    }
+}

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -30,6 +30,11 @@ final class ArrayExtensionsTests: XCTestCase {
 	func testIndexes() {
 		XCTAssertEqual([1, 1, 2, 3, 4, 1, 2, 1].indexes(of: 1), [0, 1, 5, 7])
 	}
+    
+    func testIndices() {
+        XCTAssertEqual([1, 1, 2, 3, 4, 1, 2, 1].indices(of: 1), [0, 1, 5, 7])
+        XCTAssertEqual(["a", "b", "c", "b", "4", "1", "2", "1"].indices(of: "b"), [1, 3])
+    }
 	
 	func testLastIndex() {
 		XCTAssertNotNil([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 2))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Summary
Renamed method of `ArrayExtensions` `indexes(of:)` to `indices(of:)` since Apple's API is using that naming. There are few other usages in SwifterSwift project where _"indices"_ is used and this was only place where _"indexes"_ was used.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
