### PR TITLE
Blank string check methods added in String extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `sort(by: KeyPath)` and `sorted(by: KeyPath)` to sort arrays based on Swift 4 keyPath. [#343](https://github.com/SwifterSwift/SwifterSwift/pull/343) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **String**
   - Added `loremIpsum(ofLength: )` static function to return a lorem ipsum string. [#318](https://github.com/SwifterSwift/SwifterSwift/issues/318) by [omaralbeik](https://github.com/omaralbeik).
-  -  Added computed property `isBlank` to check if the given string is blank or not.
+  -  Added computed property `isWhitespace` to check if the given string is blank or not.[#363](https://github.com/SwifterSwift/SwifterSwift/pull/363) by [rkp1026](https://github.com/rkp1026).
 - **UIDatePicker**
   - Added `textColor` to get and set the text color of a UIDatePicker. [#328](https://github.com/SwifterSwift/SwifterSwift/issues/328) by [omaralbeik](https://github.com/omaralbeik).
 - **NSImage**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `sort(by: KeyPath)` and `sorted(by: KeyPath)` to sort arrays based on Swift 4 keyPath. [#343](https://github.com/SwifterSwift/SwifterSwift/pull/343) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **String**
   - Added `loremIpsum(ofLength: )` static function to return a lorem ipsum string. [#318](https://github.com/SwifterSwift/SwifterSwift/issues/318) by [omaralbeik](https://github.com/omaralbeik).
+  -  Added computed property `isBlank` to check if the given string is blank or not.
 - **UIDatePicker**
   - Added `textColor` to get and set the text color of a UIDatePicker. [#328](https://github.com/SwifterSwift/SwifterSwift/issues/328) by [omaralbeik](https://github.com/omaralbeik).
 - **NSImage**

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -318,6 +318,11 @@ public extension String {
 		return replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\n", with: "")
 	}
 	
+    /// SwifterSwift: Check if the given string is blank
+    /// "test string".isBlank -> false
+    public var isBlank: Bool {
+        return self.trimmingCharacters(in: .whitespaces).isEmpty
+    }
 }
 
 // MARK: - Methods

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -320,8 +320,8 @@ public extension String {
 	
     /// SwifterSwift: Check if the given string is blank
     /// "test string".isBlank -> false
-    public var isBlank: Bool {
-        return self.trimmingCharacters(in: .whitespaces).isEmpty
+    public var isWhitespace: Bool {
+        return self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -318,8 +318,7 @@ public extension String {
 		return replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "\n", with: "")
 	}
 	
-    /// SwifterSwift: Check if the given string is blank
-    /// "test string".isBlank -> false
+    /// SwifterSwift: Check if the given string contains only white spaces
     public var isWhitespace: Bool {
         return self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -654,11 +654,14 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(str, "str")
     }
     
-    func testBlankString() {
+    func testWhiteSpaces() {
         var str = "test string"
-        XCTAssertEqual(str.isBlank, false)
+        XCTAssertEqual(str.isWhitespace, false)
         
         str = "     "
-        XCTAssertEqual(str.isBlank, true)
+        XCTAssertEqual(str.isWhitespace, true)
+        
+        str = "   \n \n  "
+        XCTAssertEqual(str.isWhitespace, true)
     }
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -653,4 +653,12 @@ final class StringExtensionsTests: XCTestCase {
         str.padEnd(2)
         XCTAssertEqual(str, "str")
     }
+    
+    func testBlankString() {
+        var str = "test string"
+        XCTAssertEqual(str.isBlank, false)
+        
+        str = "     "
+        XCTAssertEqual(str.isBlank, true)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
