### PR TITLE
 🚀 Wrap to the content (String / AttributedText) UITextView #New-Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
 # Upcoming release
+### Added
+- **UITextView**:
+- Added `wrapToContent()` method which will remove insets, offsets, paddings which lies within UITextView's `bounds` and `contenSize`. [#458](https://github.com/SwifterSwift/SwifterSwift/pull/458) by [ratulSharker](https://github.com/ratulSharker)
 
 ### Added
 - **UITableView**:

--- a/Sources/Extensions/UIKit/UITextViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextViewExtensions.swift
@@ -32,7 +32,16 @@ public extension UITextView {
 		let range = NSMakeRange(0, 1)
 		scrollRangeToVisible(range)
 	}
-
+    
+    /// SwifterSwift: Wrap to the content (Text / Attributed Text).
+    func wrapToContent() {
+        self.contentInset = UIEdgeInsets.zero
+        self.scrollIndicatorInsets = UIEdgeInsets.zero
+        self.contentOffset = CGPoint.zero
+        self.textContainerInset = UIEdgeInsets.zero
+        self.textContainer.lineFragmentPadding = 0
+    }
+    
 }
 #endif
 

--- a/Sources/Extensions/UIKit/UITextViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextViewExtensions.swift
@@ -40,6 +40,7 @@ public extension UITextView {
         self.contentOffset = CGPoint.zero
         self.textContainerInset = UIEdgeInsets.zero
         self.textContainer.lineFragmentPadding = 0
+        self.sizeToFit()
     }
     
 }

--- a/Sources/Extensions/UIKit/UITextViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextViewExtensions.swift
@@ -35,12 +35,12 @@ public extension UITextView {
 
     /// SwifterSwift: Wrap to the content (Text / Attributed Text).
     public func wrapToContent() {
-        self.contentInset = UIEdgeInsets.zero
-        self.scrollIndicatorInsets = UIEdgeInsets.zero
-        self.contentOffset = CGPoint.zero
-        self.textContainerInset = UIEdgeInsets.zero
-        self.textContainer.lineFragmentPadding = 0
-        self.sizeToFit()
+        contentInset = UIEdgeInsets.zero
+        scrollIndicatorInsets = UIEdgeInsets.zero
+        contentOffset = CGPoint.zero
+        textContainerInset = UIEdgeInsets.zero
+        textContainer.lineFragmentPadding = 0
+        sizeToFit()
     }
 
 }

--- a/Sources/Extensions/UIKit/UITextViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextViewExtensions.swift
@@ -32,7 +32,7 @@ public extension UITextView {
 		let range = NSMakeRange(0, 1)
 		scrollRangeToVisible(range)
 	}
