### PR TITLE
Add UIGestureRecognizer extension to remove itself from associated view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+- **UIGestureRecognizer**:
+  - Added `removeFromView()` method to remove recognizer from the view the recognizer is attached to. [#456](https://github.com/SwifterSwift/SwifterSwift/pull/456) by [mmdock](https://github.com/mmdock)
 - **UITableView**:
   - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
   - Added `safeScrollToRow(at:at:animated:)` method to safely scroll UITableView to the given IndexPath. [#445](https://github.com/SwifterSwift/SwifterSwift/pull/445) by [setoelkahfi](https://github.com/setoelkahfi).

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) 
 import UIKit
 
+#if !os(watchOS)
 // MARK: - Methods
 public extension UIGestureRecognizer {
 
@@ -17,4 +18,6 @@ public extension UIGestureRecognizer {
         self.view?.removeGestureRecognizer(self)
     }
 }
+#endif
+
 #endif

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -13,7 +13,7 @@ import UIKit
 // MARK: - Methods
 public extension UIGestureRecognizer {
 
-    /// SwifterSwift: Remove Gesture Recognizer from view.
+    /// SwifterSwift: Remove Gesture Recognizer from its view.
     public func remove() {
         self.view?.removeGestureRecognizer(self)
     }

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -15,7 +15,6 @@ public extension UIGestureRecognizer {
     /// SwifterSwift: Remove Gesture Recognizer from view.
     public func remove() {
         self.view?.removeGestureRecognizer(self)
-        
     }
 }
 #endif

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  UIGestureRecognizerExtensions.swift
+//  SwifterSwift
+//
+//  Created by Morgan Dock on 4/21/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if canImport(UIKit)
+import UIKit
+
+// MARK: - Methods
+public extension UIGestureRecognizer {
+
+    /// SwifterSwift: Remove Gesture Recognizer from view.
+    public func remove() {
+        self.view?.removeGestureRecognizer(self)
+        
+    }
+}
+#endif

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -14,7 +14,7 @@ import UIKit
 public extension UIGestureRecognizer {
 
     /// SwifterSwift: Remove Gesture Recognizer from its view.
-    public func remove() {
+    public func removeFromView() {
         self.view?.removeGestureRecognizer(self)
     }
 }

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-#if canImport(UIKit) 
+#if canImport(UIKit)
 import UIKit
 
 #if !os(watchOS)

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -358,6 +358,8 @@
 		784C75372051BE1D001C48DD /* MKPolylineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784C75362051BE1D001C48DD /* MKPolylineTests.swift */; };
 		784C75382051BE1D001C48DD /* MKPolylineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784C75362051BE1D001C48DD /* MKPolylineTests.swift */; };
 		784C75392051BE1D001C48DD /* MKPolylineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784C75362051BE1D001C48DD /* MKPolylineTests.swift */; };
+		90693551208B4F9400407C4D /* UIGestureRecognizerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */; };
+		90693555208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90693554208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift */; };
 		9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914851F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
@@ -543,6 +545,8 @@
 		70269A2F1FB47B0C00C6C2D0 /* CalendarExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionTest.swift; sourceTree = "<group>"; };
 		784C752E2051BD26001C48DD /* MKPolylineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKPolylineExtensions.swift; sourceTree = "<group>"; };
 		784C75362051BE1D001C48DD /* MKPolylineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKPolylineTests.swift; sourceTree = "<group>"; };
+		90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizerExtensions.swift; sourceTree = "<group>"; };
+		90693554208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizerExtensionsTests.swift; sourceTree = "<group>"; };
 		9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensions.swift; sourceTree = "<group>"; };
 		9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionsTests.swift; sourceTree = "<group>"; };
 		9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocolExtensions.swift; sourceTree = "<group>"; };
@@ -764,6 +768,7 @@
 				07B7F17E1F5EB41600E6F910 /* UIButtonExtensions.swift */,
 				07B7F17F1F5EB41600E6F910 /* UICollectionViewExtensions.swift */,
 				074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */,
+				90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */,
 				07B7F1811F5EB41600E6F910 /* UIImageExtensions.swift */,
 				07B7F1821F5EB41600E6F910 /* UIImageViewExtensions.swift */,
 				07B7F1831F5EB41600E6F910 /* UILabelExtensions.swift */,
