### PR TITLE
Add isValidIndexPath to UITableViewExtensions

### DIFF
--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -172,6 +172,14 @@ public extension UITableView {
 
         register(UINib(nibName: identifier, bundle: bundle), forCellReuseIdentifier: identifier)
     }
+    
+    /// SwifterSwift: Check whether IndexPath is valid within the tableView
+    ///
+    /// - Parameter indexPath: An IndexPath to check
+    /// - Returns: Boolean value for valid or invalid IndexPath
+    public func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
+        return indexPath.section < self.numberOfSections && indexPath.row < self.numberOfRows(inSection: indexPath.section)
+    }
 
 }
 #endif

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -96,6 +96,13 @@ final class UITableViewExtensionsTests: XCTestCase {
 		let headerFooterView = tableView.dequeueReusableHeaderFooterView(withClass: UITableViewHeaderFooterView.self)
 		XCTAssertNotNil(headerFooterView)
 	}
+    
+    func testIsValidIndexPath() {
+        let validIndexPath = IndexPath(row: 0, section: 0)
+        XCTAssertTrue(tableView.isValidIndexPath(validIndexPath))
+        let invalidIndexPath = IndexPath(row: 10, section: 0)
+        XCTAssertFalse(tableView.isValidIndexPath(invalidIndexPath))
+    }
 
 	#if os(iOS)
 	func testRegisterReusableViewWithClassAndNib() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
:rocket:

This PR will support my next PR about safely scroll table view to index path. Because it mentioned that one PR only for one extension, so I separate it.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
