### PR TITLE
Added deprecation warning to Array.groupByKey(keyForValue:) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIView**:
   - **Breaking Change** `firstResponder` UIView extension is now a function and suport recursive find in the view hierarchy. [#447](https://github.com/SwifterSwift/SwifterSwift/pull/447) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
  
-> ### Deprecated
+### Deprecated
 - **Array**
   - `groupByKey(keyForValue:)`. [#454](https://github.com/SwifterSwift/SwifterSwift/pull/454) by [@calebkleveter](https://github.com/calebkleveter)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `dequeueReusableSupplementaryView(ofKind:withClass:for)`now returns `UICollectionReusableView` object, `fatalError(...)` if not found. [#439](https://github.com/SwifterSwift/SwifterSwift/pull/439) by [jdisho](https://github.com/jdisho)
 
 ### Deprecated
+- **Array**
+  - `groupByKey(keyForValue:)`. [#454](https://github.com/SwifterSwift/SwifterSwift/pull/454) by [@calebkleveter](https://github.com/calebkleveter)
 
 ### Removed
 

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -280,22 +280,6 @@ public extension Array {
 		return slices
 	}
 
-    @available(*, deprecated, message: "Use 'Dictionary.init(grouping:by:)' instead.")
-	/// SwifterSwift: Group the elements of the array in a dictionary.
-	///
-	///     [0, 2, 5, 4, 7].groupByKey { $0%2 ? "evens" : "odds" } -> [ "evens" : [0, 2, 4], "odds" : [5, 7] ]
-	///
-	/// - Parameter getKey: Clousure to define the key for each element.
-	/// - Returns: A dictionary with values grouped with keys.
-	public func groupByKey<K: Hashable>(keyForValue: (_ element: Element) throws -> K) rethrows -> [K: [Element]] {
-		var group = [K: [Element]]()
-		for value in self {
-			let key = try keyForValue(value)
-			group[key] = (group[key] ?? []) + [value]
-		}
-		return group
-	}
-
 	/// SwifterSwift: Separates an array into 2 arrays based on a predicate.
 	///
 	///     [0, 1, 2, 3, 4, 5].divided { $0 % 2 == 0 } -> ( [0, 2, 4], [1, 3, 5] )

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -280,6 +280,7 @@ public extension Array {
 		return slices
 	}
 
+    @available(*, deprecated, message: "Use 'Dictionary.init(grouping:by:)' instead.")
 	/// SwifterSwift: Group the elements of the array in a dictionary.
 	///
 	///     [0, 2, 5, 4, 7].groupByKey { $0%2 ? "evens" : "odds" } -> [ "evens" : [0, 2, 4], "odds" : [5, 7] ]

--- a/Sources/Extensions/SwiftStdlib/Deprecated/SwiftStdlibDeprecated.swift
+++ b/Sources/Extensions/SwiftStdlib/Deprecated/SwiftStdlibDeprecated.swift
@@ -122,6 +122,21 @@ public extension Array {
 		return self[index]
 	}
 
+    /// SwifterSwift: Group the elements of the array in a dictionary.
+    ///
+    ///     [0, 2, 5, 4, 7].groupByKey { $0%2 ? "evens" : "odds" } -> [ "evens" : [0, 2, 4], "odds" : [5, 7] ]
+    ///
+    /// - Parameter getKey: Clousure to define the key for each element.
+    /// - Returns: A dictionary with values grouped with keys.
+    @available(*, deprecated, message: "Use 'Dictionary.init(grouping:by:)' instead.")
+    public func groupByKey<K: Hashable>(keyForValue: (_ element: Element) throws -> K) rethrows -> [K: [Element]] {
+        var group = [K: [Element]]()
+        for value in self {
+            let key = try keyForValue(value)
+            group[key] = (group[key] ?? []) + [value]
+        }
+        return group
+    }
 }
 
 public extension Array where Element: Equatable {

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -17,7 +17,6 @@ final class CollectionExtensionsTests: XCTestCase {
 		collection.forEachInParallel { item in
 			XCTAssert(collection.contains(item))
 		}
-        collection.groupByKey(keyForValue: { $0 })
 	}
 
 	func testSafeSubscript() {

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -17,6 +17,7 @@ final class CollectionExtensionsTests: XCTestCase {
 		collection.forEachInParallel { item in
 			XCTAssert(collection.contains(item))
 		}
+        collection.groupByKey(keyForValue: { $0 })
 	}
 
 	func testSafeSubscript() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
