### PR TITLE
update UITableView and UICollectionView Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 >
 > ### Added
 > ### Changed
+- **UITableViewExtentions**:
+  - `dequeueReusableCell(withClass:for)`, `dequeueReusableCell(withClass)` now return `UITableViewCell` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
+  - `dequeueReusableHeaderFooterView(withClass)`now returns `UITableViewHeaderFooterView` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
+- **UICollectionView**:
+  - `dequeueReusableCell(withClass:for)` now return `UICollectionViewCell` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
+  - `dequeueReusableSupplementaryView(ofKind:withClass:for)`now returns `UICollectionReusableView` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
 > ### Deprecated
 > ### Removed
 > ### Fixed

--- a/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -89,7 +89,7 @@ public extension UICollectionView {
 	///   - name: UICollectionReusableView type.
 	///   - indexPath: location of cell in collectionView.
 	/// - Returns: UICollectionReusableView object with associated class name.
-	public func dequeueReusableSupplementaryView<T: UICollectionReusableView>(ofKind kind: String, withClass name: T.Type, for indexPath: IndexPath) -> T? {
+	public func dequeueReusableSupplementaryView<T: UICollectionReusableView>(ofKind kind: String, withClass name: T.Type, for indexPath: IndexPath) -> T {
         guard let cell = dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: String(describing: name), for: indexPath) as? T else {
             fatalError("Couldn't find nib file for \(String(describing: name))")
         }

--- a/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -75,9 +75,12 @@ public extension UICollectionView {
 	///   - name: UICollectionViewCell type.
 	///   - indexPath: location of cell in collectionView.
 	/// - Returns: UICollectionViewCell object with associated class name.
-	public func dequeueReusableCell<T: UICollectionViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T? {
-		return dequeueReusableCell(withReuseIdentifier: String(describing: name), for: indexPath) as? T
-	}
+    public func dequeueReusableCell<T: UICollectionViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
+        guard let cell = self.dequeueReusableCell(withReuseIdentifier: String(describing: name), for: indexPath) as? T else {
+            fatalError("Couldn't find nib file for \(String(describing: name))")
+        }
+        return cell
+    }
 
 	/// SwifterSwift: Dequeue reusable UICollectionReusableView using class name.
 	///
@@ -87,7 +90,10 @@ public extension UICollectionView {
 	///   - indexPath: location of cell in collectionView.
 	/// - Returns: UICollectionReusableView object with associated class name.
 	public func dequeueReusableSupplementaryView<T: UICollectionReusableView>(ofKind kind: String, withClass name: T.Type, for indexPath: IndexPath) -> T? {
-		return dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: String(describing: name), for: indexPath) as? T
+        guard let cell = dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: String(describing: name), for: indexPath) as? T else {
+            fatalError("Couldn't find nib file for \(String(describing: name))")
+        }
+		return cell
 	}
 
 	/// SwifterSwift: Register UICollectionReusableView using class name.

--- a/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -76,8 +76,8 @@ public extension UICollectionView {
 	///   - indexPath: location of cell in collectionView.
 	/// - Returns: UICollectionViewCell object with associated class name.
     public func dequeueReusableCell<T: UICollectionViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
-        guard let cell = self.dequeueReusableCell(withReuseIdentifier: String(describing: name), for: indexPath) as? T else {
-            fatalError("Couldn't find nib file for \(String(describing: name))")
+        guard let cell = dequeueReusableCell(withReuseIdentifier: String(describing: name), for: indexPath) as? T else {
+            fatalError("Couldn't find UICollectionViewCell for \(String(describing: name))")
         }
         return cell
     }
@@ -91,7 +91,7 @@ public extension UICollectionView {
 	/// - Returns: UICollectionReusableView object with associated class name.
 	public func dequeueReusableSupplementaryView<T: UICollectionReusableView>(ofKind kind: String, withClass name: T.Type, for indexPath: IndexPath) -> T {
         guard let cell = dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: String(describing: name), for: indexPath) as? T else {
-            fatalError("Couldn't find nib file for \(String(describing: name))")
+            fatalError("Couldn't find UICollectionReusableView for \(String(describing: name))")
         }
 		return cell
 	}

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -94,8 +94,8 @@ public extension UITableView {
 	/// - Parameter name: UITableViewCell type
 	/// - Returns: UITableViewCell object with associated class name.
     public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type) -> T {
-        guard let cell = self.dequeueReusableCell(withIdentifier: String(describing: name)) as? T else {
-            fatalError("Couldn't find nib file for \(String(describing: name))")
+        guard let cell = dequeueReusableCell(withIdentifier: String(describing: name)) as? T else {
+            fatalError("Couldn't find UITableViewCell for \(String(describing: name))")
         }
         return cell
     }
@@ -108,7 +108,7 @@ public extension UITableView {
 	/// - Returns: UITableViewCell object with associated class name.
     public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
         guard let cell = dequeueReusableCell(withIdentifier: String(describing: name), for: indexPath) as? T else {
-            fatalError("Couldn't find nib file for \(String(describing: name))")
+            fatalError("Couldn't find UITableViewCell for \(String(describing: name))")
         }
         return cell
     }
@@ -118,8 +118,8 @@ public extension UITableView {
 	/// - Parameter name: UITableViewHeaderFooterView type
 	/// - Returns: UITableViewHeaderFooterView object with associated class name.
     public func dequeueReusableHeaderFooterView<T: UITableViewHeaderFooterView>(withClass name: T.Type) -> T {
-        guard let headerFooterView = self.dequeueReusableHeaderFooterView(withIdentifier: String(describing: name)) as? T else {
-            fatalError("Couldn't find nib file for \(String(describing: name))")
+        guard let headerFooterView = dequeueReusableHeaderFooterView(withIdentifier: String(describing: name)) as? T else {
+            fatalError("Couldn't find UITableViewHeaderFooterView for \(String(describing: name))")
         }
         return headerFooterView
     }

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -92,10 +92,13 @@ public extension UITableView {
 	/// SwifterSwift: Dequeue reusable UITableViewCell using class name
 	///
 	/// - Parameter name: UITableViewCell type
-	/// - Returns: UITableViewCell object with associated class name (optional value)
-	public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type) -> T? {
-		return dequeueReusableCell(withIdentifier: String(describing: name)) as? T
-	}
+	/// - Returns: UITableViewCell object with associated class name.
+    public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type) -> T {
+        guard let cell = self.dequeueReusableCell(withIdentifier: String(describing: name)) as? T else {
+            fatalError("Couldn't find nib file for \(String(describing: name))")
+        }
+        return cell
+    }
 
 	/// SwiferSwift: Dequeue reusable UITableViewCell using class name for indexPath
 	///
@@ -103,17 +106,23 @@ public extension UITableView {
 	///   - name: UITableViewCell type.
 	///   - indexPath: location of cell in tableView.
 	/// - Returns: UITableViewCell object with associated class name.
-	public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T? {
-		return dequeueReusableCell(withIdentifier: String(describing: name), for: indexPath) as? T
-	}
+    public func dequeueReusableCell<T: UITableViewCell>(withClass name: T.Type, for indexPath: IndexPath) -> T {
+        guard let cell = dequeueReusableCell(withIdentifier: String(describing: name), for: indexPath) as? T else {
+            fatalError("Couldn't find nib file for \(String(describing: name))")
+        }
+        return cell
+    }
 
 	/// SwiferSwift: Dequeue reusable UITableViewHeaderFooterView using class name
 	///
 	/// - Parameter name: UITableViewHeaderFooterView type
-	/// - Returns: UITableViewHeaderFooterView object with associated class name (optional value)
-	public func dequeueReusableHeaderFooterView<T: UITableViewHeaderFooterView>(withClass name: T.Type) -> T? {
-		return dequeueReusableHeaderFooterView(withIdentifier: String(describing: name)) as? T
-	}
+	/// - Returns: UITableViewHeaderFooterView object with associated class name.
+    public func dequeueReusableHeaderFooterView<T: UITableViewHeaderFooterView>(withClass name: T.Type) -> T {
+        guard let headerFooterView = self.dequeueReusableHeaderFooterView(withIdentifier: String(describing: name)) as? T else {
+            fatalError("Couldn't find nib file for \(String(describing: name))")
+        }
+        return headerFooterView
+    }
 
 	/// SwifterSwift: Register UITableViewHeaderFooterView using class name
 	///

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -99,8 +99,6 @@ final class UITableViewExtensionsTests: XCTestCase {
 
 	#if os(iOS)
 	func testRegisterReusableViewWithClassAndNib() {
-		let nilView = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
-		XCTAssertNil(nilView)
 		let nib = UINib(nibName: "UITableViewHeaderFooterView", bundle: Bundle(for: UITableViewExtensionsTests.self))
 		tableView.register(nib: nib, withHeaderFooterViewClass: UITableViewHeaderFooterView.self)
 		let view = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
@@ -109,16 +107,12 @@ final class UITableViewExtensionsTests: XCTestCase {
 	#endif
 
 	func testRegisterReusableViewWithClass() {
-		let nilView = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
-		XCTAssertNil(nilView)
 		tableView.register(headerFooterViewClassWith: UITableViewHeaderFooterView.self)
 		let view = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
 		XCTAssertNotNil(view)
 	}
 
 	func testRegisterCellWithClass() {
-		let nilCell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
-		XCTAssertNil(nilCell)
 		tableView.register(cellWithClass: UITableViewCell.self)
 		let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
 		XCTAssertNotNil(cell)
@@ -126,8 +120,6 @@ final class UITableViewExtensionsTests: XCTestCase {
 
 	#if os(iOS)
 	func testRegisterCellWithClassAndNib() {
-		let nilCell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
-		XCTAssertNil(nilCell)
 		let nib = UINib(nibName: "UITableViewCell", bundle: Bundle(for: UITableViewExtensionsTests.self))
 		tableView.register(nib: nib, withCellClass: UITableViewCell.self)
 		let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
@@ -137,8 +129,6 @@ final class UITableViewExtensionsTests: XCTestCase {
 
 	#if os(iOS)
 	func testRegisterCellWithNibUsingClass() {
-		let nilCell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
-		XCTAssertNil(nilCell)
 		tableView.register(nibWithCellClass: UITableViewCell.self, at: UITableViewExtensionsTests.self)
 		let cell = tableView.dequeueReusableCell(withClass: UITableViewCell.self)
 		XCTAssertNotNil(cell)


### PR DESCRIPTION
In this PR I am updating:
`dequeueReusableCell(withClass:for)`,
`dequeueReusableHeaderFooterView(withClass)`,
`dequeueReusableCell(withClass)` in **UITableViewExtentions** and  `dequeueReusableCell(withClass:for)`,
`dequeueReusableSupplementaryView(ofKind:withClass:for)` in **UICollectionViewExtentions** 
to return not an optional value. In my opinion is better to get a `fatalError(...)` if the nib file could not be found.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.