### PR TITLE
Add safeScrollToRow(at:at:animated:) to safely scroll table view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > # Upcoming release
 >
 > ### Added
-- **UITableViewExtentions**:
-  - Added `isValidIndexPath(_ indexPath:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
+- **UITableViewExtensions**:
+  - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
+  - Added `safeScrollToRow(at:at:animated:)` method to check whether given IndexPath is valid within UITableView. [#445](https://github.com/SwifterSwift/SwifterSwift/pull/445) by [setoelkahfi](https://github.com/setoelkahfi).
 > ### Changed
-- **UITableViewExtentions**:
+- **UITableViewExtensions**:
   - `dequeueReusableCell(withClass:for)`, `dequeueReusableCell(withClass)` now return `UITableViewCell` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
   - `dequeueReusableHeaderFooterView(withClass)`now returns `UITableViewHeaderFooterView` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
 - **UICollectionView**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
-- **UITableViewExtensions**:
+- **UITableView**:
   - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
-  - Added `safeScrollToRow(at:at:animated:)` method to check whether given IndexPath is valid within UITableView. [#445](https://github.com/SwifterSwift/SwifterSwift/pull/445) by [setoelkahfi](https://github.com/setoelkahfi).
+  - Added `safeScrollToRow(at:at:animated:)` method to safely scroll UITableView to the given IndexPath. [#445](https://github.com/SwifterSwift/SwifterSwift/pull/445) by [setoelkahfi](https://github.com/setoelkahfi).
 - **Optional**:
   - Added `isNilOrEmpty` property to check whether an optional is nil or empty collection.
 
 ### Changed
-- **UITableViewExtensions**:
+- **UITableView**:
   - `dequeueReusableCell(withClass:for)`, `dequeueReusableCell(withClass)` now return `UITableViewCell` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
   - `dequeueReusableHeaderFooterView(withClass)`now returns `UITableViewHeaderFooterView` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
 - **UICollectionView**:

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -181,6 +181,18 @@ public extension UITableView {
         return indexPath.section < self.numberOfSections && indexPath.row < self.numberOfRows(inSection: indexPath.section)
     }
 
+    /// SwifterSwift: Safely scroll to possibly invalid IndexPath
+    ///
+    /// - Parameters:
+    ///   - indexPath: Target IndexPath to scroll to
+    ///   - scrollPosition: Scroll position
+    ///   - animated: Whether to animate or not
+    public func safeScrollToRow(at indexPath: IndexPath, at scrollPosition: UITableViewScrollPosition, animated: Bool) {
+        if isValidIndexPath(indexPath) {
+            self.scrollToRow(at: indexPath, at: scrollPosition, animated: animated)
+        }
+    }
+
 }
 #endif
 

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -188,9 +188,9 @@ public extension UITableView {
     ///   - scrollPosition: Scroll position
     ///   - animated: Whether to animate or not
     public func safeScrollToRow(at indexPath: IndexPath, at scrollPosition: UITableViewScrollPosition, animated: Bool) {
-        if indexPath.section < numberOfSections && indexPath.row < numberOfRows(inSection: indexPath.section) {
-            self.scrollToRow(at: indexPath, at: scrollPosition, animated: animated)
-        }
+        guard indexPath.section < numberOfSections else { return }
+        guard indexPath.row < numberOfRows(inSection: indexPath.section) else { return }
+        scrollToRow(at: indexPath, at: scrollPosition, animated: animated)
     }
 
 }

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -188,7 +188,7 @@ public extension UITableView {
     ///   - scrollPosition: Scroll position
     ///   - animated: Whether to animate or not
     public func safeScrollToRow(at indexPath: IndexPath, at scrollPosition: UITableViewScrollPosition, animated: Bool) {
-        if isValidIndexPath(indexPath) {
+        if indexPath.section < numberOfSections && indexPath.row < numberOfRows(inSection: indexPath.section) {
             self.scrollToRow(at: indexPath, at: scrollPosition, animated: animated)
         }
     }

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -105,6 +105,14 @@ final class UITableViewExtensionsTests: XCTestCase {
     }
 
     func testSafeScrollToIndexPath() {
+        let validIndexPathTop = IndexPath(row: 0, section: 0)
+        XCTAssertNoThrow(tableView.safeScrollToRow(at: validIndexPathTop, at: .top, animated: false))
+        XCTAssertEqual(CGPoint.zero, tableView.contentOffset)
+        let validIndexPathBottom = IndexPath(row: 7, section: 1)
+        let bottomOffset = CGPoint(x: 0, y: tableView.contentSize.height - tableView.bounds.size.height)
+        tableView.safeScrollToRow(at: validIndexPathBottom, at: .bottom, animated: false)
+        XCTAssertEqual(bottomOffset.x, tableView.contentOffset.x, accuracy: 0.0)
+        XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 1.0)
         let invalidIndexPath = IndexPath(row: 10, section: 0)
         XCTAssertNoThrow(tableView.safeScrollToRow(at: invalidIndexPath, at: .bottom, animated: false))
     }

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -106,18 +106,31 @@ final class UITableViewExtensionsTests: XCTestCase {
 
     func testSafeScrollToIndexPath() {
         let validIndexPathTop = IndexPath(row: 0, section: 0)
+
+        tableView.contentOffset = .init(x: 0, y: 100)
+        XCTAssertNotEqual(tableView.contentOffset, .zero)
+
         tableView.safeScrollToRow(at: validIndexPathTop, at: .top, animated: false)
-        XCTAssertEqual(CGPoint.zero, tableView.contentOffset)
+        XCTAssertEqual(tableView.contentOffset, .zero)
+
         let validIndexPathBottom = IndexPath(row: 7, section: 1)
         let bottomOffset = CGPoint(x: 0, y: tableView.contentSize.height - tableView.bounds.size.height)
+
+        tableView.contentOffset = .init(x: 0, y: 200)
+        XCTAssertNotEqual(tableView.contentOffset, bottomOffset)
+
         tableView.safeScrollToRow(at: validIndexPathBottom, at: .bottom, animated: false)
         #if os(tvOS)
             XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 15.0)
         #else
             XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 2.0)
         #endif
-        let invalidIndexPath = IndexPath(row: 10, section: 0)
+
+        let invalidIndexPath = IndexPath(row: 213, section: 21)
+        tableView.contentOffset = .zero
+
         tableView.safeScrollToRow(at: invalidIndexPath, at: .bottom, animated: false)
+        XCTAssertEqual(tableView.contentOffset, .zero)
     }
 
 	#if os(iOS)

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -106,7 +106,7 @@ final class UITableViewExtensionsTests: XCTestCase {
 
     func testSafeScrollToIndexPath() {
         let validIndexPathTop = IndexPath(row: 0, section: 0)
-        XCTAssertNoThrow(tableView.safeScrollToRow(at: validIndexPathTop, at: .top, animated: false))
+        tableView.safeScrollToRow(at: validIndexPathTop, at: .top, animated: false)
         XCTAssertEqual(CGPoint.zero, tableView.contentOffset)
         let validIndexPathBottom = IndexPath(row: 7, section: 1)
         let bottomOffset = CGPoint(x: 0, y: tableView.contentSize.height - tableView.bounds.size.height)
@@ -117,7 +117,7 @@ final class UITableViewExtensionsTests: XCTestCase {
             XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 2.0)
         #endif
         let invalidIndexPath = IndexPath(row: 10, section: 0)
-        XCTAssertNoThrow(tableView.safeScrollToRow(at: invalidIndexPath, at: .bottom, animated: false))
+        tableView.safeScrollToRow(at: invalidIndexPath, at: .bottom, animated: false)
     }
 
 	#if os(iOS)

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -111,8 +111,11 @@ final class UITableViewExtensionsTests: XCTestCase {
         let validIndexPathBottom = IndexPath(row: 7, section: 1)
         let bottomOffset = CGPoint(x: 0, y: tableView.contentSize.height - tableView.bounds.size.height)
         tableView.safeScrollToRow(at: validIndexPathBottom, at: .bottom, animated: false)
-        XCTAssertEqual(bottomOffset.x, tableView.contentOffset.x, accuracy: 0.0)
-        XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 1.0)
+        #if os(tvOS)
+            XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 15.0)
+        #else
+            XCTAssertEqual(bottomOffset.y, tableView.contentOffset.y, accuracy: 2.0)
+        #endif
         let invalidIndexPath = IndexPath(row: 10, section: 0)
         XCTAssertNoThrow(tableView.safeScrollToRow(at: invalidIndexPath, at: .bottom, animated: false))
     }

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -104,6 +104,11 @@ final class UITableViewExtensionsTests: XCTestCase {
         XCTAssertFalse(tableView.isValidIndexPath(invalidIndexPath))
     }
 
+    func testSafeScrollToIndexPath() {
+        let invalidIndexPath = IndexPath(row: 10, section: 0)
+        XCTAssertNoThrow(tableView.safeScrollToRow(at: invalidIndexPath, at: .bottom, animated: false))
+    }
+
 	#if os(iOS)
 	func testRegisterReusableViewWithClassAndNib() {
 		let nib = UINib(nibName: "UITableViewHeaderFooterView", bundle: Bundle(for: UITableViewExtensionsTests.self))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
🚀 

This extension will safely scroll UITableView to given IndexPath.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
