### PR TITLE
Add bold and italic properties to UIFont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 - **Array**
   - added `divided(by:)` to separate an array into 2 arrays based on a predicate. [#367](https://github.com/SwifterSwift/SwifterSwift/pull/367) by [@neoneye](https://github.com/neoneye).
+- **UIFont**
+  - added `bold` and `italic` to UIFont. [#382](https://github.com/SwifterSwift/SwifterSwift/pull/382) by [@vyax](https://github.com/vyax).
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/Sources/Extensions/UIKit/UIFontExtensions.swift
+++ b/Sources/Extensions/UIKit/UIFontExtensions.swift
@@ -11,6 +11,16 @@ import UIKit
 
 // MARK: - Properties
 public extension UIFont {
+    
+    /// SwifterSwift: Font as bold font
+    public var bold: UIFont {
+        return UIFont(descriptor: fontDescriptor.withSymbolicTraits(.traitBold)!, size: 0)
+    }
+    
+    /// SwifterSwift: Font as italic font
+    public var italic: UIFont {
+        return UIFont(descriptor: fontDescriptor.withSymbolicTraits(.traitItalic)!, size: 0)
+    }
 	
 	/// SwifterSwift: Font as monospaced font
 	///

--- a/Tests/UIKitTests/UIFontExtensionsTest.swift
+++ b/Tests/UIKitTests/UIFontExtensionsTest.swift
@@ -11,6 +11,18 @@ import XCTest
 @testable import SwifterSwift
 
 final class UIFontExtension: XCTestCase {
+    
+    func testBold() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let boldFont = font.bold
+        XCTAssert(boldFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+    }
+    
+    func testItalic() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let italicFont = font.italic
+        XCTAssert(italicFont.fontDescriptor.symbolicTraits.contains(.traitItalic))
+    }
 	
 	func testMonospacedDigitFont() {
 		let font = UIFont.preferredFont(forTextStyle: .body)


### PR DESCRIPTION
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
