### PR TITLE
String to slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ---
 
 > # Upcoming release
->
+- **String**
+  - added `toSlug()` to return a slug version of a given string. [397#](https://github.com/SwifterSwift/SwifterSwift/pull/397) by [FrankKair](https://github.com/FrankKair)
+
 > ### Added
 - **Array**
   - added `divided(by:)` to separate an array into 2 arrays based on a predicate. [#367](https://github.com/SwifterSwift/SwifterSwift/pull/367) by [@neoneye](https://github.com/neoneye).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ---
 
 > # Upcoming release
-- **String**
-  - added `toSlug()` to return a slug version of a given string. [397#](https://github.com/SwifterSwift/SwifterSwift/pull/397) by [FrankKair](https://github.com/FrankKair)
 
 > ### Added
 - **Array**
@@ -32,6 +30,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UserDefaults**
   - added `object(type: with key: usingDecoder decoder:)` method to be able to retrieve Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
   - added `set(codable: forKey key: usingEncoder encoder:)` method to be able to store Codable objects from UserDefaults. [#388](https://github.com/SwifterSwift/SwifterSwift/pull/388) by [jason-ingenuity](https://github.com/jason-ingenuity).
+- **String**
+  - added `toSlug()` to return a slug version of a given string. [397#](https://github.com/SwifterSwift/SwifterSwift/pull/397) by [FrankKair](https://github.com/FrankKair)
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -425,6 +425,34 @@ public extension String {
 		// https://stackoverflow.com/questions/42822838
 		return words().count
 	}
+
+    /// SwifterSwift: Transforms the string into a slug string.
+    ///
+    ///        "Swift is amazing".toSlug() -> "swift-is-amazing"
+    ///
+    /// - Returns: The string in slug format.
+    public func toSlug() -> String {
+        let lowercased = self.lowercased()
+        let latinized = lowercased.latinized
+        let withDashes = latinized.replacingOccurrences(of: " ", with: "-")
+
+        let alphanumerics = NSCharacterSet.alphanumerics
+        var filtered = withDashes.filter {
+            guard String($0) != "-" else { return true }
+            guard String($0) != "&" else { return true }
+            return String($0).rangeOfCharacter(from: alphanumerics) != nil
+        }
+
+        while filtered.lastCharacterAsString == "-" {
+            filtered = String(filtered.dropLast())
+        }
+
+        while filtered.firstCharacterAsString == "-" {
+            filtered = String(filtered.dropFirst())
+        }
+
+        return filtered.replacingOccurrences(of: "--", with: "-")
+    }
 	
 	/// SwifterSwift: Safely subscript string with index.
 	///

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -582,6 +582,12 @@ final class StringExtensionsTests: XCTestCase {
 	func testWordsCount() {
 		XCTAssertEqual("Swift is amazing".wordCount(), 3)
 	}
+
+    func testToSlug() {
+        let str = "  A nice & hög _ Str    "
+        XCTAssertEqual(str.toSlug(), "a-nice-&-hog-str")
+        XCTAssertEqual("Swift is amazing".toSlug(), "swift-is-amazing")
+    }
     
     func testPaddingStart() {
         XCTAssertEqual("str".paddingStart(10), "       str")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Creates a method to return a slug version of a string.
Example:

```swift
let str = "  A nice & hög _ Str    "
str.toSlug() // Returns "a-nice-&-hog-str"
```

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.