### PR TITLE
Query parameters getter for URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > # Upcoming release
 >
 > ### Added
++- **URL**
+ +  - Added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 > ### Changed
 > ### Deprecated
 > ### Removed
@@ -40,8 +42,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `random(from: Date, upTo: Date) -> Date` method that return radom date in in the specified range [#336](https://github.com/SwifterSwift/SwifterSwift/pull/336) by [akuzminskyi](https://github.com/akuzminskyi).
   - Added `string(withFormat format: String)` method to get a string from a date with the given format.
   - Added `init?(integerLiteral value: Int)` initializer to create date object from Int literal. [#342](https://github.com/SwifterSwift/SwifterSwift/pull/342) by [n0an](https://github.com/n0an).
-- **URL**
-  - Added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `random(from: Date, upTo: Date) -> Date` method that return radom date in in the specified range [#336](https://github.com/SwifterSwift/SwifterSwift/pull/336) by [akuzminskyi](https://github.com/akuzminskyi).
   - Added `string(withFormat format: String)` method to get a string from a date with the given format.
   - Added `init?(integerLiteral value: Int)` initializer to create date object from Int literal. [#342](https://github.com/SwifterSwift/SwifterSwift/pull/342) by [n0an](https://github.com/n0an).
+- **URL**
+  - Added `queryParmeters` property to get the query parameters from a URL as a dictionary by [nathanbacon](https://github.com/nathanbacon).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `string(withFormat format: String)` method to get a string from a date with the given format.
   - Added `init?(integerLiteral value: Int)` initializer to create date object from Int literal. [#342](https://github.com/SwifterSwift/SwifterSwift/pull/342) by [n0an](https://github.com/n0an).
 - **URL**
-  - Added `queryParmeters` property to get the query parameters from a URL as a dictionary by [nathanbacon](https://github.com/nathanbacon).
+  - Added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 
 ### Changed
 

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -18,7 +18,7 @@ public extension URL {
         var items: [String: String] = [:]
         
         for queryItem in queryItems {
-            items[queryItem.name] = queryItem.value ?? ""
+            items[queryItem.name] = queryItem.value
         }
         
         return items

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -12,13 +12,13 @@ import Foundation
 public extension URL {
     
     /// SwifterSwift: Dictionary of the URL's query parameters
-    public var queryParameters: [String: String?]? {
+    public var queryParameters: [String: String]? {
         guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems else { return nil }
         
-        var items: [String: String?] = [:]
+        var items: [String: String] = [:]
         
         for queryItem in queryItems {
-            items[queryItem.name] = queryItem.value
+            items[queryItem.name] = queryItem.value ?? ""
         }
         
         return items

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -38,5 +38,18 @@ public extension URL {
 	public mutating func appendQueryParameters(_ parameters: [String: String]) {
 		self = appendingQueryParameters(parameters)
 	}
+    
+    /// SwifterSwift: Dictionary of the URL's query parameters
+    public var queryParameters: [String: String]? {
+            guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems else { return nil }
+            
+            var items: [String: String] = [:]
+            
+            for queryItem in queryItems {
+                items[queryItem.name] = queryItem.value ?? ""
+            }
+            
+            return items
+    }
 	
 }

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -8,6 +8,23 @@
 
 import Foundation
 
+// MARK: - Properties
+public extension URL {
+    
+    /// SwifterSwift: Dictionary of the URL's query parameters
+    public var queryParameters: [String: String?]? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems else { return nil }
+        
+        var items: [String: String?] = [:]
+        
+        for queryItem in queryItems {
+            items[queryItem.name] = queryItem.value
+        }
+        
+        return items
+    }
+}
+
 // MARK: - Methods
 public extension URL {
 	
@@ -38,18 +55,5 @@ public extension URL {
 	public mutating func appendQueryParameters(_ parameters: [String: String]) {
 		self = appendingQueryParameters(parameters)
 	}
-    
-    /// SwifterSwift: Dictionary of the URL's query parameters
-    public var queryParameters: [String: String?]? {
-            guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems else { return nil }
-            
-            var items: [String: String?] = [:]
 
-            for queryItem in queryItems {
-                items[queryItem.name] = queryItem.value
-            }
-            
-            return items
-    }
-	
 }

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -40,13 +40,13 @@ public extension URL {
 	}
     
     /// SwifterSwift: Dictionary of the URL's query parameters
-    public var queryParameters: [String: String]? {
+    public var queryParameters: [String: String?]? {
             guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false), let queryItems = components.queryItems else { return nil }
             
-            var items: [String: String] = [:]
-            
+            var items: [String: String?] = [:]
+
             for queryItem in queryItems {
-                items[queryItem.name] = queryItem.value ?? ""
+                items[queryItem.name] = queryItem.value
             }
             
             return items

--- a/Sources/Extensions/UIKit/UIStoryboardExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStoryboardExtensions.swift
@@ -26,6 +26,6 @@ public extension UIStoryboard {
 	public func instantiateViewController<T: UIViewController>(withClass name: T.Type) -> T? {
 		return instantiateViewController(withIdentifier: String(describing: name)) as? T
 	}
-	
+
 }
 #endif

--- a/Sources/Extensions/UIKit/UIStoryboardExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStoryboardExtensions.swift
@@ -26,6 +26,6 @@ public extension UIStoryboard {
 	public func instantiateViewController<T: UIViewController>(withClass name: T.Type) -> T? {
 		return instantiateViewController(withIdentifier: String(describing: name)) as? T
 	}
-
+	
 }
 #endif

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -42,7 +42,7 @@ final class URLExtensionsTests: XCTestCase {
         }
         
         XCTAssertEqual(parameters.count, 2)
-        XCTAssertEqual(qValue, params["q"])
+        XCTAssertEqual(qValue, "swifter swift")
         XCTAssertEqual(steveValue, "jobs")
     }
 	

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -35,13 +35,15 @@ final class URLExtensionsTests: XCTestCase {
 	}
     
     func testQueryItemsVar() {
-        guard let parameters = queryUrl.queryParameters, let value = parameters["q"] else {
+        let url = URL(string: "https://www.google.com?q=swifter%20swift&steve=jobs")!
+        guard let parameters = url.queryParameters, let qValue = parameters["q"], let steveValue = parameters["steve"] else {
             XCTAssert(false)
             return
         }
         
-        XCTAssertEqual(parameters.count, 1)
-        XCTAssertEqual(value, params["q"])
+        XCTAssertEqual(parameters.count, 2)
+        XCTAssertEqual(qValue, params["q"])
+        XCTAssertEqual(steveValue, "jobs")
     }
 	
 }

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -33,5 +33,15 @@ final class URLExtensionsTests: XCTestCase {
 		url.appendQueryParameters(params)
 		XCTAssertEqual(url, queryUrl)
 	}
+    
+    func testQueryItemsVar() {
+        guard let parameters = queryUrl.queryParameters, let value = parameters["q"] else {
+            XCTAssert(false)
+            return
+        }
+        
+        XCTAssertEqual(parameters.count, 1)
+        XCTAssertEqual(value, params["q"])
+    }
 	
 }

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -34,7 +34,7 @@ final class URLExtensionsTests: XCTestCase {
 		XCTAssertEqual(url, queryUrl)
 	}
     
-    func testQueryItemsVar() {
+    func testQueryParameters() {
         let url = URL(string: "https://www.google.com?q=swifter%20swift&steve=jobs")!
         guard let parameters = url.queryParameters, let qValue = parameters["q"], let steveValue = parameters["steve"] else {
             XCTAssert(false)

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -35,15 +35,16 @@ final class URLExtensionsTests: XCTestCase {
 	}
     
     func testQueryParameters() {
-        let url = URL(string: "https://www.google.com?q=swifter%20swift&steve=jobs")!
-        guard let parameters = url.queryParameters, let qValue = parameters["q"], let steveValue = parameters["steve"] else {
+        let url = URL(string: "https://www.google.com?q=swifter%20swift&steve=jobs&empty")!
+        guard let parameters = url.queryParameters else {
             XCTAssert(false)
             return
         }
         
-        XCTAssertEqual(parameters.count, 2)
-        XCTAssertEqual(qValue, "swifter swift")
-        XCTAssertEqual(steveValue, "jobs")
+        XCTAssertEqual(parameters.count, 3)
+        XCTAssertEqual(parameters["q"], "swifter swift")
+        XCTAssertEqual(parameters["steve"], "jobs")
+        XCTAssertEqual(parameters["empty"], "")
     }
 	
 }

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -41,10 +41,10 @@ final class URLExtensionsTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(parameters.count, 3)
+        XCTAssertEqual(parameters.count, 2)
         XCTAssertEqual(parameters["q"], "swifter swift")
         XCTAssertEqual(parameters["steve"], "jobs")
-        XCTAssertEqual(parameters["empty"], "")
+        XCTAssertEqual(parameters["empty"], nil)
     }
 	
 }


### PR DESCRIPTION
This is useful for iMessage app/extensions because information is exchanged through URL query items but it might be useful in general.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
