### PR TITLE
remove empty overrides in URLExtensionTests.swift

### DIFF
--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -14,16 +14,6 @@ final class URLExtensionsTests: XCTestCase {
 	var url = URL(string: "https://www.google.com")!
 	let params = ["q": "swifter swift"]
 	let queryUrl = URL(string: "https://www.google.com?q=swifter%20swift")!
-
-	override func setUp() {
-		super.setUp()
-		// Put setup code here. This method is called before the invocation of each test method in the class.
-	}
-	
-	override func tearDown() {
-		// Put teardown code here. This method is called after the invocation of each test method in the class.
-		super.tearDown()
-	}
 	
 	func testAppendingQueryParameters() {
 		XCTAssertEqual(url.appendingQueryParameters(params), queryUrl)


### PR DESCRIPTION
As far as I know these overrides are unnecessary the tests finish as expected.
