### PR TITLE
Add UIStackView convenience init with UIViews and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - added `isDigits` to check if string only contains digits. [#396](https://github.com/SwifterSwift/SwifterSwift/pull/396) by [seifeet](https://github.com/seifeet).
   - added `toSlug()` to return a slug version of a given string. [397#](https://github.com/SwifterSwift/SwifterSwift/pull/397) by [FrankKair](https://github.com/FrankKair)
 - New **UIStackView**
-  - added `init(views:, orientation:, spacing:, alignment:, distribution:)` to directly initialize a `UIStackView` with an array of `UIViews`. [#408](https://github.com/SwifterSwift/SwifterSwift/pull/408) by [BennX](https://github.com/BennX)
+  - added `init(views:, orientation:, spacing:, alignment:, distribution:)` to directly initialize a `UIStackView` with an array of `UIViews`. [#409](https://github.com/SwifterSwift/SwifterSwift/pull/409) by [BennX](https://github.com/BennX)
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **String**
   - added `isDigits` to check if string only contains digits. [#396](https://github.com/SwifterSwift/SwifterSwift/pull/396) by [seifeet](https://github.com/seifeet).
   - added `toSlug()` to return a slug version of a given string. [397#](https://github.com/SwifterSwift/SwifterSwift/pull/397) by [FrankKair](https://github.com/FrankKair)
+- New **UIStackView**
+  - added `init(views:, orientation:, spacing:, alignment:, distribution:)` to directly initialize a `UIStackView` with an array of `UIViews`. [#408](https://github.com/SwifterSwift/SwifterSwift/pull/408) by [BennX](https://github.com/BennX)
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - added `isDigits` to check if string only contains digits. [#396](https://github.com/SwifterSwift/SwifterSwift/pull/396) by [seifeet](https://github.com/seifeet).
   - added `toSlug()` to return a slug version of a given string. [397#](https://github.com/SwifterSwift/SwifterSwift/pull/397) by [FrankKair](https://github.com/FrankKair)
 - New **UIStackView**
-  - added `init(views:, orientation:, spacing:, alignment:, distribution:)` to directly initialize a `UIStackView` with an array of `UIViews`. [#409](https://github.com/SwifterSwift/SwifterSwift/pull/409) by [BennX](https://github.com/BennX)
+  - added `init(arrangedSubviews:, axis:, spacing:, alignment:, distribution:)` to directly initialize a `UIStackView` with an array of `UIViews`. [#409](https://github.com/SwifterSwift/SwifterSwift/pull/409) by [BennX](https://github.com/BennX)
 > ### Changed
 > ### Deprecated
 > ### Removed

--- a/Sources/Extensions/UIKit/UIStackViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStackViewExtensions.swift
@@ -3,6 +3,7 @@
 //  SwifterSwift-iOS
 //
 //  Created by Benjamin Meyer on 2/18/18.
+//  Copyright © 2018 SwifterSwift
 //
 
 #if os(iOS) || os(tvOS)
@@ -11,19 +12,20 @@ import UIKit
 // MARK: - Initializers
 @available(iOS 9.0, *)
 public extension UIStackView {
+    
     /// SwifterSwift: Initialize an UIStackView with an array of UIView and common parameters.
     ///
-    ///        let stackView = UIStackView(views: [UIView(), UIView()], orientation: .vertical)
+    ///     let stackView = UIStackView(views: [UIView(), UIView()], orientation: .vertical)
     ///
-    /// - Parameter views: The UIViews to add to the stack.
-    /// - Parameter orientation: The axis along which the arranged views are laid out.(default: .horizontal)
-    /// - Parameter spacing: The distance in points between the adjacent edges of the stack view’s arranged views.(default: 0.0)
-    /// - Parameter alignment: The alignment of the arranged subviews perpendicular to the stack view’s axis. (default: .fill)
-    /// - Parameter distribution: The distribution of the arranged views along the stack view’s axis.(default: .fill)
-    /// - Returns: A UIStackView of all views of the given array with the passed configuration.
-    public convenience init(views: [UIView], orientation: UILayoutConstraintAxis = .horizontal, spacing: CGFloat = 0.0, alignment: UIStackViewAlignment = .fill, distribution: UIStackViewDistribution = .fill) {
+    /// - Parameters:
+    ///   - views: The UIViews to add to the stack.
+    ///   - axis: The axis along which the arranged views are laid out.(default: .horizontal)
+    ///   - spacing: The distance in points between the adjacent edges of the stack view’s arranged views.(default: 0.0)
+    ///   - alignment: The alignment of the arranged subviews perpendicular to the stack view’s axis. (default: .fill)
+    ///   - distribution: The distribution of the arranged views along the stack view’s axis.(default: .fill)
+    public convenience init(views: [UIView], axis: UILayoutConstraintAxis = .horizontal, spacing: CGFloat = 0.0, alignment: UIStackViewAlignment = .fill, distribution: UIStackViewDistribution = .fill) {
         self.init(arrangedSubviews: views)
-        self.axis = orientation
+        self.axis = axis
         self.spacing = spacing
         self.alignment = alignment
         self.distribution = distribution

--- a/Sources/Extensions/UIKit/UIStackViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStackViewExtensions.swift
@@ -1,0 +1,32 @@
+//
+//  UIStackViewExtensions.swift
+//  SwifterSwift-iOS
+//
+//  Created by Benjamin Meyer on 2/18/18.
+//
+
+#if os(iOS) || os(tvOS)
+import UIKit
+    
+// MARK: - Initializers
+@available(iOS 9.0, *)
+public extension UIStackView {
+    /// SwifterSwift: Initialize an UIStackView with an array of UIView and common parameters.
+    ///
+    ///        let stackView = UIStackView(views: [UIView(), UIView()], orientation: .vertical)
+    ///
+    /// - Parameter views: The UIViews to add to the stack.
+    /// - Parameter orientation: The axis along which the arranged views are laid out.(default: .horizontal)
+    /// - Parameter spacing: The distance in points between the adjacent edges of the stack view’s arranged views.(default: 0.0)
+    /// - Parameter alignment: The alignment of the arranged subviews perpendicular to the stack view’s axis. (default: .fill)
+    /// - Parameter distribution: The distribution of the arranged views along the stack view’s axis.(default: .fill)
+    /// - Returns: A UIStackView of all views of the given array with the passed configuration.
+    public convenience init(views: [UIView], orientation: UILayoutConstraintAxis = .horizontal, spacing: CGFloat = 0.0, alignment: UIStackViewAlignment = .fill, distribution: UIStackViewDistribution = .fill) {
+        self.init(arrangedSubviews: views)
+        self.axis = orientation
+        self.spacing = spacing
+        self.alignment = alignment
+        self.distribution = distribution
+    }
+}
+#endif

--- a/Sources/Extensions/UIKit/UIStackViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStackViewExtensions.swift
@@ -15,7 +15,7 @@ public extension UIStackView {
     
     /// SwifterSwift: Initialize an UIStackView with an array of UIView and common parameters.
     ///
-    ///     let stackView = UIStackView(views: [UIView(), UIView()], axis: .vertical)
+    ///     let stackView = UIStackView(arrangedSubviews: [UIView(), UIView()], axis: .vertical)
     ///
     /// - Parameters:
     ///   - arrangedSubviews: The UIViews to add to the stack.

--- a/Sources/Extensions/UIKit/UIStackViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStackViewExtensions.swift
@@ -15,16 +15,16 @@ public extension UIStackView {
     
     /// SwifterSwift: Initialize an UIStackView with an array of UIView and common parameters.
     ///
-    ///     let stackView = UIStackView(views: [UIView(), UIView()], orientation: .vertical)
+    ///     let stackView = UIStackView(views: [UIView(), UIView()], axis: .vertical)
     ///
     /// - Parameters:
     ///   - views: The UIViews to add to the stack.
-    ///   - axis: The axis along which the arranged views are laid out.(default: .horizontal)
+    ///   - axis: The axis along which the arranged views are laid out.
     ///   - spacing: The distance in points between the adjacent edges of the stack view’s arranged views.(default: 0.0)
     ///   - alignment: The alignment of the arranged subviews perpendicular to the stack view’s axis. (default: .fill)
     ///   - distribution: The distribution of the arranged views along the stack view’s axis.(default: .fill)
-    public convenience init(views: [UIView], axis: UILayoutConstraintAxis = .horizontal, spacing: CGFloat = 0.0, alignment: UIStackViewAlignment = .fill, distribution: UIStackViewDistribution = .fill) {
-        self.init(arrangedSubviews: views)
+    public convenience init(arrangedSubviews: [UIView], axis: UILayoutConstraintAxis, spacing: CGFloat = 0.0, alignment: UIStackViewAlignment = .fill, distribution: UIStackViewDistribution = .fill) {
+        self.init(arrangedSubviews: arrangedSubviews)
         self.axis = axis
         self.spacing = spacing
         self.alignment = alignment

--- a/Sources/Extensions/UIKit/UIStackViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIStackViewExtensions.swift
@@ -18,7 +18,7 @@ public extension UIStackView {
     ///     let stackView = UIStackView(views: [UIView(), UIView()], axis: .vertical)
     ///
     /// - Parameters:
-    ///   - views: The UIViews to add to the stack.
+    ///   - arrangedSubviews: The UIViews to add to the stack.
     ///   - axis: The axis along which the arranged views are laid out.
     ///   - spacing: The distance in points between the adjacent edges of the stack view’s arranged views.(default: 0.0)
     ///   - alignment: The alignment of the arranged subviews perpendicular to the stack view’s axis. (default: .fill)

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -323,6 +323,8 @@
 		182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		278CA08D1F9A9232004918BD /* NSImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA08C1F9A9232004918BD /* NSImageExtensions.swift */; };
 		278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */; };
+		42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */; };
+		42F53FF02039C7140070DC11 /* UIStackViewExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */; };
 		70269A2B1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
 		70269A2C1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
 		70269A2D1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
@@ -504,6 +506,8 @@
 		185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGColorExtensionsTests.swift; sourceTree = "<group>"; };
 		278CA08C1F9A9232004918BD /* NSImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensions.swift; sourceTree = "<group>"; };
 		278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensionsTests.swift; sourceTree = "<group>"; };
+		42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensions.swift; sourceTree = "<group>"; };
+		42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTest.swift; sourceTree = "<group>"; };
 		70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensions.swift; sourceTree = "<group>"; };
 		70269A2F1FB47B0C00C6C2D0 /* CalendarExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionTest.swift; sourceTree = "<group>"; };
 		9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensions.swift; sourceTree = "<group>"; };
@@ -740,6 +744,7 @@
 				07B7F1901F5EB41600E6F910 /* UIViewControllerExtensions.swift */,
 				07B7F1911F5EB41600E6F910 /* UIViewExtensions.swift */,
 				076AEC881FDB48580077D153 /* UIDatePickerExtensions.swift */,
+				42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -817,6 +822,7 @@
 				07C50D211F5EB03200F46E5A /* UITextViewExtensionsTests.swift */,
 				07C50D221F5EB03200F46E5A /* UIViewControllerExtensionsTests.swift */,
 				07C50D231F5EB03200F46E5A /* UIViewExtensionsTests.swift */,
+				42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -1265,6 +1271,7 @@
 				07B7F20C1F5EB43C00E6F910 /* BoolExtensions.swift in Sources */,
 				07B7F22F1F5EB45100E6F910 /* CGFloatExtensions.swift in Sources */,
 				07B7F1981F5EB42000E6F910 /* UIImageViewExtensions.swift in Sources */,
+				42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */,
 				07B7F2321F5EB45100E6F910 /* CLLocationExtensions.swift in Sources */,
 				07B7F20E1F5EB43C00E6F910 /* CollectionExtensions.swift in Sources */,
 				07B7F2151F5EB43C00E6F910 /* IntExtensions.swift in Sources */,
@@ -1510,6 +1517,7 @@
 				9D9784E41FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
 				07C50D361F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */,
 				07C50D8C1F5EB06000F46E5A /* CGFloatExtensionsTests.swift in Sources */,
+				42F53FF02039C7140070DC11 /* UIStackViewExtensionsTest.swift in Sources */,
 				07D896091F5EC80700FC894D /* SwifterSwiftTests.swift in Sources */,
 				07C50D3E1F5EB04700F46E5A /* UITextViewExtensionsTests.swift in Sources */,
 				074EAF1F1F7BA74700C74636 /* UIFontExtensionsTest.swift in Sources */,

--- a/Tests/UIKitTests/UIStackViewExtensionsTest.swift
+++ b/Tests/UIKitTests/UIStackViewExtensionsTest.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-
 #if os(iOS) || os(tvOS)
     
 import XCTest
@@ -18,7 +17,7 @@ class UIStackViewExtensionsTest: XCTestCase {
     func testInitWithViews() {
         let view1 = UIView()
         let view2 = UIView()
-        var stack = UIStackView(views: [view1, view2])
+        var stack = UIStackView(arrangedSubviews: [view1, view2], axis: .horizontal)
         
         XCTAssertEqual(stack.arrangedSubviews.count, 2)
         XCTAssertTrue(stack.arrangedSubviews[0] === view1)
@@ -29,12 +28,12 @@ class UIStackViewExtensionsTest: XCTestCase {
         XCTAssertEqual(stack.distribution, .fill)
         XCTAssertEqual(stack.spacing, 0.0)
         
-        XCTAssertEqual(UIStackView(views: [view1, view2], axis: .vertical).axis, .vertical)
-        XCTAssertEqual(UIStackView(views: [view1, view2], alignment: .center).alignment, .center)
-        XCTAssertEqual(UIStackView(views: [view1, view2], distribution: .fillEqually).distribution, .fillEqually)
-        XCTAssertEqual(UIStackView(views: [view1, view2], spacing: 16.0).spacing, 16.0)
+        XCTAssertEqual(UIStackView(arrangedSubviews: [view1, view2], axis: .vertical).axis, .vertical)
+        XCTAssertEqual(UIStackView(arrangedSubviews: [view1, view2], axis: .vertical, alignment: .center).alignment, .center)
+        XCTAssertEqual(UIStackView(arrangedSubviews: [view1, view2], axis: .vertical, distribution: .fillEqually).distribution, .fillEqually)
+        XCTAssertEqual(UIStackView(arrangedSubviews: [view1, view2], axis: .vertical, spacing: 16.0).spacing, 16.0)
         
-        stack = UIStackView(views: [view1, view2], axis: .vertical, spacing: 16.0,
+        stack = UIStackView(arrangedSubviews: [view1, view2], axis: .vertical, spacing: 16.0,
                                   alignment: .center, distribution: .fillEqually)
         
         XCTAssertEqual(stack.axis, .vertical)

--- a/Tests/UIKitTests/UIStackViewExtensionsTest.swift
+++ b/Tests/UIKitTests/UIStackViewExtensionsTest.swift
@@ -1,0 +1,45 @@
+//
+//  UIStackViewExtensionsTest.swift
+//  SwifterSwift
+//
+//  Created by Benjamin Meyer on 2/18/18.
+//
+
+
+#if os(iOS) || os(tvOS)
+    
+import XCTest
+@testable import SwifterSwift
+
+class UIStackViewExtensionsTest: XCTestCase {
+    
+    // MARK: - Initializers
+    func testInitWithViews() {
+        let view1 = UIView()
+        let view2 = UIView()
+        var stack = UIStackView(views: [view1, view2])
+        
+        XCTAssertEqual(stack.arrangedSubviews.count, 2)
+        XCTAssertTrue(stack.arrangedSubviews[0] === view1)
+        XCTAssertTrue(stack.arrangedSubviews[1] === view2)
+        //defaults
+        XCTAssertEqual(stack.axis, .horizontal)
+        XCTAssertEqual(stack.alignment, .fill)
+        XCTAssertEqual(stack.distribution, .fill)
+        XCTAssertEqual(stack.spacing, 0.0)
+        
+        XCTAssertEqual(UIStackView(views: [view1, view2], orientation: .vertical).axis, .vertical)
+        XCTAssertEqual(UIStackView(views: [view1, view2], alignment: .center).alignment, .center)
+        XCTAssertEqual(UIStackView(views: [view1, view2], distribution: .fillEqually).distribution, .fillEqually)
+        XCTAssertEqual(UIStackView(views: [view1, view2], spacing: 16.0).spacing, 16.0)
+        
+        stack = UIStackView(views: [view1, view2], orientation: .vertical, spacing: 16.0,
+                                  alignment: .center, distribution: .fillEqually)
+        
+        XCTAssertEqual(stack.axis, .vertical)
+        XCTAssertEqual(stack.alignment, .center)
+        XCTAssertEqual(stack.distribution, .fillEqually)
+        XCTAssertEqual(stack.spacing, 16.0)
+    }
+}
+#endif

--- a/Tests/UIKitTests/UIStackViewExtensionsTest.swift
+++ b/Tests/UIKitTests/UIStackViewExtensionsTest.swift
@@ -3,6 +3,7 @@
 //  SwifterSwift
 //
 //  Created by Benjamin Meyer on 2/18/18.
+//  Copyright © 2018 SwifterSwift
 //
 
 
@@ -28,12 +29,12 @@ class UIStackViewExtensionsTest: XCTestCase {
         XCTAssertEqual(stack.distribution, .fill)
         XCTAssertEqual(stack.spacing, 0.0)
         
-        XCTAssertEqual(UIStackView(views: [view1, view2], orientation: .vertical).axis, .vertical)
+        XCTAssertEqual(UIStackView(views: [view1, view2], axis: .vertical).axis, .vertical)
         XCTAssertEqual(UIStackView(views: [view1, view2], alignment: .center).alignment, .center)
         XCTAssertEqual(UIStackView(views: [view1, view2], distribution: .fillEqually).distribution, .fillEqually)
         XCTAssertEqual(UIStackView(views: [view1, view2], spacing: 16.0).spacing, 16.0)
         
-        stack = UIStackView(views: [view1, view2], orientation: .vertical, spacing: 16.0,
+        stack = UIStackView(views: [view1, view2], axis: .vertical, spacing: 16.0,
                                   alignment: .center, distribution: .fillEqually)
         
         XCTAssertEqual(stack.axis, .vertical)


### PR DESCRIPTION
Adding a convenience init to UIStackView  to create a UIStackView from an Array of UIViews. Taking the defaults and parameter docs from Apples Defaults.

See also #407 
Closes #399

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.
