### PR TITLE
Signed numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,17 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `all()` method moved from ArrayExtensions to SequenceExtensions. [#424](https://github.com/SwifterSwift/SwifterSwift/pull/424) by [n0an](https://github.com/n0an).
   - `none()` method moved from ArrayExtensions to SequenceExtensions. [#424](https://github.com/SwifterSwift/SwifterSwift/pull/424) by [n0an](https://github.com/n0an).
   - Added `any()` method to return if any element of sequence elements conforms to given condition. [#424](https://github.com/SwifterSwift/SwifterSwift/pull/424) by [n0an](https://github.com/n0an).
+- **SignedInteger**
+  - added `ordinalString(locale:)` method to return string ordinal representation of number in specified locale language.
+- **SignedNumeric**
+  - added `spelledOutString(locale:)` method to return string representation of number spelled in specified locale language.
 - **String**
   - added computed property `isSpelledCorrectly` to check if the given string has typos or not. [#430](https://github.com/SwifterSwift/SwifterSwift/pull/430) by [n0an](https://github.com/n0an).
   - added `removingPrefix(_ prefix:)` method to remove given prefix from the string. [#430](https://github.com/SwifterSwift/SwifterSwift/pull/430) by [n0an](https://github.com/n0an).
   - added `removingSuffix(_ suffix:)` method to remove given suffix from the string. [#430](https://github.com/SwifterSwift/SwifterSwift/pull/430) by [n0an](https://github.com/n0an).
 - **SwiftLint**:
   - reduced the number of disabled rules in _.swiftlint.yml_, please add `disable` and `enable` statements from now on when needed in code.
-  
+
 ### Changed
 - **SignedNumeric**:
   - `asLocaleCurrency` now returns an optional string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `none()` method moved from ArrayExtensions to SequenceExtensions. [#424](https://github.com/SwifterSwift/SwifterSwift/pull/424) by [n0an](https://github.com/n0an).
   - Added `any()` method to return if any element of sequence elements conforms to given condition. [#424](https://github.com/SwifterSwift/SwifterSwift/pull/424) by [n0an](https://github.com/n0an).
 - **SignedInteger**
-  - added `ordinalString(locale:)` method to return string ordinal representation of number in specified locale language.
+  - added `ordinalString(locale:)` method to return string ordinal representation of number in specified locale language. [#434](https://github.com/SwifterSwift/SwifterSwift/pull/434) by [n0an](https://github.com/n0an).
 - **SignedNumeric**
-  - added `spelledOutString(locale:)` method to return string representation of number spelled in specified locale language.
+  - added `spelledOutString(locale:)` method to return string representation of number spelled in specified locale language. [#434](https://github.com/SwifterSwift/SwifterSwift/pull/434) by [n0an](https://github.com/n0an).
 - **String**
   - added computed property `isSpelledCorrectly` to check if the given string has typos or not. [#430](https://github.com/SwifterSwift/SwifterSwift/pull/430) by [n0an](https://github.com/n0an).
   - added `removingPrefix(_ prefix:)` method to remove given prefix from the string. [#430](https://github.com/SwifterSwift/SwifterSwift/pull/430) by [n0an](https://github.com/n0an).

--- a/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
@@ -78,5 +78,22 @@ public extension SignedInteger {
 		return (self * n).abs / gcd(of: n)
 	}
 	// swiftlint:enable identifier_name
-
+    
+    /// SwifterSwift: Ordinal representation of an integer.
+    ///
+    ///        print((12).ordinalString()) // prints "12th"
+    ///
+    /// - Parameter locale: Locale, default is .current.
+    /// - Returns: String ordinal representation of number in specified locale language. E.g. input 92, output in "en": "92nd"
+    public func ordinalString(locale: Locale = .current) -> String? {
+        if #available(iOS 9.0, macOS 10.11, *) {
+            let formatter = NumberFormatter()
+            formatter.locale = locale
+            formatter.numberStyle = .ordinal
+            guard let number = self as? NSNumber else { return nil }
+            return formatter.string(from: number)
+        } else {
+            return ""
+        }
+    }
 }

--- a/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
@@ -79,24 +79,20 @@ public extension SignedInteger {
 	}
 	// swiftlint:enable identifier_name
     
+    #if canImport(Foundation)
+    @available(iOS 9.0, macOS 10.11, *)
     /// SwifterSwift: Ordinal representation of an integer.
     ///
     ///        print((12).ordinalString()) // prints "12th"
     ///
     /// - Parameter locale: Locale, default is .current.
     /// - Returns: String ordinal representation of number in specified locale language. E.g. input 92, output in "en": "92nd"
-    
-    #if canImport(Foundation)
     public func ordinalString(locale: Locale = .current) -> String? {
-        if #available(iOS 9.0, macOS 10.11, *) {
             let formatter = NumberFormatter()
             formatter.locale = locale
             formatter.numberStyle = .ordinal
             guard let number = self as? NSNumber else { return nil }
             return formatter.string(from: number)
-        } else {
-            return nil
-        }
     }
     #endif
 }

--- a/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
@@ -85,6 +85,8 @@ public extension SignedInteger {
     ///
     /// - Parameter locale: Locale, default is .current.
     /// - Returns: String ordinal representation of number in specified locale language. E.g. input 92, output in "en": "92nd"
+    
+    #if canImport(Foundation)
     public func ordinalString(locale: Locale = .current) -> String? {
         if #available(iOS 9.0, macOS 10.11, *) {
             let formatter = NumberFormatter()
@@ -93,7 +95,8 @@ public extension SignedInteger {
             guard let number = self as? NSNumber else { return nil }
             return formatter.string(from: number)
         } else {
-            return ""
+            return nil
         }
     }
+    #endif
 }

--- a/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
@@ -35,6 +35,7 @@ public extension SignedNumeric {
     ///
     /// - Parameter locale: Locale, default is .current.
     /// - Returns: String representation of number spelled in specified locale language. E.g. input 92, output in "en": "ninety-two"
+    #if canImport(Foundation)
     public func spelledOutString(locale: Locale = .current) -> String? {
         let formatter = NumberFormatter()
         formatter.locale = locale
@@ -43,4 +44,5 @@ public extension SignedNumeric {
         guard let number = self as? NSNumber else { return nil }
         return formatter.string(from: number)
     }
+    #endif
 }

--- a/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
@@ -25,3 +25,22 @@ public extension SignedNumeric {
 	}
 
 }
+
+// MARK: - Methods
+public extension SignedNumeric {
+    
+    /// SwifterSwift: Spelled out representation of a number.
+    ///
+    ///        print((12.32).spelledOutString()) // prints "twelve point three two"
+    ///
+    /// - Parameter locale: Locale, default is .current.
+    /// - Returns: String representation of number spelled in specified locale language. E.g. input 92, output in "en": "ninety-two"
+    public func spelledOutString(locale: Locale = .current) -> String? {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .spellOut
+        
+        guard let number = self as? NSNumber else { return nil }
+        return formatter.string(from: number)
+    }
+}

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -715,6 +715,18 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(testString * -5, "")
         XCTAssertEqual(-5 * testString, "")
     }
+    
+    func testIntSpellOut() {
+        let num = 12.32
+        XCTAssertNotNil(num.spelledOutString(locale: Locale(identifier: "en_US")))
+        XCTAssertEqual(num.spelledOutString(locale: Locale(identifier: "en_US")), "twelve point three two")
+    }
+    
+    func testIntOrdinal() {
+        let num = 12
+        XCTAssertNotNil(num.ordinalString())
+        XCTAssertEqual(num.ordinalString(), "12th")
+    }
 
 }
 // swiftlint:enable type_body_length


### PR DESCRIPTION
🚀 
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a changelog entry describing my changes.

Added one method to SignedNumeric extension, and one to SignedInteger extension:
- spelledOutString(locale:)  returns String representation of number spelled in specified locale language
- ordinalString(locale:)  returns String ordinal representation of number in specified locale language