### PR TITLE
🚀 add `applyShadow(color:alpha:xOffset:yOffset:blur:spread)` method to ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **CALayer**:
-  - Added `applyShadow(color:alpha:xOffset:yOffset:blur:spread)` method to apply a shadow to a CALayer with the same describing paramaters as Sketch, Zeplin, etc. [#459](https://github.com/SwifterSwift/SwifterSwift/issues/459) by [mmdock](https://github.com/mmdock)
+  - Added `applyShadow(color:alpha:xOffset:yOffset:blur:spread)` method to apply a shadow to a CALayer with the same describing paramaters as Sketch, Zeplin, etc. [#460](https://github.com/SwifterSwift/SwifterSwift/pull/460) by [mmdock](https://github.com/mmdock)
 - **UIScrollView**:
   - Added `snapshot` method to get a full snapshot of a rendered scroll view. [#457](https://github.com/SwifterSwift/SwifterSwift/pull/457) by [aliamcami](https://github.com/aliamcami).
 - **UIGestureRecognizer**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+- **CALayer**:
+  - Added `applyShadow(color:alpha:xOffset:yOffset:blur:spread)` method to apply a shadow to a CALayer with the same describing paramaters as Sketch, Zeplin, etc. [#459](https://github.com/SwifterSwift/SwifterSwift/issues/459) by [mmdock](https://github.com/mmdock)
 - **UIScrollView**:
   - Added `snapshot` method to get a full snapshot of a rendered scroll view. [#457](https://github.com/SwifterSwift/SwifterSwift/pull/457) by [aliamcami](https://github.com/aliamcami).
 - **UIGestureRecognizer**:

--- a/Sources/Extensions/CoreAnimation/CALayerExtensions.swift
+++ b/Sources/Extensions/CoreAnimation/CALayerExtensions.swift
@@ -1,0 +1,34 @@
+//
+//  CALayerExtension.swift
+//  SwifterSwift
+//
+//  Created by Morgan Dock on 4/26/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+public extension CALayer {
+
+    /// SwifterSwift: Create a shadow affect, using the same parameters used in design software such as Sketch, Zeplin, and others.
+    /// This Extension originates from here: https://stackoverflow.com/questions/34269399/how-to-control-shadow-spread-and-blur/34270362
+    ///
+    /// - Parameters:
+    ///   - color: the tint of the shadow effect.  Default is UIColor.black
+    ///   - alpha: opacity of the color applied to the shaddow effect.  Default is 0.5
+    ///   - x: the horizontal offset applied to the shadow effect.  Default is 0.
+    ///   - y: the vertical offset applied to the shadow effect.  Default is 2.
+    ///   - blur: if set to 0 the shadow will be sharp, the higher the number, the more blurred it will be.  Default is 4.
+    ///   - spread: positive values increase the size of the shadow, negative values decrease the size. Default is 0 (the shadow is same size as blur).
+    public func applyShadow(color: UIColor = .black, alpha: Float = 0.5, xOffset: CGFloat = 0, yOffset: CGFloat = 2, blur: CGFloat = 4, spread: CGFloat = 0) {
+        shadowColor = color.cgColor
+        shadowOpacity = alpha
+        shadowOffset = CGSize(width: xOffset, height: yOffset)
+        shadowRadius = blur / 2.0
+        if spread == 0 {
+            shadowPath = nil
+        } else {
+            let dirX = -spread
+            let rect = bounds.insetBy(dx: dirX, dy: dirX)
+            shadowPath = UIBezierPath(rect: rect).cgPath
+        }
+    }
+}

--- a/Sources/Extensions/CoreAnimation/CALayerExtensions.swift
+++ b/Sources/Extensions/CoreAnimation/CALayerExtensions.swift
@@ -15,20 +15,19 @@ public extension CALayer {
     ///   - color: the tint of the shadow effect.  Default is UIColor.black
     ///   - alpha: opacity of the color applied to the shaddow effect.  Default is 0.5
     ///   - x: the horizontal offset applied to the shadow effect.  Default is 0.
-    ///   - y: the vertical offset applied to the shadow effect.  Default is 2.
-    ///   - blur: if set to 0 the shadow will be sharp, the higher the number, the more blurred it will be.  Default is 4.
-    ///   - spread: positive values increase the size of the shadow, negative values decrease the size. Default is 0 (the shadow is same size as blur).
-    public func applyShadow(color: UIColor = .black, alpha: Float = 0.5, xOffset: CGFloat = 0, yOffset: CGFloat = 2, blur: CGFloat = 4, spread: CGFloat = 0) {
-        shadowColor = color.cgColor
+    ///   - y: the vertical offset applied to the shadow effect.  Default is 0.
+    ///   - blur: if set to 0 the shadow will be sharp, the higher the number, the more blurred it will be.  Default is 0.
+    ///   - spread: positive values increase the size of the shadow, negative values decrease the size. Default is 0.
+    public func applyShadow(color: CGColor = UIColor.black.cgColor, alpha: Float = 0.5, offset: CGSize = CGSize(width: 0, height: 0), blur: CGFloat = 0, spread: CGFloat = 0) {
+        shadowColor = color
         shadowOpacity = alpha
-        shadowOffset = CGSize(width: xOffset, height: yOffset)
+        shadowOffset = offset
         shadowRadius = blur / 2.0
         if spread == 0 {
             shadowPath = nil
         } else {
             let dirX = -spread
-            let rect = bounds.insetBy(dx: dirX, dy: dirX)
-            shadowPath = UIBezierPath(rect: rect).cgPath
+            shadowPath = CGPath(rect: bounds.insetBy(dx: dirX, dy: dirX), transform: nil)
         }
     }
 }

--- a/Sources/Extensions/CoreAnimation/CALayerExtensions.swift
+++ b/Sources/Extensions/CoreAnimation/CALayerExtensions.swift
@@ -6,19 +6,20 @@
 //  Copyright © 2018 SwifterSwift
 //
 
+#if !os(watchOS)
+
 public extension CALayer {
 
     /// SwifterSwift: Create a shadow affect, using the same parameters used in design software such as Sketch, Zeplin, and others.
     /// This Extension originates from here: https://stackoverflow.com/questions/34269399/how-to-control-shadow-spread-and-blur/34270362
     ///
     /// - Parameters:
-    ///   - color: the tint of the shadow effect.  Default is UIColor.black
-    ///   - alpha: opacity of the color applied to the shaddow effect.  Default is 0.5
-    ///   - x: the horizontal offset applied to the shadow effect.  Default is 0.
-    ///   - y: the vertical offset applied to the shadow effect.  Default is 0.
-    ///   - blur: if set to 0 the shadow will be sharp, the higher the number, the more blurred it will be.  Default is 0.
+    ///   - color: the tint of the shadow effect.  No Default is provided
+    ///   - alpha: opacity of the color applied to the shaddow effect.  Default is 0.08
+    ///   - offset: the x and y offsets represented as a CGSize.  Default is (0, 3)
+    ///   - blur: if set to 0 the shadow will be sharp, the higher the number, the more blurred it will be.  Default is 5.
     ///   - spread: positive values increase the size of the shadow, negative values decrease the size. Default is 0.
-    public func applyShadow(color: CGColor = UIColor.black.cgColor, alpha: Float = 0.5, offset: CGSize = CGSize(width: 0, height: 0), blur: CGFloat = 0, spread: CGFloat = 0) {
+    public func applyShadow(withColor color: CGColor, alpha: Float = 0.08, offset: CGSize = CGSize(width: 0, height: 3), blur: CGFloat = 5, spread: CGFloat = 0) {
         shadowColor = color
         shadowOpacity = alpha
         shadowOffset = offset
@@ -30,4 +31,6 @@ public extension CALayer {
             shadowPath = CGPath(rect: bounds.insetBy(dx: dirX, dy: dirX), transform: nil)
         }
     }
+
 }
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 		86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3F7AD208D3DF300BC297B /* UIScrollViewExtensionsTest.swift */; };
 		90693551208B4F9400407C4D /* UIGestureRecognizerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */; };
 		90693555208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90693554208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift */; };
+		90B1983A2091CCEE0038A08E /* CALayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B198392091CCEE0038A08E /* CALayerExtensions.swift */; };
 		9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
 		9D4914851F85138E00F3868F /* NSPredicateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */; };
@@ -551,6 +552,7 @@
 		86B3F7AD208D3DF300BC297B /* UIScrollViewExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewExtensionsTest.swift; sourceTree = "<group>"; };
 		90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizerExtensions.swift; sourceTree = "<group>"; };
 		90693554208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizerExtensionsTests.swift; sourceTree = "<group>"; };
+		90B198392091CCEE0038A08E /* CALayerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerExtensions.swift; sourceTree = "<group>"; };
 		9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensions.swift; sourceTree = "<group>"; };
 		9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionsTests.swift; sourceTree = "<group>"; };
 		9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocolExtensions.swift; sourceTree = "<group>"; };
@@ -715,6 +717,7 @@
 		07898B941F27904200558C97 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				90B198382091CCD50038A08E /* CoreAnimation */,
 				784C752D2051BD01001C48DD /* MapKit */,
 				0726D7751F7C19880028CAB5 /* Shared */,
 				077BA0871F6BE73000D9C4AC /* SwiftStdlib */,
@@ -940,6 +943,14 @@
 				784C75362051BE1D001C48DD /* MKPolylineTests.swift */,
 			);
 			path = MapKitTests;
