### PR TITLE
Fix for StringExtensions - isNumeric - incorrect behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,14 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UserDefaults**
   - added `object(type: with key: usingDecoder decoder:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
   - added `set(codable: forKey key: usingEncoder encoder:)` method to be able to store Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
+- **StringExtensions**
+  - added `isDigits` to check if string only contains digits. [#396](https://github.com/SwifterSwift/SwifterSwift/pull/396) by [seifeet](https://github.com/seifeet).
 > ### Changed
 > ### Deprecated
 > ### Removed
 > ### Fixed
+- **StringExtensions**
+  - Fixed `isNumeric` to check if string is a valid Swift number and added isDigits to check if string only contains digits. [#396](https://github.com/SwifterSwift/SwifterSwift/pull/396) by [seifeet](https://github.com/seifeet).
 > ### Security
 
 
@@ -1054,4 +1058,3 @@ DateExtensions:
 
 UIViewExtensions:
 - **shake**: Completion handler added to shake function
-

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -183,16 +183,32 @@ public extension String {
 		return URL(string: self)?.isFileURL ?? false
 	}
 	
-	/// SwifterSwift: Check if string contains only numbers.
+	/// SwifterSwift: Check if string is a valid Swift number.
 	///
+    /// Note:
+    /// In North America, "." is the decimal separator,
+    /// while in many parts of Europe "," is used,
+    ///
 	///		"123".isNumeric -> true
+    ///     "1.3".isNumeric -> true (en_US)
+    ///     "1,3".isNumeric -> true (fr_FR)
 	///		"abc".isNumeric -> false
 	///
-	public var isNumeric: Bool {
-		let hasLetters = rangeOfCharacter(from: .letters, options: .numeric, range: nil) != nil
-		let hasNumbers = rangeOfCharacter(from: .decimalDigits, options: .literal, range: nil) != nil
-		return !hasLetters && hasNumbers
-	}
+    public var isNumeric: Bool {
+        let scanner = Scanner(string: self)
+        scanner.locale = NSLocale.current
+        return scanner.scanDecimal(nil) && scanner.isAtEnd
+    }
+    
+    /// SwifterSwift: Check if string only contains digits.
+    ///
+    ///     "123".isDigits -> true
+    ///     "1.3".isDigits -> false
+    ///     "abc".isDigits -> false
+    ///
+    public var isDigits: Bool {
+        return CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: self))
+    }
 	
 	/// SwifterSwift: Last character of string (if applicable).
 	///

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -135,9 +135,22 @@ final class StringExtensionsTests: XCTestCase {
     
 	func testIsNumeric() {
 		XCTAssert("123".isNumeric)
+        XCTAssert("123.4".isNumeric)
+        XCTAssert("1.25e2".isNumeric)
+        XCTAssert("1.25e-2".isNumeric)
+        XCTAssert("000123.456".isNumeric)
 		XCTAssertFalse("123abc".isNumeric)
 		XCTAssertFalse("abc".isNumeric)
+        XCTAssertFalse("123.@.".isNumeric)
 	}
+    
+    func testIsDigits() {
+        XCTAssert("123".isDigits)
+        XCTAssert("987654321".isDigits)
+        XCTAssertFalse("123.4".isDigits)
+        XCTAssertFalse("1.25e2".isDigits)
+        XCTAssertFalse("123abc".isDigits)
+    }
 
     func testHasUniqueCharacters() {
         XCTAssert("swift".hasUniqueCharacters())


### PR DESCRIPTION
update isNumeric to check if string is a valid Swift number and add isDigits to check if string only contains digits

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 4.
- [X] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a changelog entry describing my changes.