-    
+
     /// SwifterSwift: Wrap to the content (Text / Attributed Text).
     func wrapToContent() {
         self.contentInset = UIEdgeInsets.zero
@@ -42,7 +42,7 @@ public extension UITextView {
         self.textContainer.lineFragmentPadding = 0
         self.sizeToFit()
     }
-    
+
 }
 #endif
 

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -42,7 +42,7 @@ final class UITextViewExtensionsTests: XCTestCase {
 
     func testWrapToContent() {
         let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
- 
+
         // initial setting
         textView.frame = CGRect.init(x: 0, y: 0, width: 100, height: 20)
         textView.font = UIFont.systemFont(ofSize: 20.0)

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -39,15 +39,15 @@ final class UITextViewExtensionsTests: XCTestCase {
 		textView.scrollToTop()
 		XCTAssertNotEqual(textView.contentOffset.y, 0.0)
 	}
-    
+
     func testWrapToContent() {
         let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-        
+ 
         // initial setting
         textView.frame = CGRect.init(x: 0, y: 0, width: 100, height: 20)
         textView.font = UIFont.systemFont(ofSize: 20.0)
         textView.text = text
-        
+
         // determining the text size
         let constraintRect = CGSize(width: 100, height: CGFloat.greatestFiniteMagnitude)
         let boundingBox = text.boundingRect(with: constraintRect,
@@ -56,20 +56,20 @@ final class UITextViewExtensionsTests: XCTestCase {
                                             context: nil)
         let textHeight = ceil(boundingBox.height)
         let textSize = CGSize.init(width: 100, height: textHeight)
-        
+
         // before setting wrap, content won't be equal to bounds
         XCTAssertNotEqual(textView.bounds.size, textView.contentSize)
-        
+
         // calling the wrap extension method
         textView.wrapToContent()
-        
+
         // setting the frame
         //
         // This is important to set the frame after calling the wrapToContent, otherwise
         // boundingRect can give you fractional value, and method call `sizeToFit` inside the
         // wrapToContent would change to the fractional value instead of the ceil value.
         textView.bounds = CGRect.init(x: 0, y: 0, width: textSize.width, height: textSize.height)
-        
+
         // after setting wrap, content size will be equal to bounds
         XCTAssertEqual(textView.bounds.size, textView.contentSize)
     }

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -57,17 +57,21 @@ final class UITextViewExtensionsTests: XCTestCase {
         let textHeight = ceil(boundingBox.height)
         let textSize = CGSize.init(width: 100, height: textHeight)
         
-        textView.bounds = CGRect.init(x: 0, y: 0, width: textSize.width, height: textSize.height)
-        
         // before setting wrap, content won't be equal to bounds
         XCTAssertNotEqual(textView.bounds.size, textView.contentSize)
         
-        // setting the wrapping option
+        // calling the wrap extension method
         textView.wrapToContent()
+        
+        // setting the frame
+        //
+        // This is important to set the frame after calling the wrapToContent, otherwise
+        // boundingRect can give you fractional value, and method call `sizeToFit` inside the
+        // wrapToContent would change to the fractional value instead of the ceil value.
+        textView.bounds = CGRect.init(x: 0, y: 0, width: textSize.width, height: textSize.height)
         
         // after setting wrap, content size will be equal to bounds
         XCTAssertEqual(textView.bounds.size, textView.contentSize)
     }
-    
 }
 #endif

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -39,6 +39,35 @@ final class UITextViewExtensionsTests: XCTestCase {
 		textView.scrollToTop()
 		XCTAssertNotEqual(textView.contentOffset.y, 0.0)
 	}
-
+    
+    func testWrapToContent() {
+        let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        
+        // initial setting
+        textView.frame = CGRect.init(x: 0, y: 0, width: 100, height: 20)
+        textView.font = UIFont.systemFont(ofSize: 20.0)
+        textView.text = text
+        
+        // determining the text size
+        let constraintRect = CGSize(width: 100, height: CGFloat.greatestFiniteMagnitude)
+        let boundingBox = text.boundingRect(with: constraintRect,
+                                            options: NSStringDrawingOptions.usesLineFragmentOrigin,
+                                            attributes: [.font: textView.font!],
+                                            context: nil)
+        let textHeight = ceil(boundingBox.height)
+        let textSize = CGSize.init(width: 100, height: textHeight)
+        
+        textView.bounds = CGRect.init(x: 0, y: 0, width: textSize.width, height: textSize.height)
+        
+        // before setting wrap, content won't be equal to bounds
+        XCTAssertNotEqual(textView.bounds.size, textView.contentSize)
+        
+        // setting the wrapping option
+        textView.wrapToContent()
+        
+        // after setting wrap, content size will be equal to bounds
+        XCTAssertEqual(textView.bounds.size, textView.contentSize)
+    }
+    
 }
 #endif

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -44,7 +44,7 @@ final class UITextViewExtensionsTests: XCTestCase {
         let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 
         // initial setting
-        textView.frame = CGRect.init(x: 0, y: 0, width: 100, height: 20)
+        textView.frame = CGRect(x: 0, y: 0, width: 100, height: 20)
         textView.font = UIFont.systemFont(ofSize: 20.0)
         textView.text = text
 
@@ -55,7 +55,7 @@ final class UITextViewExtensionsTests: XCTestCase {
                                             attributes: [.font: textView.font!],
                                             context: nil)
         let textHeight = ceil(boundingBox.height)
-        let textSize = CGSize.init(width: 100, height: textHeight)
+        let textSize = CGSize(width: 100, height: textHeight)
 
         // before setting wrap, content won't be equal to bounds
         XCTAssertNotEqual(textView.bounds.size, textView.contentSize)
@@ -68,7 +68,7 @@ final class UITextViewExtensionsTests: XCTestCase {
         // This is important to set the frame after calling the wrapToContent, otherwise
         // boundingRect can give you fractional value, and method call `sizeToFit` inside the
         // wrapToContent would change to the fractional value instead of the ceil value.
-        textView.bounds = CGRect.init(x: 0, y: 0, width: textSize.width, height: textSize.height)
+        textView.bounds = CGRect(x: 0, y: 0, width: textSize.width, height: textSize.height)
 
         // after setting wrap, content size will be equal to bounds
         XCTAssertEqual(textView.bounds.size, textView.contentSize)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) 

While `UITextView` is used as a non-scrollable text container (i.e chat bubble) some inset, offset, padding required to set to zero as following

```swift
textView.contentInset = UIEdgeInsets.zero
textView.scrollIndicatorInsets = UIEdgeInsets.zero
textView.contentOffset = CGPoint.zero
textView.textContainerInset = UIEdgeInsets.zero
textView.textContainer.lineFragmentPadding = 0
textView.sizeToFit()
```

This extension `wrapToContent` wrap everything up into a nice little instance method.
