### PR TITLE
Update UITableViewExtensions.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > ### Removed
 > ### Fixed
 - **UITableView**
-  - Fixed removeTableFooterView() to actually remove the view. [#419](https://github.com/SwifterSwift/SwifterSwift/pull/419) by [happiehappie](https://github.com/happiehappie).
+  - Fixed `removeTableFooterView()` to actually remove the view. [#419](https://github.com/SwifterSwift/SwifterSwift/pull/419) by [happiehappie](https://github.com/happiehappie).
 - **String**
-   - Fixed UIView extension `addShadow`  was not showing the shadow on view bug. [#420](https://github.com/SwifterSwift/SwifterSwift/pull/420) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+  - Fixed UIView extension `addShadow`  was not showing the shadow on view bug. [#420](https://github.com/SwifterSwift/SwifterSwift/pull/420) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 > ### Security
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > ### Deprecated
 > ### Removed
 > ### Fixed
+- **UITableView**
+  - Update the assigned value for tableFooterView. [#419](https://github.com/SwifterSwift/SwifterSwift/pull/419) by [happiehappie](https://github.com/happiehappie).
 > ### Security
 
 ---

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -65,7 +65,7 @@ public extension UITableView {
 	
 	/// SwifterSwift: Remove TableFooterView.
 	public func removeTableFooterView() {
-		tableFooterView = nil
+		tableFooterView = UIView()
 	}
 	
 	/// SwifterSwift: Remove TableHeaderView.

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -53,10 +53,8 @@ final class UITableViewExtensionsTests: XCTestCase {
 	}
 	
 	func testRemoveTableFooterView() {
-		tableView.tableFooterView = UIView()
-		XCTAssertNotNil(tableView.tableFooterView)
 		tableView.removeTableFooterView()
-		XCTAssertNil(tableView.tableFooterView)
+		XCTAssertEqual((tableView.tableFooterView ?? UIView()).frame.height, 0)
 	}
 	
 	func testRemoveTableHeaderView() {


### PR DESCRIPTION
Setting the tableFooterView to nil won't remove the footer view, you need to create an empty UIView() to actually remove it

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a changelog entry describing my changes.