+			sourceTree = "<group>";
+		};
+		90B198382091CCD50038A08E /* CoreAnimation */ = {
+			isa = PBXGroup;
+			children = (
+				90B198392091CCEE0038A08E /* CALayerExtensions.swift */,
+			);
+			path = CoreAnimation;
 			sourceTree = "<group>";
 		};
 		B23678EA1FB116680027C931 /* Deprecated */ = {
@@ -1360,6 +1371,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07B7F2191F5EB43C00E6F910 /* SignedNumericExtensions.swift in Sources */,
+				90B1983A2091CCEE0038A08E /* CALayerExtensions.swift in Sources */,
 				A94AA78720280F9100E229A5 /* FileManagerExtensions.swift in Sources */,
 				90693551208B4F9400407C4D /* UIGestureRecognizerExtensions.swift in Sources */,
 				B23678EC1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */,


### PR DESCRIPTION
…apply a shadow to a CALayer with the same describing parameters as Sketch, Zeplin, etc. (#459)

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 4.
- [X] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

1)
I am not sure if shadows are supported in tvOS and watchOS - if not, proper checks need to be added
2)
I am not sure how to write a test for a UI based extension (If there is an example to reference, please link so I can learn)
3)
Please let me know thoughts on this.  I feel the parameter names and such may need a little adjusting, specifically xOffset and yOffset.  I wanted to just call them x and y like Sketch does, however, SwiftLint does not allow variable names of a length less than 3.

I happen to use this extension literally ALL the time.  (Well, one similar to it, but have found this one way easier to use, understand, and read... but the base functionality is the same.)

