### PR TITLE
Add withRoundedCorners(radius:) extension to UIImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - added `commonSuffix(with:, options:)` to get the longest common suffix of the receiver and a given string. [#379](https://github.com/SwifterSwift/SwifterSwift/pull/379) by [@vyax](https://github.com/vyax).
 - **UIFont**
   - added `bold` and `italic` to UIFont. [#382](https://github.com/SwifterSwift/SwifterSwift/pull/382) by [@vyax](https://github.com/vyax).
+- **UIImage**
+  - added `withRoundedCorners(radius:)` to round the corners of an image. The parameter radius is optional, the resulting image will be round if it is unspecified. [#380](https://github.com/SwifterSwift/SwifterSwift/pull/380) by [@vyax](https://github.com/vyax).
 - **URL**
   - added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 > ### Changed

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -137,6 +137,31 @@ public extension UIImage {
 		UIGraphicsEndImageContext()
 		return tintedImage!
 	}
+    
+    /// SwifterSwift: UIImage with rounded corners
+    ///
+    /// - Parameters:
+    ///   - radius: corner radius (optional), resulting image will be round if unspecified
+    /// - Returns: UIImage with all corners rounded
+    public func withRoundedCorners(radius: CGFloat? = nil) -> UIImage? {
+        let maxRadius = min(size.width, size.height) / 2
+        let cornerRadius: CGFloat
+        if let radius = radius, radius > 0 && radius <= maxRadius {
+            cornerRadius = radius
+        } else {
+            cornerRadius = maxRadius
+        }
+        
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        
+        let rect = CGRect(origin: .zero, size: size)
+        UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius).addClip()
+        draw(in: rect)
+        
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
 	
 }
 

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -94,5 +94,13 @@ final class UIImageExtensionsTests: XCTestCase {
         XCTAssertEqual(testImage.bytesSize, tintedImage.bytesSize)
     }
     
+    func testWithCornerRadius() {
+        let image = UIImage(color: .black, size: CGSize(width: 20, height: 20))
+        XCTAssertNotNil(image.withRoundedCorners())
+        XCTAssertNotNil(image.withRoundedCorners(radius: 5))
+        XCTAssertNotNil(image.withRoundedCorners(radius: -10))
+        XCTAssertNotNil(image.withRoundedCorners(radius: 30))
+    }
+    
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.

fixes #361