### PR TITLE
Random numerics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 - **UITableViewExtentions**:
   - Added `isValidIndexPath(_ indexPath:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
+  **(BinaryFloatingPoint/BinaryInteger/Strideable)Extensions**:
+  - Added extensions for generating random numbers for any type of number (BinaryInteger/BinaryFloat). [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+> ### Changed
 **Optional**:
   - Added `isNilOrEmpty` property to check whether an optional is nil or empty collection.
 
@@ -16,14 +19,23 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UICollectionView**:
   - `dequeueReusableCell(withClass:for)` now return `UICollectionViewCell` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
   - `dequeueReusableSupplementaryView(ofKind:withClass:for)`now returns `UICollectionReusableView` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
+- **ColorExtensions**:
+  - `random` now uses `CGFloat.random()` to generate the random color values. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+- **ArrayExtensions**:
+  - `shuffle()` now uses `Int.random(lowerBound:upperBound:)` to perform the Fisher-Yates shuffle. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+- **BoolExtensions**:
+  - `random` now uses `Int.random(lowerBound:upperBound:)`. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+> ### Deprecated
+- **CGFloatExtensions**:
+  - `randomBetween` has been deprecated in favour of `CGFloat.random(lowerBound:upperBound)`. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+- **IntExtensions**:
+  - `random(between:and:)` has been deprecated in favour of `Int.random(lowerBound:upperBound)`. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+> ### Removed
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
+> ### Fixed
+- **Project**
+  - Set `SwifterSwift` as the project's default organization so that newly created files will set it automatically. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+> ### Security
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UITableViewExtentions**:
   - Added `isValidIndexPath(_ indexPath:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
   **(BinaryFloatingPoint/BinaryInteger/Strideable)Extensions**:
-  - Added extensions for generating random numbers for any type of number (BinaryInteger/BinaryFloat). [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+  - Added extensions for generating random numbers for any type of number (BinaryInteger/BinaryFloatingPoint). [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
+  **(Signed/Unsigned-RandomizableInteger)**:
+  - Added a new protocol (with extensions for Int/UInt/8/16/32/64) for generating random numbers for any type of integer. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
 > ### Changed
 **Optional**:
   - Added `isNilOrEmpty` property to check whether an optional is nil or empty collection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 - **UITableViewExtentions**:
   - Added `isValidIndexPath(_ indexPath:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
-  **(BinaryFloatingPoint/BinaryInteger/Strideable)Extensions**:
+- **(BinaryFloatingPoint/BinaryInteger/Strideable)Extensions**:
   - Added extensions for generating random numbers for any type of number (BinaryInteger/BinaryFloatingPoint). [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
-  **(Signed/Unsigned-RandomizableInteger)**:
+- **(Signed/Unsigned-RandomizableInteger)**:
   - Added a new protocol (with extensions for Int/UInt/8/16/32/64) for generating random numbers for any type of integer. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
-> ### Changed
-**Optional**:
+- **Optional**:
   - Added `isNilOrEmpty` property to check whether an optional is nil or empty collection.
 
 ### Changed
@@ -27,17 +26,20 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `shuffle()` now uses `Int.random(lowerBound:upperBound:)` to perform the Fisher-Yates shuffle. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
 - **BoolExtensions**:
   - `random` now uses `Int.random(lowerBound:upperBound:)`. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
-> ### Deprecated
+
+### Deprecated
 - **CGFloatExtensions**:
   - `randomBetween` has been deprecated in favour of `CGFloat.random(lowerBound:upperBound)`. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
 - **IntExtensions**:
   - `random(between:and:)` has been deprecated in favour of `Int.random(lowerBound:upperBound)`. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
-> ### Removed
 
-> ### Fixed
+### Removed
+
+### Fixed
 - **Project**
   - Set `SwifterSwift` as the project's default organization so that newly created files will set it automatically. [#444](https://github.com/SwifterSwift/SwifterSwift/pull/444) by [guykogus](https://github.com/guykogus).
-> ### Security
+
+### Security
 
 ---
 

--- a/Sources/Extensions/CoreGraphics/CGFloatExtensions.swift
+++ b/Sources/Extensions/CoreGraphics/CGFloatExtensions.swift
@@ -81,9 +81,9 @@ public extension CGFloat {
 	///   - min: minimum number to start random from.
 	///   - max: maximum number random number end before.
 	/// - Returns: random CGFloat between two CGFloat values.
+	@available(*, deprecated: 4.4, message: "Use `CGFloat.random(lowerBound:upperBound:)` instead.")
 	public static func randomBetween(min: CGFloat, max: CGFloat) -> CGFloat {
-		let delta = max - min
-		return min + CGFloat(arc4random_uniform(UInt32(delta)))
+		return CGFloat.random(lowerBound: min, upperBound: max)
 	}
 
 }

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -866,17 +866,9 @@ public extension Date {
 	///   - toDate: maximum date (default is Date.distantFuture)
 	/// - Returns: random date between two dates.
 	public static func random(from fromDate: Date = Date.distantPast, upTo toDate: Date = Date.distantFuture) -> Date {
-		guard fromDate != toDate else {
-			return fromDate
-		}
-
-		let diff = llabs(Int64(toDate.timeIntervalSinceReferenceDate - fromDate.timeIntervalSinceReferenceDate))
-		var randomValue: Int64 = 0
-		arc4random_buf(&randomValue, MemoryLayout<Int64>.size)
-		randomValue = llabs(randomValue%diff)
-
-		let startReferenceDate = toDate > fromDate ? fromDate : toDate
-		return startReferenceDate.addingTimeInterval(TimeInterval(randomValue))
+        let randomReferenceDate = TimeInterval.random(lowerBound: fromDate.timeIntervalSinceReferenceDate,
+                                                      upperBound: toDate.timeIntervalSinceReferenceDate)
+        return Date(timeIntervalSinceReferenceDate: randomReferenceDate)
 	}
 
 }

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -26,10 +26,7 @@ public extension Color {
 
 	/// SwifterSwift: Random color.
 	public static var random: Color {
-		let red = Int(arc4random_uniform(255))
-		let green = Int(arc4random_uniform(255))
-		let blue = Int(arc4random_uniform(255))
-		return Color(red: red, green: green, blue: blue)!
+		return Color(red: CGFloat.random(), green: CGFloat.random(), blue: CGFloat.random(), alpha: 1.0)
 	}
 
 	// swiftlint:disable next large_tuple

--- a/Sources/Extensions/Shared/RandomizableInteger.swift
+++ b/Sources/Extensions/Shared/RandomizableInteger.swift
@@ -1,0 +1,154 @@
+//
+//  RandomizableInteger.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 13/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+/// An integer from which we can generate random numbers.
+public protocol RandomizableInteger: FixedWidthInteger {
+    /// SwifterSwift: Generate a random integer within a given range.
+    ///
+    /// - Parameters:
+    ///   - lowerBound: The lower bound of the integer range.
+    ///   - upperBound: The upper bound of the integer range.
+    /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    static func random(lowerBound: Self, upperBound: Self) -> Self
+}
+
+/// A signed integer that has an unsigned integer counterpart
+public protocol SignedRandomizableInteger: RandomizableInteger, SignedInteger {
+
+    /// The `UnsignedInteger` counterpart with equal bit width
+    associatedtype Unsigned: UnsignedRandomizableInteger
+
+}
+
+/// An unsigned integer that has a signed integer counterpart
+public protocol UnsignedRandomizableInteger: RandomizableInteger, UnsignedInteger {
+
+    /// The `SignedInteger` counterpart with equal bit width
+    associatedtype Signed: SignedRandomizableInteger
+
+}
+
+// MARK: - Random functions
+
+// The randomization functions are adapted from @jstn's solution:
+// https://stackoverflow.com/questions/24007129/how-does-one-generate-a-random-number-in-apples-swift-language/25129039#25129039
+
+public extension UnsignedRandomizableInteger {
+    /// SwifterSwift: Generate a random integer within a given range.
+    ///
+    ///   This version is able to handle `UInt64`,
+    ///   which would not be possible using `BinaryInteger.random(lowerBound:upperBound:)`
+    ///
+    /// - Parameters:
+    ///   - lowerBound: The lower bound of the integer range. Defaults to 0.
+    ///   - upperBound: The upper bound of the integer range.
+    /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    /// - Complexity:
+    ///   This could theoretically loop forever but each retry has p > 0.5 (worst case, usually far better).
+    public static func random(lowerBound: Self = 0, upperBound: Self) -> Self {
+        // Static asserts are not yet available in Swift
+        assert(Self.bitWidth == Signed.bitWidth)
+        assert(lowerBound < upperBound)
+
+        var mod: Self
+        let diff = upperBound - lowerBound
+        var rand: Self = arc4random()
+
+        if diff > Self(Signed.max) {
+            mod = 1 + ~diff
+        } else {
+            mod = ((max - (diff * 2)) + 1) % diff
+        }
+
+        while rand < mod {
+            rand = arc4random()
+        }
+
+        return (rand % diff) + lowerBound
+    }
+}
+
+public extension SignedRandomizableInteger {
+    /// SwifterSwift: Generate a random integer within a given range.
+    ///
+    ///   This version is able to handle `Int64`, as well as finding a random number in the range `Self.min..<Self.max`,
+    ///   which would not be possible using `BinaryInteger.random(lowerBound:upperBound:)` due to overflow
+    ///
+    /// - Parameters:
+    ///   - lowerBound: The lower bound of the integer range. Defaults to 0.
+    ///   - upperBound: The upper bound of the integer range.
+    /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    public static func random(lowerBound: Self = 0, upperBound: Self) -> Self {
+        // Static asserts are not yet available in Swift
+        assert(Self.bitWidth == Unsigned.bitWidth)
+        assert(lowerBound < upperBound)
+
+        let (sub, overflow) = upperBound.subtractingReportingOverflow(lowerBound)
+        let diff = overflow ? Unsigned.max - Unsigned(~sub) : Unsigned(sub)
+        let rand = Unsigned.random(upperBound: diff)
+
+        if rand > Unsigned(Self.max) {
+            return Self(rand - (Unsigned(~lowerBound) + 1))
+        } else {
+            return Self(rand) + lowerBound
+        }
+    }
+}
+
+// MARK: -
+// MARK: SignedRandomizableInteger types
+
+extension Int: SignedRandomizableInteger {
+    public typealias Unsigned = UInt
+}
+
+extension Int8: SignedRandomizableInteger {
+    public typealias Unsigned = UInt8
+}
+
+extension Int16: SignedRandomizableInteger {
+    public typealias Unsigned = UInt16
+}
+
+extension Int32: SignedRandomizableInteger {
+    public typealias Unsigned = UInt32
+}
+
+extension Int64: SignedRandomizableInteger {
+    public typealias Unsigned = UInt64
+}
+
+// MARK: UnsignedRandomizableInteger types
+
+extension UInt: UnsignedRandomizableInteger {
+    public typealias Signed = Int
+}
+
+extension UInt8: UnsignedRandomizableInteger {
+    public typealias Signed = Int8
+}
+
+extension UInt16: UnsignedRandomizableInteger {
+    public typealias Signed = Int16
+}
+
+extension UInt32: UnsignedRandomizableInteger {
+    public typealias Signed = Int32
+}
+
+extension UInt64: UnsignedRandomizableInteger {
+    public typealias Signed = Int64
+}
+
+// MARK: - Private functions
+
+private func arc4random<T: ExpressibleByIntegerLiteral>() -> T {
+    var rand: T = 0
+    arc4random_buf(&rand, MemoryLayout<T>.size)
+    return rand
+}

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -366,7 +366,7 @@ public extension Array {
 		// http://stackoverflow.com/questions/37843647/shuffle-array-swift-3
 		guard count > 1 else { return self }
 		for index in startIndex..<endIndex - 1 {
-			let randomIndex = Int(arc4random_uniform(UInt32(endIndex - index))) + index
+			let randomIndex = Int.random(lowerBound: index, upperBound: endIndex)
 			if index != randomIndex { swapAt(index, randomIndex) }
 		}
 		return self

--- a/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
@@ -7,13 +7,13 @@
 //
 
 public extension BinaryFloatingPoint {
-	/// SwifterSwift: Generate a random floating point number within a given range.
-	///
-	/// - Parameters:
-	///   - lowerBound: The lower bound of the floating point range. Defaults to 0.0.
-	///   - upperBound: The upper bound of the floating point range. Defaults to 1.0.
-	/// - Returns: A floating point between `lowerBound` and `upperBound` (inclusive).
-	public static func random(lowerBound: Self = 0.0, upperBound: Self = 1.0) -> Self {
-		return lowerBound + (Self(drand48()) * (upperBound - lowerBound))
-	}
+    /// SwifterSwift: Generate a random floating point number within a given range.
+    ///
+    /// - Parameters:
+    ///   - lowerBound: The lower bound of the floating point range. Defaults to 0.0.
+    ///   - upperBound: The upper bound of the floating point range. Defaults to 1.0.
+    /// - Returns: A floating point between `lowerBound` and `upperBound` (inclusive).
+    public static func random(lowerBound: Self = 0.0, upperBound: Self = 1.0) -> Self {
+        return lowerBound + (Self(drand48()) * (upperBound - lowerBound))
+    }
 }

--- a/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
@@ -1,0 +1,19 @@
+//
+//  BinaryFloatingPointExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 11/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+extension BinaryFloatingPoint {
+	/// SwifterSwift: Generate a random floating point number within a given range.
+	///
+	/// - Parameters:
+	///   - lowerBound: The lower bound of the floating point range. Defaults to 0.0.
+	///   - upperBound: The upper bound of the floating point range. Defaults to 1.0.
+	/// - Returns: A floating point between `lowerBound` and `upperBound` (inclusive).
+	public static func random(lowerBound: Self = 0.0, upperBound: Self = 1.0) -> Self {
+		return lowerBound + (Self(drand48()) * (upperBound - lowerBound))
+	}
+}

--- a/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-extension BinaryFloatingPoint {
+public extension BinaryFloatingPoint {
 	/// SwifterSwift: Generate a random floating point number within a given range.
 	///
 	/// - Parameters:

--- a/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
@@ -7,13 +7,19 @@
 //
 
 public extension BinaryFloatingPoint {
+
     /// SwifterSwift: Generate a random floating point number within a given range.
     ///
     /// - Parameters:
     ///   - lowerBound: The lower bound of the floating point range. Defaults to 0.0.
     ///   - upperBound: The upper bound of the floating point range. Defaults to 1.0.
     /// - Returns: A floating point between `lowerBound` and `upperBound` (inclusive).
+    /// - Warning: If `upperBound - lowerBound` has a non-normal value (e.g. `infinity` or `nan`) the result is undefined.
     public static func random(lowerBound: Self = 0.0, upperBound: Self = 1.0) -> Self {
-        return lowerBound + (Self(drand48()) * (upperBound - lowerBound))
+        assert(lowerBound <= upperBound)
+        let distance = upperBound - lowerBound
+        assert(distance.isNormal)
+        return lowerBound + (Self(drand48()) * distance)
     }
+
 }

--- a/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift
@@ -18,7 +18,7 @@ public extension BinaryFloatingPoint {
     public static func random(lowerBound: Self = 0.0, upperBound: Self = 1.0) -> Self {
         assert(lowerBound <= upperBound)
         let distance = upperBound - lowerBound
-        assert(distance.isNormal)
+        assert(!distance.isSubnormal)
         return lowerBound + (Self(drand48()) * distance)
     }
 

--- a/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
@@ -7,14 +7,19 @@
 //
 
 public extension BinaryInteger {
-	/// SwifterSwift: Generate a random integer within a given range.
-	///
-	/// - Parameters:
-	///   - lowerBound: The lower bound of the integer range. Defaults to 0.
-	///   - upperBound: The upper bound of the integer range.
-	/// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
-	public static func random(lowerBound: Self = 0, upperBound: Self) -> Self {
-		let distance = Self(lowerBound.distance(to: upperBound))
-		return lowerBound + numericCast(arc4random_uniform(numericCast(distance)))
-	}
+    /// SwifterSwift: Generate a random integer within a given range.
+    ///
+    /// Note that if the distance between `lowerBound` and `upperBound` is greater than the type can represent,
+    /// e.g. `Int.min..<Int.max`,
+    /// the function will crash.
+    ///
+    /// - Parameters:
+    ///   - lowerBound: The lower bound of the integer range. Defaults to 0.
+    ///   - upperBound: The upper bound of the integer range.
+    /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    public static func random(lowerBound: Self = 0, upperBound: Self) -> Self {
+        assert(lowerBound < upperBound)
+        let distance = Self(lowerBound.distance(to: upperBound))
+        return lowerBound + numericCast(arc4random_uniform(numericCast(distance)))
+    }
 }

--- a/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-extension BinaryInteger {
+public extension BinaryInteger {
 	/// SwifterSwift: Generate a random integer within a given range.
 	///
 	/// - Parameters:

--- a/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
@@ -1,0 +1,20 @@
+//
+//  BinaryIntegerExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 11/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+extension BinaryInteger {
+	/// SwifterSwift: Generate a random integer within a given range.
+	///
+	/// - Parameters:
+	///   - lowerBound: The lower bound of the integer range. Defaults to 0.
+	///   - upperBound: The upper bound of the integer range.
+	/// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+	public static func random(lowerBound: Self = 0, upperBound: Self) -> Self {
+		let distance = Self(lowerBound.distance(to: upperBound))
+		return lowerBound + numericCast(arc4random_uniform(numericCast(distance)))
+	}
+}

--- a/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BinaryIntegerExtensions.swift
@@ -7,19 +7,24 @@
 //
 
 public extension BinaryInteger {
+
     /// SwifterSwift: Generate a random integer within a given range.
-    ///
-    /// Note that if the distance between `lowerBound` and `upperBound` is greater than the type can represent,
-    /// e.g. `Int.min..<Int.max`,
-    /// the function will crash.
     ///
     /// - Parameters:
     ///   - lowerBound: The lower bound of the integer range. Defaults to 0.
     ///   - upperBound: The upper bound of the integer range.
     /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    /// - Warning: This is an unsafe implementation.
+    ///
+    ///   It will crash for signed integers where `upperBound - lowerBound` has a value that can't be represented
+    ///   (e.g. `Int16.min..<Int16.max`).
+    ///
+    ///   It will crash for 64-bit integers, since it relies on `arc4random_uniform`, which provides a 32-bit random number.
     public static func random(lowerBound: Self = 0, upperBound: Self) -> Self {
         assert(lowerBound < upperBound)
-        let distance = Self(lowerBound.distance(to: upperBound))
+
+        let distance = upperBound - lowerBound
         return lowerBound + numericCast(arc4random_uniform(numericCast(distance)))
     }
+
 }

--- a/Sources/Extensions/SwiftStdlib/BoolExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/BoolExtensions.swift
@@ -33,7 +33,7 @@ public extension Bool {
 	///     Bool.random -> false
 	///
 	public static var random: Bool {
-		return arc4random_uniform(2) == 1
+		return Int.random(upperBound: 2) == 1
 	}
 
 }

--- a/Sources/Extensions/SwiftStdlib/IntExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/IntExtensions.swift
@@ -182,7 +182,6 @@ public extension Int {
 	/// - Parameters:
 	///   - min: minimum number to start random from.
 	///   - max: maximum number random number end before.
-	@available(*, deprecated: 4.4, message: "Use `Int.random(lowerBound:upperBound:)` instead.")
 	public init(randomBetween min: Int, and max: Int) {
 		self = Int.random(lowerBound: min, upperBound: max)
 	}

--- a/Sources/Extensions/SwiftStdlib/IntExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/IntExtensions.swift
@@ -100,6 +100,7 @@ public extension Int {
 	///   - min: minimum number to start random from.
 	///   - max: maximum number random number end before.
 	/// - Returns: random double between two double values.
+	@available(*, deprecated: 4.4, message: "Use `Int.random(lowerBound:upperBound:)` instead.")
 	public static func random(between min: Int, and max: Int) -> Int {
 		return random(inRange: min...max)
 	}
@@ -181,8 +182,9 @@ public extension Int {
 	/// - Parameters:
 	///   - min: minimum number to start random from.
 	///   - max: maximum number random number end before.
+	@available(*, deprecated: 4.4, message: "Use `Int.random(lowerBound:upperBound:)` instead.")
 	public init(randomBetween min: Int, and max: Int) {
-		self = Int.random(between: min, and: max)
+		self = Int.random(lowerBound: min, upperBound: max)
 	}
 
 	/// SwifterSwift: Create a random integer in a closed interval range.

--- a/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
@@ -1,0 +1,20 @@
+//
+//  StrideableExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 11/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+extension Strideable where Stride: BinaryInteger {
+	/// SwifterSwift: Generate a random integer within a given `Strideable` range.
+	///
+	/// - Parameters:
+	///   - lowerBound: The lower bound of the integer-`Strideable` range.
+	///   - upperBound: The upper bound of the integer-`Strideable` range.
+	/// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+	public static func random(lowerBound: Self, upperBound: Self) -> Self {
+		let distance = lowerBound.distance(to: upperBound)
+		return lowerBound.advanced(by: numericCast(arc4random_uniform(numericCast(distance))))
+	}
+}

--- a/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
@@ -7,14 +7,15 @@
 //
 
 public extension Strideable where Stride: BinaryInteger {
-	/// SwifterSwift: Generate a random integer within a given `Strideable` range.
-	///
-	/// - Parameters:
-	///   - lowerBound: The lower bound of the integer-`Strideable` range.
-	///   - upperBound: The upper bound of the integer-`Strideable` range.
-	/// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
-	public static func random(lowerBound: Self, upperBound: Self) -> Self {
-		let distance = lowerBound.distance(to: upperBound)
-		return lowerBound.advanced(by: numericCast(arc4random_uniform(numericCast(distance))))
-	}
+    /// SwifterSwift: Generate a random integer within a given `Strideable` range.
+    ///
+    /// - Parameters:
+    ///   - lowerBound: The lower bound of the integer-`Strideable` range.
+    ///   - upperBound: The upper bound of the integer-`Strideable` range.
+    /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    public static func random(lowerBound: Self, upperBound: Self) -> Self {
+        assert(lowerBound < upperBound)
+        let distance = lowerBound.distance(to: upperBound)
+        return lowerBound.advanced(by: numericCast(arc4random_uniform(numericCast(distance))))
+    }
 }

--- a/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
@@ -13,9 +13,10 @@ public extension Strideable where Stride: BinaryInteger {
     ///   - lowerBound: The lower bound of the integer-`Strideable` range.
     ///   - upperBound: The upper bound of the integer-`Strideable` range.
     /// - Returns: An integer between `lowerBound` and `upperBound` (exclusive).
+    /// - Warning: This implementation suffers the same issues as `BinaryInteger.random(lowerBound:upperBound:)`
     public static func random(lowerBound: Self, upperBound: Self) -> Self {
         assert(lowerBound < upperBound)
         let distance = lowerBound.distance(to: upperBound)
-        return lowerBound.advanced(by: numericCast(arc4random_uniform(numericCast(distance))))
+        return lowerBound.advanced(by: Self.Stride.random(upperBound: distance))
     }
 }

--- a/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StrideableExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-extension Strideable where Stride: BinaryInteger {
+public extension Strideable where Stride: BinaryInteger {
 	/// SwifterSwift: Generate a random integer within a given `Strideable` range.
 	///
 	/// - Parameters:

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -719,11 +719,10 @@ public extension String {
 	/// - Returns: random string of given length.
 	public static func random(ofLength length: Int) -> String {
 		guard length > 0 else { return "" }
-		let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+		let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charactersArray
 		var randomString = ""
 		for _ in 1...length {
-			let randomIndex = arc4random_uniform(UInt32(base.count))
-			let randomCharacter = base.charactersArray[Int(randomIndex)]
+			let randomCharacter = base.randomItem!
 			randomString.append(randomCharacter)
 		}
 		return randomString
@@ -1031,11 +1030,10 @@ public extension String {
 			return
 		}
 
-		let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+		let base = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 		var randomString = ""
 		for _ in 1...length {
-			let randomIndex = arc4random_uniform(UInt32(base.count))
-			let randomCharacter = Array(base)[Int(randomIndex)]
+			let randomCharacter = base.randomItem!
 			randomString.append(randomCharacter)
 		}
 		self = randomString

--- a/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
@@ -3,7 +3,7 @@
 //  SwifterSwift
 //
 //  Created by Omar Albeik on 5.04.2018.
-//  Copyright © 2018 ___ORGANIZATIONNAME___
+//  Copyright © 2018 SwifterSwift
 //
 
 #if canImport(UIKit)

--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -27,17 +27,17 @@ Pod::Spec.new do |s|
 
   # SwiftStdlib Extensions
   s.subspec 'SwiftStdlib' do |sp|
-    sp.source_files  = 'Sources/Extensions/SwiftStdlib/*.swift'
+    sp.source_files  = 'Sources/Extensions/SwiftStdlib/*.swift', 'Sources/Extensions/Shared/RandomizableInteger.swift'
   end
 
   # Foundation Extensions
   s.subspec 'Foundation' do |sp|
-    sp.source_files  = 'Sources/Extensions/Foundation/*.swift'
+    sp.source_files  = 'Sources/Extensions/Foundation/*.swift', 'Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift'
   end
 
   # UIKit Extensions
   s.subspec 'UIKit' do |sp|
-    sp.source_files  = 'Sources/Extensions/UIKit/*.swift', 'Sources/Extensions/Shared/ColorExtensions.swift'
+    sp.source_files  = 'Sources/Extensions/UIKit/*.swift', 'Sources/Extensions/Shared/ColorExtensions.swift', 'Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift'
   end
 
   # AppKit Extensions
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
 
   # CoreGraphics Extensions
   s.subspec 'CoreGraphics' do |sp|
-    sp.source_files  = 'Sources/Extensions/CoreGraphics/*.swift'
+    sp.source_files  = 'Sources/Extensions/CoreGraphics/*.swift', 'Sources/Extensions/SwiftStdlib/BinaryFloatingPointExtensions.swift'
   end
 
   # CoreLocation Extensions

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -387,6 +387,13 @@
 		B23678ED1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
 		B23678EE1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
 		B23678EF1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
+		F8AD1ECE2080DA0800E17EF1 /* RandomizableInteger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ECD2080DA0800E17EF1 /* RandomizableInteger.swift */; };
+		F8AD1ECF2080DA0800E17EF1 /* RandomizableInteger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ECD2080DA0800E17EF1 /* RandomizableInteger.swift */; };
+		F8AD1ED02080DA0800E17EF1 /* RandomizableInteger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ECD2080DA0800E17EF1 /* RandomizableInteger.swift */; };
+		F8AD1ED12080DA0800E17EF1 /* RandomizableInteger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ECD2080DA0800E17EF1 /* RandomizableInteger.swift */; };
+		F8AD1ED32080DA4100E17EF1 /* RandomizableIntegerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ED22080DA4100E17EF1 /* RandomizableIntegerTests.swift */; };
+		F8AD1ED42080DA4100E17EF1 /* RandomizableIntegerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ED22080DA4100E17EF1 /* RandomizableIntegerTests.swift */; };
+		F8AD1ED52080DA4100E17EF1 /* RandomizableIntegerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AD1ED22080DA4100E17EF1 /* RandomizableIntegerTests.swift */; };
 		F8E78D0A207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
 		F8E78D0B207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
 		F8E78D0C207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
@@ -573,6 +580,8 @@
 		A9CD166720242AF900DBE263 /* UICollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UICollectionViewCell.xib; sourceTree = "<group>"; };
 		A9FF467020245ABA0084C40F /* test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test.json; sourceTree = "<group>"; };
 		B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftStdlibDeprecated.swift; sourceTree = "<group>"; };
+		F8AD1ECD2080DA0800E17EF1 /* RandomizableInteger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RandomizableInteger.swift; sourceTree = "<group>"; };
+		F8AD1ED22080DA4100E17EF1 /* RandomizableIntegerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomizableIntegerTests.swift; sourceTree = "<group>"; };
 		F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrideableExtensions.swift; sourceTree = "<group>"; };
 		F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryFloatingPointExtensions.swift; sourceTree = "<group>"; };
 		F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryIntegerExtensions.swift; sourceTree = "<group>"; };
@@ -649,6 +658,7 @@
 			isa = PBXGroup;
 			children = (
 				0726D7761F7C199E0028CAB5 /* ColorExtensions.swift */,
+				F8AD1ECD2080DA0800E17EF1 /* RandomizableInteger.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -824,13 +834,13 @@
 			isa = PBXGroup;
 			children = (
 				784C75322051BDCA001C48DD /* MapKitTests */,
+				D86A98EE1F7E50C90084EDCD /* SharedTests */,
 				077BA0931F6BE93000D9C4AC /* SwiftStdlibTests */,
 				07C50CF91F5EB03200F46E5A /* FoundationTests */,
 				07C50D0D1F5EB03200F46E5A /* UIKitTests */,
 				07D8960F1F5ED8AB00FC894D /* CoreLocationTests */,
 				07D8960E1F5ED89A00FC894D /* CoreGraphicsTests */,
 				07C50D241F5EB03200F46E5A /* AppKitTests */,
-				D86A98EE1F7E50C90084EDCD /* SharedTests */,
 				07C50CCD1F5EAF2700F46E5A /* Info.plist */,
 				07C50D081F5EB03200F46E5A /* Resources */,
 				07C50CF81F5EB03200F46E5A /* SwifterSwiftTests.swift */,
@@ -975,6 +985,7 @@
 			isa = PBXGroup;
 			children = (
 				07C50D121F5EB03200F46E5A /* ColorExtensionsTests.swift */,
+				F8AD1ED22080DA4100E17EF1 /* RandomizableIntegerTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -1392,6 +1403,7 @@
 				9D9784DB1FCAE3D200D988E7 /* StringProtocolExtensions.swift in Sources */,
 				07B7F20C1F5EB43C00E6F910 /* BoolExtensions.swift in Sources */,
 				F8E78D12207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */,
+				F8AD1ECE2080DA0800E17EF1 /* RandomizableInteger.swift in Sources */,
 				07B7F22F1F5EB45100E6F910 /* CGFloatExtensions.swift in Sources */,
 				07B7F1981F5EB42000E6F910 /* UIImageViewExtensions.swift in Sources */,
 				42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */,
@@ -1466,6 +1478,7 @@
 				07B7F2381F5EB45200E6F910 /* CLLocationExtensions.swift in Sources */,
 				07B7F1FC1F5EB43C00E6F910 /* CollectionExtensions.swift in Sources */,
 				07B7F2031F5EB43C00E6F910 /* IntExtensions.swift in Sources */,
+				F8AD1ECF2080DA0800E17EF1 /* RandomizableInteger.swift in Sources */,
 				07B7F1FF1F5EB43C00E6F910 /* DictionaryExtensions.swift in Sources */,
 				18C8E5DF2074C60C00F8AF51 /* SequenceExtensions.swift in Sources */,
 				07B7F2361F5EB45200E6F910 /* CGPointExtensions.swift in Sources */,
@@ -1534,6 +1547,7 @@
 				07B7F22C1F5EB45100E6F910 /* CLLocationExtensions.swift in Sources */,
 				07B7F1EA1F5EB43B00E6F910 /* CollectionExtensions.swift in Sources */,
 				07B7F1F11F5EB43B00E6F910 /* IntExtensions.swift in Sources */,
+				F8AD1ED02080DA0800E17EF1 /* RandomizableInteger.swift in Sources */,
 				07B7F1ED1F5EB43B00E6F910 /* DictionaryExtensions.swift in Sources */,
 				07B7F22A1F5EB45100E6F910 /* CGPointExtensions.swift in Sources */,
 				07B7F1C11F5EB42200E6F910 /* UICollectionViewExtensions.swift in Sources */,
@@ -1616,6 +1630,7 @@
 				07B7F1DF1F5EB43B00E6F910 /* IntExtensions.swift in Sources */,
 				07B7F2201F5EB44600E6F910 /* CGColorExtensions.swift in Sources */,
 				0726D77C1F7C24840028CAB5 /* ColorExtensions.swift in Sources */,
+				F8AD1ED12080DA0800E17EF1 /* RandomizableInteger.swift in Sources */,
 				07B7F1D51F5EB43B00E6F910 /* ArrayExtensions.swift in Sources */,
 				F8E78D15207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */,
 				07B7F21C1F5EB43E00E6F910 /* SwifterSwift.swift in Sources */,
@@ -1673,6 +1688,7 @@
 				07C50D301F5EB04700F46E5A /* UIImageExtensionsTests.swift in Sources */,
 				07C50D3A1F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */,
 				07C50D341F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */,
+				F8AD1ED32080DA4100E17EF1 /* RandomizableIntegerTests.swift in Sources */,
 				07C50D5A1F5EB05000F46E5A /* CollectionExtensionsTests.swift in Sources */,
 				076AEC8D1FDB49480077D153 /* UIDatePickerExtensionsTests.swift in Sources */,
 				07C50D351F5EB04700F46E5A /* UINavigationItemExtensionsTests.swift in Sources */,
@@ -1720,6 +1736,7 @@
 				07C50D421F5EB04700F46E5A /* UIBarButtonExtensionsTests.swift in Sources */,
 				077BA0BA1F6BEA6A00D9C4AC /* UserDefaultsExtensionsTests.swift in Sources */,
 				07C50D671F5EB05100F46E5A /* CharacterExtensionsTests.swift in Sources */,
+				F8AD1ED42080DA4100E17EF1 /* RandomizableIntegerTests.swift in Sources */,
 				F8E78D1D207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */,
 				9D49148A1F8515D100F3868F /* NSPredicateExtensionsTests.swift in Sources */,
 				07C50D651F5EB05100F46E5A /* ArrayExtensionsTests.swift in Sources */,
@@ -1797,6 +1814,7 @@
 				07C50D751F5EB05100F46E5A /* CharacterExtensionsTests.swift in Sources */,
 				07FE50431F891B40000766AA /* ColorExtensionsTests.swift in Sources */,
 				07C50D7D1F5EB05100F46E5A /* LocaleExtensionsTests.swift in Sources */,
+				F8AD1ED52080DA4100E17EF1 /* RandomizableIntegerTests.swift in Sources */,
 				07C50D781F5EB05100F46E5A /* DateExtensionsTests.swift in Sources */,
 				07C50D821F5EB05800F46E5A /* CGPointExtensionsTests.swift in Sources */,
 				F8E78D21207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -387,6 +387,27 @@
 		B23678ED1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
 		B23678EE1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
 		B23678EF1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
+		F8E78D0A207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
+		F8E78D0B207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
+		F8E78D0C207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
+		F8E78D0D207E7DBE009AB93E /* StrideableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */; };
+		F8E78D0E207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */; };
+		F8E78D0F207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */; };
+		F8E78D10207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */; };
+		F8E78D11207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */; };
+		F8E78D12207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */; };
+		F8E78D13207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */; };
+		F8E78D14207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */; };
+		F8E78D15207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */; };
+		F8E78D19207E7DD5009AB93E /* StrideableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D16207E7DD5009AB93E /* StrideableExtensionsTests.swift */; };
+		F8E78D1A207E7DD5009AB93E /* StrideableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D16207E7DD5009AB93E /* StrideableExtensionsTests.swift */; };
+		F8E78D1B207E7DD5009AB93E /* StrideableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D16207E7DD5009AB93E /* StrideableExtensionsTests.swift */; };
+		F8E78D1C207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D17207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift */; };
+		F8E78D1D207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D17207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift */; };
+		F8E78D1E207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D17207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift */; };
+		F8E78D1F207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D18207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift */; };
+		F8E78D20207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D18207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift */; };
+		F8E78D21207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E78D18207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -552,6 +573,12 @@
 		A9CD166720242AF900DBE263 /* UICollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UICollectionViewCell.xib; sourceTree = "<group>"; };
 		A9FF467020245ABA0084C40F /* test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test.json; sourceTree = "<group>"; };
 		B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftStdlibDeprecated.swift; sourceTree = "<group>"; };
+		F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrideableExtensions.swift; sourceTree = "<group>"; };
+		F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryFloatingPointExtensions.swift; sourceTree = "<group>"; };
+		F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryIntegerExtensions.swift; sourceTree = "<group>"; };
+		F8E78D16207E7DD5009AB93E /* StrideableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrideableExtensionsTests.swift; sourceTree = "<group>"; };
+		F8E78D17207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryIntegerExtensionsTests.swift; sourceTree = "<group>"; };
+		F8E78D18207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryFloatingPointExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -630,6 +657,8 @@
 			isa = PBXGroup;
 			children = (
 				07B7F1661F5EB41600E6F910 /* ArrayExtensions.swift */,
+				F8E78D08207E7DBD009AB93E /* BinaryFloatingPointExtensions.swift */,
+				F8E78D09207E7DBE009AB93E /* BinaryIntegerExtensions.swift */,
 				07B7F1671F5EB41600E6F910 /* BoolExtensions.swift */,
 				07B7F1681F5EB41600E6F910 /* CharacterExtensions.swift */,
 				07B7F1691F5EB41600E6F910 /* CollectionExtensions.swift */,
@@ -641,6 +670,7 @@
 				07B7F1741F5EB41600E6F910 /* OptionalExtensions.swift */,
 				18C8E5DD2074C58100F8AF51 /* SequenceExtensions.swift */,
 				07B7F1751F5EB41600E6F910 /* SignedIntegerExtensions.swift */,
+				F8E78D07207E7DBD009AB93E /* StrideableExtensions.swift */,
 				07B7F1771F5EB41600E6F910 /* StringExtensions.swift */,
 				9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */,
 				07B7F1761F5EB41600E6F910 /* SignedNumericExtensions.swift */,
@@ -653,6 +683,8 @@
 			isa = PBXGroup;
 			children = (
 				07C50CFA1F5EB03200F46E5A /* ArrayExtensionsTests.swift */,
+				F8E78D18207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift */,
+				F8E78D17207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift */,
 				07C50CFB1F5EB03200F46E5A /* BoolExtensionsTests.swift */,
 				07C50CFC1F5EB03200F46E5A /* CharacterExtensionsTests.swift */,
 				07C50CFD1F5EB03200F46E5A /* CollectionExtensionsTests.swift */,
@@ -664,6 +696,7 @@
 				07C50D051F5EB03200F46E5A /* OptionalExtensionsTests.swift */,
 				18C8E5E22074C67000F8AF51 /* SequenceExtensionsTests.swift */,
 				078916DD20760DA700AC0665 /* SignedIntegerExtensionsTests.swift */,
+				F8E78D16207E7DD5009AB93E /* StrideableExtensionsTests.swift */,
 				07C50D061F5EB03200F46E5A /* StringExtensionsTests.swift */,
 				9D9784DF1FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift */,
 				07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */,
@@ -1353,9 +1386,11 @@
 				07B7F2181F5EB43C00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				784C752F2051BD26001C48DD /* MKPolylineExtensions.swift in Sources */,
 				07B7F1A71F5EB42000E6F910 /* UIViewExtensions.swift in Sources */,
+				F8E78D0E207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */,
 				07B7F1991F5EB42000E6F910 /* UILabelExtensions.swift in Sources */,
 				9D9784DB1FCAE3D200D988E7 /* StringProtocolExtensions.swift in Sources */,
 				07B7F20C1F5EB43C00E6F910 /* BoolExtensions.swift in Sources */,
+				F8E78D12207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */,
 				07B7F22F1F5EB45100E6F910 /* CGFloatExtensions.swift in Sources */,
 				07B7F1981F5EB42000E6F910 /* UIImageViewExtensions.swift in Sources */,
 				42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */,
@@ -1381,6 +1416,7 @@
 				07B7F1931F5EB42000E6F910 /* UIBarButtonItemExtensions.swift in Sources */,
 				07B7F1A21F5EB42000E6F910 /* UITabBarExtensions.swift in Sources */,
 				07B7F1A61F5EB42000E6F910 /* UIViewControllerExtensions.swift in Sources */,
+				F8E78D0A207E7DBE009AB93E /* StrideableExtensions.swift in Sources */,
 				07B7F2311F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F20D1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F19D1F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
@@ -1419,6 +1455,7 @@
 				07B7F2061F5EB43C00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				07B7F1BD1F5EB42000E6F910 /* UIViewExtensions.swift in Sources */,
 				07B7F1AF1F5EB42000E6F910 /* UILabelExtensions.swift in Sources */,
+				F8E78D0B207E7DBE009AB93E /* StrideableExtensions.swift in Sources */,
 				9D9784DC1FCAE42600D988E7 /* StringProtocolExtensions.swift in Sources */,
 				07B7F1FA1F5EB43C00E6F910 /* BoolExtensions.swift in Sources */,
 				A9AEB78620283ACC0021AACF /* FileManagerExtensions.swift in Sources */,
@@ -1446,9 +1483,11 @@
 				07B7F1A91F5EB42000E6F910 /* UIBarButtonItemExtensions.swift in Sources */,
 				07B7F1B81F5EB42000E6F910 /* UITabBarExtensions.swift in Sources */,
 				078CE2A0207643F8001720DF /* UIKitDeprecated.swift in Sources */,
+				F8E78D13207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */,
 				07B7F1BC1F5EB42000E6F910 /* UIViewControllerExtensions.swift in Sources */,
 				07B7F2371F5EB45200E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F1FB1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
+				F8E78D0F207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */,
 				07B7F1B31F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
 				07B7F2081F5EB43C00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F2391F5EB45200E6F910 /* NSAttributedStringExtensions.swift in Sources */,
@@ -1484,6 +1523,7 @@
 				07B7F1F41F5EB43B00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				07B7F1D31F5EB42200E6F910 /* UIViewExtensions.swift in Sources */,
 				07B7F1C51F5EB42200E6F910 /* UILabelExtensions.swift in Sources */,
+				F8E78D0C207E7DBE009AB93E /* StrideableExtensions.swift in Sources */,
 				9D9784DD1FCAE42600D988E7 /* StringProtocolExtensions.swift in Sources */,
 				07B7F1E81F5EB43B00E6F910 /* BoolExtensions.swift in Sources */,
 				A9AEB78720283ACC0021AACF /* FileManagerExtensions.swift in Sources */,
@@ -1511,9 +1551,11 @@
 				07B7F1CE1F5EB42200E6F910 /* UITabBarExtensions.swift in Sources */,
 				078CE2A1207643F8001720DF /* UIKitDeprecated.swift in Sources */,
 				07B7F1D21F5EB42200E6F910 /* UIViewControllerExtensions.swift in Sources */,
+				F8E78D14207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */,
 				07B7F22B1F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F1E91F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F1C91F5EB42200E6F910 /* UISearchBarExtensions.swift in Sources */,
+				F8E78D10207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */,
 				07B7F1F61F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F22D1F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				071306711FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
@@ -1548,6 +1590,7 @@
 				07B7F1D81F5EB43B00E6F910 /* CollectionExtensions.swift in Sources */,
 				07B7F1DD1F5EB43B00E6F910 /* FloatExtensions.swift in Sources */,
 				70269A2D1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */,
+				F8E78D0D207E7DBE009AB93E /* StrideableExtensions.swift in Sources */,
 				07B7F1D61F5EB43B00E6F910 /* BoolExtensions.swift in Sources */,
 				07B7F1DE1F5EB43B00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F1DB1F5EB43B00E6F910 /* DictionaryExtensions.swift in Sources */,
@@ -1559,6 +1602,7 @@
 				9D9784DE1FCAE42600D988E7 /* StringProtocolExtensions.swift in Sources */,
 				07B7F2221F5EB44600E6F910 /* CGPointExtensions.swift in Sources */,
 				07B7F2251F5EB44600E6F910 /* NSAttributedStringExtensions.swift in Sources */,
+				F8E78D11207E7DBE009AB93E /* BinaryFloatingPointExtensions.swift in Sources */,
 				077BA08D1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				18C8E5E12074C60C00F8AF51 /* SequenceExtensions.swift in Sources */,
 				784C75302051BD4A001C48DD /* MKPolylineExtensions.swift in Sources */,
@@ -1572,6 +1616,7 @@
 				07B7F2201F5EB44600E6F910 /* CGColorExtensions.swift in Sources */,
 				0726D77C1F7C24840028CAB5 /* ColorExtensions.swift in Sources */,
 				07B7F1D51F5EB43B00E6F910 /* ArrayExtensions.swift in Sources */,
+				F8E78D15207E7DBE009AB93E /* BinaryIntegerExtensions.swift in Sources */,
 				07B7F21C1F5EB43E00E6F910 /* SwifterSwift.swift in Sources */,
 				078CE2A2207643F8001720DF /* UIKitDeprecated.swift in Sources */,
 				B23678EF1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */,
@@ -1592,6 +1637,7 @@
 				07C50D621F5EB05000F46E5A /* OptionalExtensionsTests.swift in Sources */,
 				07C50D601F5EB05000F46E5A /* IntExtensionsTests.swift in Sources */,
 				07C50D631F5EB05000F46E5A /* StringExtensionsTests.swift in Sources */,
+				F8E78D1C207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */,
 				07C50D5C1F5EB05000F46E5A /* DateExtensionsTests.swift in Sources */,
 				077BA09E1F6BEA4900D9C4AC /* URLRequestExtensionsTests.swift in Sources */,
 				07C50D2E1F5EB04600F46E5A /* UICollectionViewExtensionsTests.swift in Sources */,
@@ -1610,7 +1656,9 @@
 				07C50D5F1F5EB05000F46E5A /* FloatExtensionsTests.swift in Sources */,
 				07C50D371F5EB04700F46E5A /* UISegmentedControlExtensionsTests.swift in Sources */,
 				07C50D8E1F5EB06000F46E5A /* CGSizeExtensionsTests.swift in Sources */,
+				F8E78D19207E7DD5009AB93E /* StrideableExtensionsTests.swift in Sources */,
 				07C50D581F5EB05000F46E5A /* BoolExtensionsTests.swift in Sources */,
+				F8E78D1F207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */,
 				07FE50451F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */,
 				07C50D391F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */,
 				784C75372051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
@@ -1656,6 +1704,7 @@
 				07C50D701F5EB05100F46E5A /* OptionalExtensionsTests.swift in Sources */,
 				07C50D6E1F5EB05100F46E5A /* IntExtensionsTests.swift in Sources */,
 				07C50D711F5EB05100F46E5A /* StringExtensionsTests.swift in Sources */,
+				F8E78D1A207E7DD5009AB93E /* StrideableExtensionsTests.swift in Sources */,
 				07C50D6A1F5EB05100F46E5A /* DateExtensionsTests.swift in Sources */,
 				077BA09F1F6BEA4900D9C4AC /* URLRequestExtensionsTests.swift in Sources */,
 				07C50D441F5EB04700F46E5A /* UICollectionViewExtensionsTests.swift in Sources */,
@@ -1670,6 +1719,7 @@
 				07C50D421F5EB04700F46E5A /* UIBarButtonExtensionsTests.swift in Sources */,
 				077BA0BA1F6BEA6A00D9C4AC /* UserDefaultsExtensionsTests.swift in Sources */,
 				07C50D671F5EB05100F46E5A /* CharacterExtensionsTests.swift in Sources */,
+				F8E78D1D207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */,
 				9D49148A1F8515D100F3868F /* NSPredicateExtensionsTests.swift in Sources */,
 				07C50D651F5EB05100F46E5A /* ArrayExtensionsTests.swift in Sources */,
 				07C50D6D1F5EB05100F46E5A /* FloatExtensionsTests.swift in Sources */,
@@ -1703,6 +1753,7 @@
 				07C50D6C1F5EB05100F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				07C50D6B1F5EB05100F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D691F5EB05100F46E5A /* DataExtensionsTests.swift in Sources */,
+				F8E78D20207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */,
 				07C50D6F1F5EB05100F46E5A /* LocaleExtensionsTests.swift in Sources */,
 				07C50D8B1F5EB06000F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				18C8E5E42074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
@@ -1726,10 +1777,12 @@
 				07C50D861F5EB05800F46E5A /* NSViewExtensionsTests.swift in Sources */,
 				07C50D851F5EB05800F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07C50D7C1F5EB05100F46E5A /* IntExtensionsTests.swift in Sources */,
+				F8E78D1E207E7DD5009AB93E /* BinaryIntegerExtensionsTests.swift in Sources */,
 				07C50D791F5EB05100F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D7B1F5EB05100F46E5A /* FloatExtensionsTests.swift in Sources */,
 				07C50D7F1F5EB05100F46E5A /* StringExtensionsTests.swift in Sources */,
 				70269A311FB47B0C00C6C2D0 /* CalendarExtensionTest.swift in Sources */,
+				F8E78D1B207E7DD5009AB93E /* StrideableExtensionsTests.swift in Sources */,
 				07C50D7A1F5EB05100F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				18C8E5E52074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */,
@@ -1745,6 +1798,7 @@
 				07C50D7D1F5EB05100F46E5A /* LocaleExtensionsTests.swift in Sources */,
 				07C50D781F5EB05100F46E5A /* DateExtensionsTests.swift in Sources */,
 				07C50D821F5EB05800F46E5A /* CGPointExtensionsTests.swift in Sources */,
+				F8E78D21207E7DD5009AB93E /* BinaryFloatingPointExtensionsTests.swift in Sources */,
 				07C50D811F5EB05800F46E5A /* CGFloatExtensionsTests.swift in Sources */,
 				07FE50471F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */,
 				A94AA78C202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -1158,6 +1158,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = SwifterSwift;
 				TargetAttributes = {
 					07898B5C1F278D7600558C97 = {
 						CreatedOnToolsVersion = 9.0;

--- a/Tests/SharedTests/RandomizableIntegerTests.swift
+++ b/Tests/SharedTests/RandomizableIntegerTests.swift
@@ -1,0 +1,124 @@
+//
+//  RandomizableIntegerTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 13/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+class IntegerCounterpartsTests: XCTestCase {
+
+    let testRuns = 10000
+
+    // MARK: Test helpers
+
+    func runIntsTest<T: SignedRandomizableInteger>(type: T.Type) {
+        var values = Set<T>(minimumCapacity: testRuns)
+        let lowerBound: T = -50
+        let upperBound: T = 50
+        for _ in 0..<testRuns {
+            let random = T.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    func runUIntsTest<T: UnsignedRandomizableInteger>(type: T.Type) {
+        var values = Set<T>(minimumCapacity: testRuns)
+        let lowerBound: T = 0
+        let upperBound: T = 100
+        for _ in 0..<testRuns {
+            let random = T.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    // MARK: Test methods
+
+    func testRandomInts() {
+        runIntsTest(type: Int.self)
+        runIntsTest(type: Int8.self)
+        runIntsTest(type: Int16.self)
+        runIntsTest(type: Int32.self)
+        runIntsTest(type: Int64.self)
+    }
+
+    func testRandomUInts() {
+        runUIntsTest(type: UInt.self)
+        runUIntsTest(type: UInt8.self)
+        runUIntsTest(type: UInt16.self)
+        runUIntsTest(type: UInt32.self)
+        runUIntsTest(type: UInt64.self)
+    }
+
+    func testMinInt64s() {
+        var values = Set<Int64>(minimumCapacity: testRuns)
+        let lowerBound = Int64.min
+        let upperBound = lowerBound + 100
+        for _ in 0..<testRuns {
+            let random = Int64.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    func testMaxInt64s() {
+        var values = Set<Int64>(minimumCapacity: testRuns)
+        let upperBound = Int64.max
+        let lowerBound = upperBound - 100
+        for _ in 0..<testRuns {
+            let random = Int64.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    func testMinMaxInt64s() {
+        var values = Set<Int64>(minimumCapacity: testRuns)
+        let lowerBound = Int64.min
+        let upperBound = Int64.max
+        for _ in 0..<testRuns {
+            let random = Int64.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertNotNil(values.first(where: { $0 < Int32.min }))
+        XCTAssertNotNil(values.first(where: { $0 > Int32.max }))
+        XCTAssertEqual(values.count, testRuns)
+    }
+
+    func testMaxUInt32s() {
+        var values = Set<UInt32>(minimumCapacity: testRuns)
+        let lowerBound = UInt32(0)
+        let upperBound = UInt32.max
+        for _ in 0..<testRuns {
+            let random = UInt32.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertNotNil(values.first(where: { $0 > UInt16.max }))
+        XCTAssertEqual(values.count, testRuns)
+    }
+
+    func testMaxUInt64s() {
+        var values = Set<UInt64>(minimumCapacity: testRuns)
+        let lowerBound = UInt64(0)
+        let upperBound = UInt64.max
+        for _ in 0..<testRuns {
+            let random = UInt64.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertNotNil(values.first(where: { $0 > UInt32.max }))
+        XCTAssertEqual(values.count, testRuns)
+    }
+
+}

--- a/Tests/SwiftStdlibTests/BinaryFloatingPointExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryFloatingPointExtensionsTests.swift
@@ -1,0 +1,34 @@
+//
+//  BinaryFloatingPointExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 11/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+final class BinaryFloatingPointExtensionsTests: XCTestCase {
+
+	func testRandomDoubles() {
+		var values = Set<Double>()
+		for _ in 0..<10000 {
+			let random = Double.random(lowerBound: -1, upperBound: 1)
+			XCTAssert(random >= -1 && random <= 1)
+			values.insert(random)
+		}
+		XCTAssertEqual(values.count, 10000)
+	}
+
+	func testRandomFloat80s() {
+		var values = Set<Float80>()
+		for _ in 0..<10000 {
+			let random = Float80.random(lowerBound: -1, upperBound: 1)
+			XCTAssert(random >= -1 && random <= 1)
+			values.insert(random)
+		}
+		XCTAssertEqual(values.count, 10000)
+	}
+
+}

--- a/Tests/SwiftStdlibTests/BinaryFloatingPointExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryFloatingPointExtensionsTests.swift
@@ -11,24 +11,24 @@ import XCTest
 
 final class BinaryFloatingPointExtensionsTests: XCTestCase {
 
-	func testRandomDoubles() {
-		var values = Set<Double>()
-		for _ in 0..<10000 {
-			let random = Double.random(lowerBound: -1, upperBound: 1)
-			XCTAssert(random >= -1 && random <= 1)
-			values.insert(random)
-		}
-		XCTAssertEqual(values.count, 10000)
-	}
+    func testRandomDoubles() {
+        var values = Set<Double>()
+        for _ in 0..<10000 {
+            let random = Double.random(lowerBound: -1, upperBound: 1)
+            XCTAssert(random >= -1 && random <= 1)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 10000)
+    }
 
-	func testRandomFloat80s() {
-		var values = Set<Float80>()
-		for _ in 0..<10000 {
-			let random = Float80.random(lowerBound: -1, upperBound: 1)
-			XCTAssert(random >= -1 && random <= 1)
-			values.insert(random)
-		}
-		XCTAssertEqual(values.count, 10000)
-	}
+    func testRandomFloat80s() {
+        var values = Set<Float80>()
+        for _ in 0..<10000 {
+            let random = Float80.random(lowerBound: -1, upperBound: 1)
+            XCTAssert(random >= -1 && random <= 1)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 10000)
+    }
 
 }

--- a/Tests/SwiftStdlibTests/BinaryFloatingPointExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryFloatingPointExtensionsTests.swift
@@ -11,6 +11,8 @@ import XCTest
 
 final class BinaryFloatingPointExtensionsTests: XCTestCase {
 
+    let testRuns = 10000
+
     func testRandomDoubles() {
         var values = Set<Double>()
         for _ in 0..<10000 {
@@ -29,6 +31,30 @@ final class BinaryFloatingPointExtensionsTests: XCTestCase {
             values.insert(random)
         }
         XCTAssertEqual(values.count, 10000)
+    }
+
+    func testLargePositiveDoubles() {
+        var values = Set<Double>(minimumCapacity: testRuns)
+        let lowerBound = 0.0
+        let upperBound = Double.greatestFiniteMagnitude
+        for _ in 0..<testRuns {
+            let random = Double.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, testRuns)
+    }
+
+    func testLargeNegativeDoubles() {
+        var values = Set<Double>(minimumCapacity: testRuns)
+        let lowerBound = -Double.greatestFiniteMagnitude
+        let upperBound = 0.0
+        for _ in 0..<testRuns {
+            let random = Double.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, testRuns)
     }
 
 }

--- a/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
@@ -11,24 +11,24 @@ import XCTest
 
 final class BinaryIntegerExtensionsTests: XCTestCase {
 
-	func testRandomDoubles() {
-		var values = Set<Double>()
+	func testRandomIntegers() {
+		var values = Set<Int>()
 		for _ in 0..<10000 {
-			let random = Double.random(lowerBound: -1, upperBound: 1)
-			XCTAssert(random >= -1 && random <= 1)
+			let random = Int.random(lowerBound: -50, upperBound: 50)
+			XCTAssert(random >= -50 && random < 50)
 			values.insert(random)
 		}
-		XCTAssertEqual(values.count, 10000)
+		XCTAssertEqual(values.count, 100)
 	}
 
-	func testRandomFloat80s() {
-		var values = Set<Float80>()
+	func testRandomUInt32s() {
+		var values = Set<UInt32>()
 		for _ in 0..<10000 {
-			let random = Float80.random(lowerBound: -1, upperBound: 1)
-			XCTAssert(random >= -1 && random <= 1)
+			let random = UInt32.random(upperBound: 100)
+			XCTAssert(random >= 0 && random < 100)
 			values.insert(random)
 		}
-		XCTAssertEqual(values.count, 10000)
+		XCTAssertEqual(values.count, 100)
 	}
 
 }

--- a/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
@@ -1,0 +1,34 @@
+//
+//  BinaryIntegerExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 11/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+final class BinaryIntegerExtensionsTests: XCTestCase {
+
+	func testRandomDoubles() {
+		var values = Set<Double>()
+		for _ in 0..<10000 {
+			let random = Double.random(lowerBound: -1, upperBound: 1)
+			XCTAssert(random >= -1 && random <= 1)
+			values.insert(random)
+		}
+		XCTAssertEqual(values.count, 10000)
+	}
+
+	func testRandomFloat80s() {
+		var values = Set<Float80>()
+		for _ in 0..<10000 {
+			let random = Float80.random(lowerBound: -1, upperBound: 1)
+			XCTAssert(random >= -1 && random <= 1)
+			values.insert(random)
+		}
+		XCTAssertEqual(values.count, 10000)
+	}
+
+}

--- a/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
@@ -11,24 +11,60 @@ import XCTest
 
 final class BinaryIntegerExtensionsTests: XCTestCase {
 
-	func testRandomIntegers() {
-		var values = Set<Int>()
-		for _ in 0..<10000 {
-			let random = Int.random(lowerBound: -50, upperBound: 50)
-			XCTAssert(random >= -50 && random < 50)
-			values.insert(random)
-		}
-		XCTAssertEqual(values.count, 100)
-	}
+    func testRandomInts() {
+        var values = Set<Int>()
+        for _ in 0..<10000 {
+            let random = Int.random(lowerBound: -50, upperBound: 50)
+            XCTAssert(random >= -50 && random < 50)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
 
-	func testRandomUInt32s() {
-		var values = Set<UInt32>()
-		for _ in 0..<10000 {
-			let random = UInt32.random(upperBound: 100)
-			XCTAssert(random >= 0 && random < 100)
-			values.insert(random)
-		}
-		XCTAssertEqual(values.count, 100)
-	}
+    func testRandomUInts() {
+        var values = Set<UInt>()
+        for _ in 0..<10000 {
+            let random = UInt.random(upperBound: 100)
+            XCTAssert(random >= 0 && random < 100)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    func testMinInt64s() {
+        var values = Set<Int64>()
+        for _ in 0..<10000 {
+            let min = Int64.min
+            let max = min + 100
+            let random = Int64.random(lowerBound: min, upperBound: max)
+            XCTAssert(random >= min && random < max)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    func testMaxInt64s() {
+        var values = Set<Int64>()
+        for _ in 0..<10000 {
+            let max = Int64.max
+            let min = max - 100
+            let random = Int64.random(lowerBound: min, upperBound: max)
+            XCTAssert(random >= min && random < max)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
+
+    func testMaxUInt32s() {
+        var values = Set<UInt32>()
+        for _ in 0..<10000 {
+            let max = UInt32.max
+            let min = max - 100
+            let random = UInt32.random(lowerBound: min, upperBound: max)
+            XCTAssert(random >= min && random < max)
+            values.insert(random)
+        }
+        XCTAssertEqual(values.count, 100)
+    }
 
 }

--- a/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BinaryIntegerExtensionsTests.swift
@@ -11,60 +11,24 @@ import XCTest
 
 final class BinaryIntegerExtensionsTests: XCTestCase {
 
+    let testRuns = 10000
+
+    // MARK: Test helpers
+
+    func runBinaryIntegers<B: BinaryInteger>(lowerBound: B, upperBound: B) {
+        var values = Set<B>(minimumCapacity: testRuns)
+        for _ in 0..<testRuns {
+            let random = B.random(lowerBound: lowerBound, upperBound: upperBound)
+            XCTAssert(random >= lowerBound && random < upperBound)
+            values.insert(random)
+        }
+        XCTAssertEqual(B(values.count), upperBound - lowerBound)
+    }
+
+    // MARK: Test methods
+
     func testRandomInts() {
-        var values = Set<Int>()
-        for _ in 0..<10000 {
-            let random = Int.random(lowerBound: -50, upperBound: 50)
-            XCTAssert(random >= -50 && random < 50)
-            values.insert(random)
-        }
-        XCTAssertEqual(values.count, 100)
-    }
-
-    func testRandomUInts() {
-        var values = Set<UInt>()
-        for _ in 0..<10000 {
-            let random = UInt.random(upperBound: 100)
-            XCTAssert(random >= 0 && random < 100)
-            values.insert(random)
-        }
-        XCTAssertEqual(values.count, 100)
-    }
-
-    func testMinInt64s() {
-        var values = Set<Int64>()
-        for _ in 0..<10000 {
-            let min = Int64.min
-            let max = min + 100
-            let random = Int64.random(lowerBound: min, upperBound: max)
-            XCTAssert(random >= min && random < max)
-            values.insert(random)
-        }
-        XCTAssertEqual(values.count, 100)
-    }
-
-    func testMaxInt64s() {
-        var values = Set<Int64>()
-        for _ in 0..<10000 {
-            let max = Int64.max
-            let min = max - 100
-            let random = Int64.random(lowerBound: min, upperBound: max)
-            XCTAssert(random >= min && random < max)
-            values.insert(random)
-        }
-        XCTAssertEqual(values.count, 100)
-    }
-
-    func testMaxUInt32s() {
-        var values = Set<UInt32>()
-        for _ in 0..<10000 {
-            let max = UInt32.max
-            let min = max - 100
-            let random = UInt32.random(lowerBound: min, upperBound: max)
-            XCTAssert(random >= min && random < max)
-            values.insert(random)
-        }
-        XCTAssertEqual(values.count, 100)
+        runBinaryIntegers(lowerBound: -50, upperBound: 50)
     }
 
 }

--- a/Tests/SwiftStdlibTests/SignedIntegerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SignedIntegerExtensionsTests.swift
@@ -3,7 +3,7 @@
 //  SwifterSwift
 //
 //  Created by Omar Albeik on 5.04.2018.
-//  Copyright © 2018 ___ORGANIZATIONNAME___
+//  Copyright © 2018 SwifterSwift
 //
 
 import XCTest

--- a/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
@@ -12,24 +12,25 @@ import XCTest
 final class StrideableExtensionsTests: XCTestCase {
 
 	struct StrideableDate: Strideable {
-		static let dayTimeInterval = TimeInterval(60 * 60 * 24)
-
 		let date: Date
+		let calendarComponentStride: Calendar.Component
 
 		// swiftlint:disable identifier_name
 		func advanced(by n: Int) -> StrideableDate {
-			return StrideableDate(date: Date(timeInterval: StrideableDate.dayTimeInterval * TimeInterval(n), since: date))
+			return StrideableDate(date: date.adding(calendarComponentStride, value: n), calendarComponentStride: calendarComponentStride)
 		}
 
 		func distance(to other: StrideableDate) -> Int {
-			return Int(round(other.date.timeIntervalSince(date) / StrideableDate.dayTimeInterval))
+			return Calendar.current.dateComponents([calendarComponentStride], from: date, to: other.date).value(for: calendarComponentStride)!
 		}
 		// swiftlint:enable identifier_name
 	}
 
 	func testDateRange() {
-		let startDate = StrideableDate(date: Date(timeIntervalSinceNow: StrideableDate.dayTimeInterval * -50))
-		let endDate = StrideableDate(date: Date(timeIntervalSinceNow: StrideableDate.dayTimeInterval * 50))
+		let calendarComponent = Calendar.Component.day
+		let now = Date()
+		let startDate = StrideableDate(date: now.adding(calendarComponent, value: -50), calendarComponentStride: calendarComponent)
+		let endDate = StrideableDate(date: now.adding(calendarComponent, value: 50), calendarComponentStride: calendarComponent)
 		var values = Set<Date>()
 		for _ in 0..<10000 {
 			let random = StrideableDate.random(lowerBound: startDate, upperBound: endDate)

--- a/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
@@ -26,7 +26,21 @@ final class StrideableExtensionsTests: XCTestCase {
         // swiftlint:enable identifier_name
     }
 
-    func testDateRange() {
+    struct StrideableInt32: Strideable {
+        let value: Int32
+
+        // swiftlint:disable identifier_name
+        func advanced(by n: Int32) -> StrideableInt32 {
+            return StrideableInt32(value: value + n)
+        }
+
+        func distance(to other: StrideableInt32) -> Int32 {
+            return other.value - value
+        }
+        // swiftlint:enable identifier_name
+    }
+
+    func testStrideableDate() {
         let calendarComponent = Calendar.Component.day
         let now = Date()
         let startDate = StrideableDate(date: now.adding(calendarComponent, value: -50), calendarComponentStride: calendarComponent)
@@ -38,6 +52,31 @@ final class StrideableExtensionsTests: XCTestCase {
             XCTAssert(random.date >= startDate.date && random.date < endDate.date, "\(random.date) is not between \(startDate.date) and \(endDate.date)")
         }
         XCTAssertEqual(values.count, 100)
+    }
+
+    func testMinMaxStrideableDate() {
+        let calendarComponent = Calendar.Component.day
+        let startDate = StrideableDate(date: Date.distantPast, calendarComponentStride: calendarComponent)
+        let endDate = StrideableDate(date: Date.distantFuture, calendarComponentStride: calendarComponent)
+        var values = Set<Date>()
+        for _ in 0..<1000 {
+            let random = StrideableDate.random(lowerBound: startDate, upperBound: endDate)
+            values.insert(random.date)
+            XCTAssert(random.date >= startDate.date && random.date < endDate.date, "\(random.date) is not between \(startDate.date) and \(endDate.date)")
+        }
+        XCTAssertEqual(values.count, 1000)
+    }
+
+    func testMaxStrideableInt32() {
+        let lowerBound = StrideableInt32(value: 0)
+        let upperBound = StrideableInt32(value: Int32.max)
+        var values = Set<Int32>()
+        for _ in 0..<1000 {
+            let random = StrideableInt32.random(lowerBound: lowerBound, upperBound: upperBound)
+            values.insert(random.value)
+            XCTAssert(random.value >= lowerBound.value && random.value < upperBound.value, "\(random.value) is not between \(lowerBound.value) and \(upperBound.value)")
+        }
+        XCTAssertEqual(values.count, 1000)
     }
 
 }

--- a/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
@@ -11,33 +11,33 @@ import XCTest
 
 final class StrideableExtensionsTests: XCTestCase {
 
-	struct StrideableDate: Strideable {
-		let date: Date
-		let calendarComponentStride: Calendar.Component
+    struct StrideableDate: Strideable {
+        let date: Date
+        let calendarComponentStride: Calendar.Component
 
-		// swiftlint:disable identifier_name
-		func advanced(by n: Int) -> StrideableDate {
-			return StrideableDate(date: date.adding(calendarComponentStride, value: n), calendarComponentStride: calendarComponentStride)
-		}
+        // swiftlint:disable identifier_name
+        func advanced(by n: Int) -> StrideableDate {
+            return StrideableDate(date: date.adding(calendarComponentStride, value: n), calendarComponentStride: calendarComponentStride)
+        }
 
-		func distance(to other: StrideableDate) -> Int {
-			return Calendar.current.dateComponents([calendarComponentStride], from: date, to: other.date).value(for: calendarComponentStride)!
-		}
-		// swiftlint:enable identifier_name
-	}
+        func distance(to other: StrideableDate) -> Int {
+            return Calendar.current.dateComponents([calendarComponentStride], from: date, to: other.date).value(for: calendarComponentStride)!
+        }
+        // swiftlint:enable identifier_name
+    }
 
-	func testDateRange() {
-		let calendarComponent = Calendar.Component.day
-		let now = Date()
-		let startDate = StrideableDate(date: now.adding(calendarComponent, value: -50), calendarComponentStride: calendarComponent)
-		let endDate = StrideableDate(date: now.adding(calendarComponent, value: 50), calendarComponentStride: calendarComponent)
-		var values = Set<Date>()
-		for _ in 0..<10000 {
-			let random = StrideableDate.random(lowerBound: startDate, upperBound: endDate)
-			values.insert(random.date)
-			XCTAssert(random.date >= startDate.date && random.date < endDate.date, "\(random.date) is not between \(startDate.date) and \(endDate.date)")
-		}
-		XCTAssertEqual(values.count, 100)
-	}
+    func testDateRange() {
+        let calendarComponent = Calendar.Component.day
+        let now = Date()
+        let startDate = StrideableDate(date: now.adding(calendarComponent, value: -50), calendarComponentStride: calendarComponent)
+        let endDate = StrideableDate(date: now.adding(calendarComponent, value: 50), calendarComponentStride: calendarComponent)
+        var values = Set<Date>()
+        for _ in 0..<10000 {
+            let random = StrideableDate.random(lowerBound: startDate, upperBound: endDate)
+            values.insert(random.date)
+            XCTAssert(random.date >= startDate.date && random.date < endDate.date, "\(random.date) is not between \(startDate.date) and \(endDate.date)")
+        }
+        XCTAssertEqual(values.count, 100)
+    }
 
 }

--- a/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
@@ -55,7 +55,7 @@ final class StrideableExtensionsTests: XCTestCase {
     }
 
     func testMinMaxStrideableDate() {
-        let calendarComponent = Calendar.Component.day
+        let calendarComponent = Calendar.Component.hour
         let startDate = StrideableDate(date: Date.distantPast, calendarComponentStride: calendarComponent)
         let endDate = StrideableDate(date: Date.distantFuture, calendarComponentStride: calendarComponent)
         var values = Set<Date>()

--- a/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StrideableExtensionsTests.swift
@@ -1,0 +1,42 @@
+//
+//  StrideableExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 11/04/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+final class StrideableExtensionsTests: XCTestCase {
+
+	struct StrideableDate: Strideable {
+		static let dayTimeInterval = TimeInterval(60 * 60 * 24)
+
+		let date: Date
+
+		// swiftlint:disable identifier_name
+		func advanced(by n: Int) -> StrideableDate {
+			return StrideableDate(date: Date(timeInterval: StrideableDate.dayTimeInterval * TimeInterval(n), since: date))
+		}
+
+		func distance(to other: StrideableDate) -> Int {
+			return Int(round(other.date.timeIntervalSince(date) / StrideableDate.dayTimeInterval))
+		}
+		// swiftlint:enable identifier_name
+	}
+
+	func testDateRange() {
+		let startDate = StrideableDate(date: Date(timeIntervalSinceNow: StrideableDate.dayTimeInterval * -50))
+		let endDate = StrideableDate(date: Date(timeIntervalSinceNow: StrideableDate.dayTimeInterval * 50))
+		var values = Set<Date>()
+		for _ in 0..<10000 {
+			let random = StrideableDate.random(lowerBound: startDate, upperBound: endDate)
+			values.insert(random.date)
+			XCTAssert(random.date >= startDate.date && random.date < endDate.date, "\(random.date) is not between \(startDate.date) and \(endDate.date)")
+		}
+		XCTAssertEqual(values.count, 100)
+	}
+
+}


### PR DESCRIPTION
🚀

<!--- Provide a general summary of your changes in the Title above -->
## Summary
These new protocols/extensions allow us to generate random numbers of any type. E.g.
`let diceRoll = Int.random(upperBound: 6)`
`let angle = Double.random(lowerBound: -.pi, upperBound: .pi)`

It turns out that this was much more complicated than initially anticipated. I thought that for integers we'd be able to create one function for `BinaryInteger`s, since Apple's documentation for `numericCast` looked promising:
```
func random(in range: Range<Int>) -> Int {
    return numericCast(arc4random_uniform(numericCast(range.count))) + range.lowerBound
}
```

However there are 2 main issues with their example:
1. It will crash for signed integers when `range.count` is larger number than `Int` can represent, e.g. `Int.min..<Int.max`.
2. `arc4random_uniform` returns a `UInt32`, so it will crash if we want a 64-bit value larger than `UInt32.max`.

After a lot of research and experimentation I found this [StackOverflow entry](https://stackoverflow.com/questions/24007129/how-does-one-generate-a-random-number-in-apples-swift-language/25129039#25129039), which helped me find a very nice solution.

I've also added some future-ready functionality for `Strideable` so that we can get a random `Index` in a `Collection`. But that will be my next task.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
