### PR TITLE
Fix Issue #412: Rename NSColor to Color in ColorExtensions.swift

### DIFF
--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -31,9 +31,9 @@ public extension Color {
 	
 	/// SwifterSwift: RGB components for a Color (between 0 and 255).
 	///
-	///		Color.red.rgbComponents.red -> 255
-	///		Color.green.rgbComponents.green -> 255
-	///		Color.blue.rgbComponents.blue -> 255
+	///		UIColor.red.rgbComponents.red -> 255
+	///		NSColor.green.rgbComponents.green -> 255
+	///		UIColor.blue.rgbComponents.blue -> 255
 	///
 	public var rgbComponents: (red: Int, green: Int, blue: Int) {
 		var components: [CGFloat] {
@@ -51,9 +51,9 @@ public extension Color {
 	
 	/// SwifterSwift: RGB components for a Color represented as CGFloat numbers (between 0 and 1)
 	///
-	///		Color.red.rgbComponents.red -> 1.0
-	///		Color.green.rgbComponents.green -> 1.0
-	///		Color.blue.rgbComponents.blue -> 1.0
+	///		UIColor.red.rgbComponents.red -> 1.0
+	///		NSColor.green.rgbComponents.green -> 1.0
+	///		UIColor.blue.rgbComponents.blue -> 1.0
 	///
 	public var cgFloatComponents: (red: CGFloat, green: CGFloat, blue: CGFloat) {
 		var components: [CGFloat] {

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -31,9 +31,9 @@ public extension Color {
 	
 	/// SwifterSwift: RGB components for a Color (between 0 and 255).
 	///
-	///		UIColor.red.rgbComponents.red -> 255
-	///		NSColor.green.rgbComponents.green -> 255
-	///		UIColor.blue.rgbComponents.blue -> 255
+	///		Color.red.rgbComponents.red -> 255
+	///		Color.green.rgbComponents.green -> 255
+	///		Color.blue.rgbComponents.blue -> 255
 	///
 	public var rgbComponents: (red: Int, green: Int, blue: Int) {
 		var components: [CGFloat] {
@@ -51,9 +51,9 @@ public extension Color {
 	
 	/// SwifterSwift: RGB components for a Color represented as CGFloat numbers (between 0 and 1)
 	///
-	///		UIColor.red.rgbComponents.red -> 1.0
-	///		NSColor.green.rgbComponents.green -> 1.0
-	///		UIColor.blue.rgbComponents.blue -> 1.0
+	///		Color.red.rgbComponents.red -> 1.0
+	///		Color.green.rgbComponents.green -> 1.0
+	///		Color.blue.rgbComponents.blue -> 1.0
 	///
 	public var cgFloatComponents: (red: CGFloat, green: CGFloat, blue: CGFloat) {
 		var components: [CGFloat] {
@@ -255,7 +255,7 @@ public extension Color {
 // MARK: - Initializers
 public extension Color {
 	
-	/// SwifterSwift: Create NSColor from RGB values with optional transparency.
+	/// SwifterSwift: Create Color from RGB values with optional transparency.
 	///
 	/// - Parameters:
 	///   - red: red component.
@@ -274,7 +274,7 @@ public extension Color {
 		self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: trans)
 	}
 	
-	/// SwifterSwift: Create NSColor from hexadecimal value with optional transparency.
+	/// SwifterSwift: Create Color from hexadecimal value with optional transparency.
 	///
 	/// - Parameters:
 	///   - hex: hex Int (example: 0xDECEB5).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Renamed NSColor and UIColor to Color

Resolves #412 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a changelog entry describing my changes.
