### PR TITLE
Array extension to group strings by its first letter and use it as sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > ### Added
 - **Array**
   - added `divided(by:)` to separate an array into 2 arrays based on a predicate. [#367](https://github.com/SwifterSwift/SwifterSwift/pull/367) by [@neoneye](https://github.com/neoneye).
+  - added `groupToSections()` method to group strings based on first letter and use it as sections. [#391](https://github.com/SwifterSwift/SwifterSwift/pull/391) by [jason-ingenuity](https://github.com/jason-ingenuity).
 - **StringProtocol**
   - added `commonSuffix(with:, options:)` to get the longest common suffix of the receiver and a given string. [#379](https://github.com/SwifterSwift/SwifterSwift/pull/379) by [@vyax](https://github.com/vyax).
 - **UICollectionView**

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -43,6 +43,43 @@ public extension Array where Element: FloatingPoint {
 	
 }
 
+// MARK: Methods (String)
+public extension Array where Element == String {
+    
+    /// SwifterSwift: Takes an array of strings and generate two lists:
+    ///               One is derived from their first character which will serve as their section label.
+    ///               Second is the array items now grouped based on their corresponding section (first letter).
+    ///
+    ///    ["Jason", "Alice", "Jack"].groupToSections() -> (["A", "J"], [["Alice"], ["Jack", "Jason"]])
+    ///
+    /// - Returns: A tuple consists of the sections list, and its grouped items.
+    public func groupToSections() -> ([String], [[String]]) {
+        // https://stackoverflow.com/questions/42981122/swift-map-array-of-objects-alphabetically-by-namestring-into-separate-letter
+        var items = self
+        
+        items = items.sorted(by: { $0 < $1 })
+        
+        let sections = Array(Set(items.map { String($0.first!) })).sorted(by: { $0 < $1 })
+        let groupedItems = items.reduce([[String]]()) {
+            guard var last = $0.last else { return [[$1]] }
+            
+            var collection = $0
+            
+            if last.first!.first! == $1.first! {
+                last += [$1]
+                collection[collection.count - 1] = last
+            } else {
+                collection += [[$1]]
+            }
+            
+            return collection
+        }
+        
+        return (sections, groupedItems)
+    }
+    
+}
+
 // MARK: - Methods
 public extension Array {
 	

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -460,4 +460,17 @@ final class ArrayExtensionsTests: XCTestCase {
                                                         Person(name: "Wade", age: nil)])
     }
     
+    func testGroupedItemsBasedOnSection() {
+        let array = ["Jason", "Alice", "Jack"]
+        let expectedSectionOutput = ["A", "J"]
+        let expectedGroupedItemsOutput = [["Alice"], ["Jack", "Jason"]]
+        let (sections, groupedItems) = array.groupToSections()
+        
+        XCTAssert(sections.count == expectedSectionOutput.count)
+        XCTAssert(groupedItems.count == expectedGroupedItemsOutput.count)
+        XCTAssertEqual(sections, expectedSectionOutput)
+        XCTAssertEqual(groupedItems[0], expectedGroupedItemsOutput[0])
+        XCTAssertEqual(groupedItems[1], expectedGroupedItemsOutput[1])
+    }
+    
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
