### PR TITLE
UserDefaults extension to save codable object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **URL**
   - added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 - **UserDefaults**
-  - added `codable(type: with key:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
+  - added `object(type: with key:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
   - added `set(codable: forKey key:)` method to be able to store Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
 > ### Changed
 > ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **URL**
   - added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
 - **UserDefaults**
-  - added `object(type: with key:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
-  - added `set(codable: forKey key:)` method to be able to store Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
+  - added `object(type: with key: usingDecoder decoder:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
+  - added `set(codable: forKey key: usingEncoder encoder:)` method to be able to store Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - added `register(nibWithCellClass:, at bundleClass:)` method to be able to register a cell with custom nib just by its class name. [#386](https://github.com/SwifterSwift/SwifterSwift/pull/386) by [jason-ingenuity](https://github.com/jason-ingenuity).
 - **URL**
   - added `queryParmeters` property to get the query parameters from a URL as a dictionary. [#370](https://github.com/SwifterSwift/SwifterSwift/pull/370) by [nathanbacon](https://github.com/nathanbacon).
+- **UserDefaults**
+  - added `codable(type: with key:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
+  - added `set(codable: forKey key:)` method to be able to store Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
+++ b/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
@@ -38,4 +38,29 @@ public extension UserDefaults {
 		return object(forKey: key) as? Date
 	}
 	
+    /// SwifterSwift: Retrieves a Codable object from UserDefaults.
+    ///
+    /// - Parameters:
+    ///   - type: Class that conforms to the Codable protocol.
+    ///   - key: key to find the Codable object for.
+    /// - Returns: Codable object for key (if exists).
+    public func object<T: Codable>(_ type: T.Type, with key: String) -> Codable? {
+        if let data = self.value(forKey: key) as? Data {
+            return try? JSONDecoder().decode(type.self, from: data)
+        } else {
+            return nil
+        }
+    }
+    
+    /// SwifterSwift: Allows storing of Codable objects to UserDefaults
+    ///
+    /// - Parameters:
+    ///   - object: Codable object to store.
+    ///   - key: Identifier of the object
+    public func set<T: Codable>(object: T, forKey key: String) {
+        let data = try? JSONEncoder().encode(object)
+        
+        self.set(data, forKey: key)
+    }
+    
 }

--- a/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
+++ b/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
@@ -42,21 +42,27 @@ public extension UserDefaults {
     ///
     /// - Parameters:
     ///   - type: Class that conforms to the Codable protocol.
-    ///   - key: key to find the Codable object for.
+    ///   - key: Identifier of the object.
+    ///   - decoder: Custom JSONDecoder instance. Defaults to `JSONDecoder()`.
     /// - Returns: Codable object for key (if exists).
-    public func object<T: Codable>(_ type: T.Type, with key: String) -> T? {
+    public func object<T: Codable>(_ type: T.Type,
+                                   with key: String,
+                                   usingDecoder decoder: JSONDecoder = JSONDecoder()) -> T? {
         guard let data = self.value(forKey: key) as? Data else { return nil }
         
-        return try? JSONDecoder().decode(type.self, from: data)
+        return try? decoder.decode(type.self, from: data)
     }
     
-    /// SwifterSwift: Allows storing of Codable objects to UserDefaults
+    /// SwifterSwift: Allows storing of Codable objects to UserDefaults.
     ///
     /// - Parameters:
     ///   - object: Codable object to store.
-    ///   - key: Identifier of the object
-    public func set<T: Codable>(object: T, forKey key: String) {
-        let data = try? JSONEncoder().encode(object)
+    ///   - key: Identifier of the object.
+    ///   - encoder: Custom JSONEncoder instance. Defaults to `JSONEncoder()`.
+    public func set<T: Codable>(object: T,
+                                forKey key: String,
+                                usingEncoder encoder: JSONEncoder = JSONEncoder()) {
+        let data = try? encoder.encode(object)
         
         self.set(data, forKey: key)
     }

--- a/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
+++ b/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
@@ -44,12 +44,10 @@ public extension UserDefaults {
     ///   - type: Class that conforms to the Codable protocol.
     ///   - key: key to find the Codable object for.
     /// - Returns: Codable object for key (if exists).
-    public func object<T: Codable>(_ type: T.Type, with key: String) -> Codable? {
-        if let data = self.value(forKey: key) as? Data {
-            return try? JSONDecoder().decode(type.self, from: data)
-        } else {
-            return nil
-        }
+    public func object<T: Codable>(_ type: T.Type, with key: String) -> T? {
+        guard let data = self.value(forKey: key) as? Data else { return nil }
+        
+        return try? JSONDecoder().decode(type.self, from: data)
     }
     
     /// SwifterSwift: Allows storing of Codable objects to UserDefaults

--- a/Tests/FoundationTests/UserDefaultsExtensionsTests.swift
+++ b/Tests/FoundationTests/UserDefaultsExtensionsTests.swift
@@ -9,6 +9,10 @@ import XCTest
 @testable import SwifterSwift
 
 final class UserDefaultsExtensionsTests: XCTestCase {
+    
+    private struct TestObject: Codable {
+        var id: Int
+    }
 	
 	func testSubscript() {
 		let key = "testKey"
@@ -37,5 +41,13 @@ final class UserDefaultsExtensionsTests: XCTestCase {
 		XCTAssertNotNil(UserDefaults.standard.date(forKey: key))
 		XCTAssertEqual(UserDefaults.standard.date(forKey: key)!, date)
 	}
+    
+    func testCodable() {
+        let key = "codableTestKey"
+        let codable: TestObject = TestObject(id: 1)
+        UserDefaults.standard.set(object: codable, forKey: key)
+        let retrievedCodable = UserDefaults.standard.object(TestObject.self, with: key)
+        XCTAssertNotNil(retrievedCodable)
+    }
 	
 }

--- a/Tests/FoundationTests/UserDefaultsExtensionsTests.swift
+++ b/Tests/FoundationTests/UserDefaultsExtensionsTests.swift
@@ -42,7 +42,15 @@ final class UserDefaultsExtensionsTests: XCTestCase {
 		XCTAssertEqual(UserDefaults.standard.date(forKey: key)!, date)
 	}
     
-    func testCodable() {
+    func testGetCodableObject() {
+        let key = "codableTestKey"
+        let codable: TestObject = TestObject(id: 1)
+        UserDefaults.standard.set(object: codable, forKey: key)
+        let retrievedCodable = UserDefaults.standard.object(TestObject.self, with: key)
+        XCTAssertNotNil(retrievedCodable)
+    }
+    
+    func testSetCodableObject() {
         let key = "codableTestKey"
         let codable: TestObject = TestObject(id: 1)
         UserDefaults.standard.set(object: codable, forKey: key)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
