### PR TITLE
Remove warnings and dead references

### DIFF
--- a/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
@@ -78,7 +78,7 @@ public extension SignedInteger {
 		return (self * n).abs / gcd(of: n)
 	}
 	// swiftlint:enable identifier_name
-    
+
     #if canImport(Foundation)
     @available(iOS 9.0, macOS 10.11, *)
     /// SwifterSwift: Ordinal representation of an integer.

--- a/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
@@ -28,7 +28,7 @@ public extension SignedNumeric {
 
 // MARK: - Methods
 public extension SignedNumeric {
-    
+
     /// SwifterSwift: Spelled out representation of a number.
     ///
     ///        print((12.32).spelledOutString()) // prints "twelve point three two"
@@ -40,7 +40,7 @@ public extension SignedNumeric {
         let formatter = NumberFormatter()
         formatter.locale = locale
         formatter.numberStyle = .spellOut
-        
+
         guard let number = self as? NSNumber else { return nil }
         return formatter.string(from: number)
     }

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -415,7 +415,6 @@
 
 /* Begin PBXFileReference section */
 		0713066E1FB597920023A9D8 /* FoundationDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationDeprecated.swift; sourceTree = "<group>"; };
-		07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationDeprecated.swift; sourceTree = "<group>"; };
 		0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensions.swift; sourceTree = "<group>"; };
 		074EAF1E1F7BA74600C74636 /* UIFontExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionsTest.swift; sourceTree = "<group>"; };
@@ -611,14 +610,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		071306651FB596600023A9D8 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				07263D5C1FB3175F003CE515 /* FoundationDeprecated.swift */,
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		0713066D1FB5977F0023A9D8 /* Deprecated */ = {
 			isa = PBXGroup;
 			children = (
@@ -686,7 +677,6 @@
 				07898B8D1F278E6300558C97 /* Sources */,
 				07C50CF21F5EAF7B00F46E5A /* Tests */,
 				07898B5E1F278D7600558C97 /* Products */,
-				071306651FB596600023A9D8 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -715,13 +715,13 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(testString * -5, "")
         XCTAssertEqual(-5 * testString, "")
     }
-    
+
     func testIntSpellOut() {
         let num = 12.32
         XCTAssertNotNil(num.spelledOutString(locale: Locale(identifier: "en_US")))
         XCTAssertEqual(num.spelledOutString(locale: Locale(identifier: "en_US")), "twelve point three two")
     }
-    
+
     func testIntOrdinal() {
         let num = 12
         XCTAssertNotNil(num.ordinalString())


### PR DESCRIPTION
🚀
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.

This is a really small update just to remove SwiftLint warnings and a dead reference to `FoundationDeprecated.swift`.