### PR TITLE
Adding organization name to the project settings

### DIFF
--- a/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/Extensions/UIKit/Deprecated/UIKitDeprecated.swift
@@ -3,7 +3,7 @@
 //  SwifterSwift
 //
 //  Created by Omar Albeik on 5.04.2018.
-//  Copyright © 2018 ___ORGANIZATIONNAME___
+//  Copyright © 2018 SwifterSwift
 //
 
 #if canImport(UIKit)

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = SwifterSwift;
 				TargetAttributes = {
 					07898B5C1F278D7600558C97 = {
 						CreatedOnToolsVersion = 9.0;

--- a/Tests/SwiftStdlibTests/SignedIntegerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SignedIntegerExtensionsTests.swift
@@ -3,7 +3,7 @@
 //  SwifterSwift
 //
 //  Created by Omar Albeik on 5.04.2018.
-//  Copyright © 2018 ___ORGANIZATIONNAME___
+//  Copyright © 2018 SwifterSwift
 //
 
 import XCTest


### PR DESCRIPTION
Adding the SwifterSwift Organization name to the project settings, so the new files will no longer be created with \_\_\_ORGANIZATIONNAME\_\_\_ :))

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