@@ -863,6 +868,7 @@
 				07C50D221F5EB03200F46E5A /* UIViewControllerExtensionsTests.swift */,
 				07C50D231F5EB03200F46E5A /* UIViewExtensionsTests.swift */,
 				42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */,
+				90693554208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -1349,6 +1355,7 @@
 			files = (
 				07B7F2191F5EB43C00E6F910 /* SignedNumericExtensions.swift in Sources */,
 				A94AA78720280F9100E229A5 /* FileManagerExtensions.swift in Sources */,
+				90693551208B4F9400407C4D /* UIGestureRecognizerExtensions.swift in Sources */,
 				B23678EC1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */,
 				0726D7771F7C199E0028CAB5 /* ColorExtensions.swift in Sources */,
 				07B7F2181F5EB43C00E6F910 /* SignedIntegerExtensions.swift in Sources */,
@@ -1602,6 +1609,7 @@
 				07C50D2F1F5EB04600F46E5A /* ColorExtensionsTests.swift in Sources */,
 				07C50D331F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */,
 				07C50D401F5EB04700F46E5A /* UIViewExtensionsTests.swift in Sources */,
+				90693555208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift in Sources */,
 				07C50D311F5EB04700F46E5A /* UIImageViewExtensionsTests.swift in Sources */,
 				07C50D2C1F5EB04600F46E5A /* UIBarButtonExtensionsTests.swift in Sources */,
 				077BA0B91F6BEA6A00D9C4AC /* UserDefaultsExtensionsTests.swift in Sources */,

--- a/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 class UIGestureRecognizerExtensionsTests: XCTestCase {
 
-    func testExample() {
-        let view: UIImageView = UIImageView()
+    func testRemove() {
+        let view = UIImageView()
         let tap = UITapGestureRecognizer()
 
         //First Baseline Assertion

--- a/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
@@ -1,0 +1,42 @@
+//
+//  UIGestureRecognizerExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Morgan Dock on 4/21/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if os(iOS)
+import XCTest
+@testable import SwifterSwift
+
+class UIGestureRecognizerExtensionsTests: XCTestCase {
+
+    func testExample() {
+        let view: UIImageView = UIImageView()
+        let tap = UITapGestureRecognizer()
+
+        //First Baseline Assertion
+        XCTAssert(view.gestureRecognizers == nil)
+        XCTAssert(tap.view == nil)
+
+        view.addGestureRecognizer(tap)
+
+        //Verify change
+        XCTAssertFalse(view.gestureRecognizers == nil)
+        XCTAssertFalse(tap.view == nil)
+
+        //Second Baseline Assertion
+        XCTAssertFalse((view.gestureRecognizers?.count ?? 0) == 0)
+        XCTAssertFalse(view.gestureRecognizers?.isEmpty ?? true)
+
+        tap.remove()
+
+        //Verify change
+        XCTAssert((view.gestureRecognizers?.count ?? 1) == 0)
+        XCTAssert(view.gestureRecognizers?.isEmpty ?? false)
+        XCTAssert(tap.view == nil)
+    }
+    
+}
+#endif

--- a/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
@@ -37,6 +37,5 @@ class UIGestureRecognizerExtensionsTests: XCTestCase {
         XCTAssert(view.gestureRecognizers?.isEmpty ?? false)
         XCTAssert(tap.view == nil)
     }
-    
 }
 #endif

--- a/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class UIGestureRecognizerExtensionsTests: XCTestCase {
 
-    func testRemove() {
+    func testRemoveFromView() {
         let view = UIImageView()
         let tap = UITapGestureRecognizer()
 
@@ -30,7 +30,7 @@ class UIGestureRecognizerExtensionsTests: XCTestCase {
         XCTAssertFalse((view.gestureRecognizers?.count ?? 0) == 0)
         XCTAssertFalse(view.gestureRecognizers?.isEmpty ?? true)
 
-        tap.remove()
+        tap.removeFromView()
 
         //Verify change
         XCTAssert((view.gestureRecognizers?.count ?? 1) == 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

I am unsure as to the changelog - not sure how to add to it exactly.  Could you explain this?
Not sure how I can be sure this supports tvOS, watchOS, etc. If you could explain this as well please, I can add what is needed for this and the changelog and request again.
