### PR TITLE
Add UIScrollView extension to snapshot entire scrollview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+- **UIScrollView**:
+  - Added `snapshot` method to get a full snapshot of a rendered scroll view. [#457](https://github.com/SwifterSwift/SwifterSwift/pull/457) by [aliamcami](https://github.com/aliamcami).
 - **UIGestureRecognizer**:
   - Added `removeFromView()` method to remove recognizer from the view the recognizer is attached to. [#456](https://github.com/SwifterSwift/SwifterSwift/pull/456) by [mmdock](https://github.com/mmdock)
 - **UITableView**:

--- a/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
@@ -1,0 +1,43 @@
+//
+//  UIScrollViewExtensions.swift
+//  SwifterSwift
+//
+//  Created by camila oliveira on 22/04/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if canImport(UIKit)
+    import UIKit
+    
+#if !os(watchOS)
+
+// MARK: - Methods
+public extension UIScrollView{
+    
+    
+    //Original Source: https://gist.github.com/thestoics/1204051
+    /// SwifterSwift: Takes a snapshot of an entire ScrollView
+    ///
+    ///    AnySubclassOfUIScroolView().snapshot
+    ///    UITableView().snapshot
+    ///
+    /// - Returns: Snapshot as UIimage for rendered ScrollView
+    public var snapshot: UIImage? {
+        UIGraphicsBeginImageContextWithOptions(contentSize, false, 0)
+        defer {
+            UIGraphicsEndImageContext()
+        }
+        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+        
+        let previousFrame = frame
+        frame = CGRect(origin: frame.origin, size: contentSize)
+        layer.render(in: context)
+        frame = previousFrame
+        
+        layer.render(in: context)
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+}
+#endif
+    
+#endif

--- a/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
@@ -8,13 +8,10 @@
 
 #if canImport(UIKit)
     import UIKit
-    
 #if !os(watchOS)
 
 // MARK: - Methods
 public extension UIScrollView{
-    
-    
     //Original Source: https://gist.github.com/thestoics/1204051
     /// SwifterSwift: Takes a snapshot of an entire ScrollView
     ///
@@ -22,22 +19,21 @@ public extension UIScrollView{
     ///    UITableView().snapshot
     ///
     /// - Returns: Snapshot as UIimage for rendered ScrollView
-    public var snapshot: UIImage? {
+    public var snapshot: UIImage?{
         UIGraphicsBeginImageContextWithOptions(contentSize, false, 0)
-        defer {
+        defer{
             UIGraphicsEndImageContext()
         }
         guard let context = UIGraphicsGetCurrentContext() else { return nil }
-        
         let previousFrame = frame
         frame = CGRect(origin: frame.origin, size: contentSize)
         layer.render(in: context)
         frame = previousFrame
-        
         layer.render(in: context)
         return UIGraphicsGetImageFromCurrentImageContext()
     }
 }
+
 #endif
-    
+
 #endif

--- a/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
@@ -11,7 +11,7 @@
 #if !os(watchOS)
 
 // MARK: - Methods
-public extension UIScrollView{
+public extension UIScrollView {
     //Original Source: https://gist.github.com/thestoics/1204051
     /// SwifterSwift: Takes a snapshot of an entire ScrollView
     ///
@@ -19,9 +19,9 @@ public extension UIScrollView{
     ///    UITableView().snapshot
     ///
     /// - Returns: Snapshot as UIimage for rendered ScrollView
-    public var snapshot: UIImage?{
+    public var snapshot: UIImage? {
         UIGraphicsBeginImageContextWithOptions(contentSize, false, 0)
-        defer{
+        defer {
             UIGraphicsEndImageContext()
         }
         guard let context = UIGraphicsGetCurrentContext() else { return nil }

--- a/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIScrollViewExtensions.swift
@@ -29,7 +29,6 @@ public extension UIScrollView{
         frame = CGRect(origin: frame.origin, size: contentSize)
         layer.render(in: context)
         frame = previousFrame
-        layer.render(in: context)
         return UIGraphicsGetImageFromCurrentImageContext()
     }
 }

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -358,6 +358,8 @@
 		784C75372051BE1D001C48DD /* MKPolylineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784C75362051BE1D001C48DD /* MKPolylineTests.swift */; };
 		784C75382051BE1D001C48DD /* MKPolylineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784C75362051BE1D001C48DD /* MKPolylineTests.swift */; };
 		784C75392051BE1D001C48DD /* MKPolylineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784C75362051BE1D001C48DD /* MKPolylineTests.swift */; };
+		86B3F7AC208D3D5C00BC297B /* UIScrollViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3F7AB208D3D5C00BC297B /* UIScrollViewExtensions.swift */; };
+		86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3F7AD208D3DF300BC297B /* UIScrollViewExtensionsTest.swift */; };
 		9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914851F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
@@ -543,6 +545,8 @@
 		70269A2F1FB47B0C00C6C2D0 /* CalendarExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionTest.swift; sourceTree = "<group>"; };
 		784C752E2051BD26001C48DD /* MKPolylineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKPolylineExtensions.swift; sourceTree = "<group>"; };
 		784C75362051BE1D001C48DD /* MKPolylineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKPolylineTests.swift; sourceTree = "<group>"; };
+		86B3F7AB208D3D5C00BC297B /* UIScrollViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewExtensions.swift; sourceTree = "<group>"; };
+		86B3F7AD208D3DF300BC297B /* UIScrollViewExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewExtensionsTest.swift; sourceTree = "<group>"; };
 		9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensions.swift; sourceTree = "<group>"; };
 		9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionsTests.swift; sourceTree = "<group>"; };
 		9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocolExtensions.swift; sourceTree = "<group>"; };
@@ -783,6 +787,7 @@
 				07B7F1911F5EB41600E6F910 /* UIViewExtensions.swift */,
 				076AEC881FDB48580077D153 /* UIDatePickerExtensions.swift */,
 				42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */,
+				86B3F7AB208D3D5C00BC297B /* UIScrollViewExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -863,6 +868,7 @@
 				07C50D221F5EB03200F46E5A /* UIViewControllerExtensionsTests.swift */,
 				07C50D231F5EB03200F46E5A /* UIViewExtensionsTests.swift */,
 				42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */,
+				86B3F7AD208D3DF300BC297B /* UIScrollViewExtensionsTest.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -1402,6 +1408,7 @@
 				70269A2B1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */,
 				07B7F2161F5EB43C00E6F910 /* LocaleExtensions.swift in Sources */,
 				07B7F2101F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
+				86B3F7AC208D3D5C00BC297B /* UIScrollViewExtensions.swift in Sources */,
 				07B7F2141F5EB43C00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F19E1F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
 				07B7F20F1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
@@ -1639,6 +1646,7 @@
 				07C50D641F5EB05000F46E5A /* URLExtensionsTests.swift in Sources */,
 				07C50D2B1F5EB04600F46E5A /* UIAlertControllerExtensionsTests.swift in Sources */,
 				07C50D5E1F5EB05000F46E5A /* DoubleExtensionsTests.swift in Sources */,
+				86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTest.swift in Sources */,
 				18C8E5E32074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				07C50D5D1F5EB05000F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D5B1F5EB05000F46E5A /* DataExtensionsTests.swift in Sources */,

--- a/Tests/UIKitTests/UIScrollViewExtensionsTest.swift
+++ b/Tests/UIKitTests/UIScrollViewExtensionsTest.swift
@@ -12,13 +12,11 @@ import XCTest
 #if os(iOS) || os(tvOS)
 final class UIScrollViewExtensionsTest: XCTestCase {
     func testSnapshot() {
-        
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let scroll = UIScrollView(frame: frame)
         scroll.contentSize = frame.size
         let snapshot = scroll.snapshot
         XCTAssertNotNil(snapshot)
-        
         let view = UIScrollView()
         XCTAssertNil(view.snapshot)
     } 

--- a/Tests/UIKitTests/UIScrollViewExtensionsTest.swift
+++ b/Tests/UIKitTests/UIScrollViewExtensionsTest.swift
@@ -1,0 +1,26 @@
+//
+//  UIScrollViewExtensionsTest.swift
+//  SwifterSwift
+//
+//  Created by camila oliveira on 22/04/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if os(iOS) || os(tvOS)
+final class UIScrollViewExtensionsTest: XCTestCase {
+    func testSnapshot() {
+        
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let scroll = UIScrollView(frame: frame)
+        scroll.contentSize = frame.size
+        let snapshot = scroll.snapshot
+        XCTAssertNotNil(snapshot)
+        
+        let view = UIScrollView()
+        XCTAssertNil(view.snapshot)
+    } 
+}
+#endif

--- a/Tests/UIKitTests/UIScrollViewExtensionsTest.swift
+++ b/Tests/UIKitTests/UIScrollViewExtensionsTest.swift
@@ -19,6 +19,6 @@ final class UIScrollViewExtensionsTest: XCTestCase {
         XCTAssertNotNil(snapshot)
         let view = UIScrollView()
         XCTAssertNil(view.snapshot)
-    } 
+    }
 }
 #endif


### PR DESCRIPTION
Snapshots the entire rendered scroll view, even if it does not show on screen at the moment. Very similar to UIView.screenshot but it returns an image representation of the entire content.