### PR TITLE
Double extensions for units of measurement and duration string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > ### Added
 - **Array**
   - added `divided(by:)` to separate an array into 2 arrays based on a predicate. [#367](https://github.com/SwifterSwift/SwifterSwift/pull/367) by [@neoneye](https://github.com/neoneye).
+- **Double**
+  - added `km`, `cm`, `mm`, `ft`, `mi`, `yd` computed properties to be able to convert double (meter) values to its corresponding units of measurement. [#387](https://github.com/SwifterSwift/SwifterSwift/pull/387) by [jason-ingenuity](https://github.com/jason-ingenuity).
+  - added `toDurationString(withSeconds: separatedBy separator:)` method to be able to provide a string representation of a double (hours) into a hours, minutes, and/or seconds format. [#387](https://github.com/SwifterSwift/SwifterSwift/pull/387) by [jason-ingenuity](https://github.com/jason-ingenuity).
 - **StringProtocol**
   - added `commonSuffix(with:, options:)` to get the longest common suffix of the receiver and a given string. [#379](https://github.com/SwifterSwift/SwifterSwift/pull/379) by [@vyax](https://github.com/vyax).
 - **UIFont**

--- a/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
@@ -25,7 +25,78 @@ public extension Double {
 	public var cgFloat: CGFloat {
 		return CGFloat(self)
 	}
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to kilometers.
+    public var km: Double {
+        // https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Extensions.html#//apple_ref/doc/uid/TP40014097-CH24-ID152
+        return self / 1000.0
+    }
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to centimeters.
+    public var cm: Double {
+        // https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Extensions.html#//apple_ref/doc/uid/TP40014097-CH24-ID152
+        return self * 100.0
+    }
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to millimeters.
+    public var mm: Double {
+        // https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Extensions.html#//apple_ref/doc/uid/TP40014097-CH24-ID152
+        return self * 1000.0
+    }
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to feet.
+    public var ft: Double {
+        // https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Extensions.html#//apple_ref/doc/uid/TP40014097-CH24-ID152
+        return self * 3.28084
+    }
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to miles.
+    public var mi: Double {
+        return self * 0.00062137
+    }
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to yards.
+    public var yd: Double {
+        return self * 1093.61
+    }
+    
+    /// SwifterSwift: Returns the current double (treated as meters) to inches.
+    public var inch: Double {
+        return self * 39.3701
+    }
 	
+}
+
+// MARK: Methods
+
+public extension Double {
+    
+    /// SwifterSwift: String representation of a double value (hours) as its duration in hours, minutes, and/or seconds.
+    ///
+    /// - Parameters:
+    ///   - withSeconds: Determines if seconds is to be added. Defaults to true
+    ///   - separator: String to serve as the separator between hours, minutes, and/or seconds.
+    ///                The default value of "hms" will have an output of 00h 00m 00s.
+    /// - Returns: String formatted to hours, minutes, seconds based on derived value from double.
+    public func toDurationString(withSeconds: Bool = true, separatedBy separator: String = "hms") -> String {
+        let totalSeconds = Int(self * 3600)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = (totalSeconds % 3600) % 60
+        var format = ""
+        
+        if separator == "hms" {
+            format = "%02ih %02im" + (withSeconds ? " %02is" : "")
+        } else {
+            format = "%02i\(separator)%02i" + (withSeconds ? "\(separator)%02i" : "")
+        }
+        
+        return String(format: format,
+                      hours,
+                      minutes < 60 ? minutes : (minutes % 60),
+                      seconds < 60 ? seconds : (seconds % 60))
+    }
+    
 }
 
 // MARK: - Operators

--- a/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
@@ -91,5 +91,29 @@ final class DoubleExtensionsTests: XCTestCase {
 		}
 		XCTAssert(num.asLocaleCurrency.contains("\(num)"))
 	}
+    
+    func testUnitsOfMeasurement() {
+        let meters = 1.0
+        
+        XCTAssertTrue(meters.km == 0.001)
+        XCTAssertTrue(meters.cm == 100)
+        XCTAssertTrue(meters.mm == 1000)
+        XCTAssertTrue(meters.ft == 3.28084)
+        XCTAssertTrue(meters.mi == 0.00062137)
+        XCTAssertTrue(meters.yd == 1093.61)
+        XCTAssertTrue(meters.inch == 39.3701)
+    }
+    
+    func testDurationString() {
+        // Default parameters
+        var durationString = 3.5.toDurationString()
+        XCTAssert(durationString == "03h 30m 00s")
+        
+        durationString = 3.5.toDurationString(withSeconds: false, separatedBy: ":")
+        XCTAssert(durationString == "03:30")
+        
+        durationString = 3.5.toDurationString(withSeconds: true, separatedBy: " ")
+        XCTAssert(durationString == "03 30 00")
+    }
 	
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
