### PR TITLE
🚀 New init method added in URL class to initialize an URL applying percent encoding. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
 # Upcoming release
+
 ### Added
+- **URL**
+- Added `init?(withPercentEncodingOfString string: String)` method to create a `URL` from after applying percent encoding. by [ratulSharker](https://github.com/ratulSharker)
 - **Character**:
 - Added `randomAlphanumeric()` method to generate a random alphanumeric Character. [#462](https://github.com/SwifterSwift/SwifterSwift/pull/458) by [oliviabrown9](https://github.com/oliviabrown9)
 - **UITextView**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **URL**
-- Added `init?(withPercentEncodingOfString string: String)` method to create a `URL` from after applying percent encoding. by [ratulSharker](https://github.com/ratulSharker)
+- Added `init?(withPercentEncodingOfString string: String)` method to create a `URL` from after applying percent encoding.[#465](https://github.com/SwifterSwift/SwifterSwift/pull/465) by [ratulSharker](https://github.com/ratulSharker)
 - **Character**:
 - Added `randomAlphanumeric()` method to generate a random alphanumeric Character. [#462](https://github.com/SwifterSwift/SwifterSwift/pull/458) by [oliviabrown9](https://github.com/oliviabrown9)
 - **UITextView**:

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -29,12 +29,26 @@ public extension URL {
 
 		return items
 	}
-
 }
 
 // MARK: - Methods
 public extension URL {
 
+    /// SwifterSwift: URL initiate with percent encoding
+    ///
+    ///     let urlString = "http://www.prothomalo.com/bangladesh/article/1472031/নারায়ণগঞ্জে-গ্যাসবোমার-ওপর-বসবাস-তাঁদের"
+    ///     let url = URL.initWithPercentEncoding(urlString)
+    ///     url -> "http://www.prothomalo.com/bangladesh/article/1472031/%E0%A6%A8%E0%A6%BE%E0%A6%B0%E0%A6%BE%E0%A6%AF%E0%A6%BC%E0%A6%A3%E0%A6%97%E0%A6%9E%E0%A7%8D%E0%A6%9C%E0%A7%87-%E0%A6%97%E0%A7%8D%E0%A6%AF%E0%A6%BE%E0%A6%B8%E0%A6%AC%E0%A7%8B%E0%A6%AE%E0%A6%BE%E0%A6%B0-%E0%A6%93%E0%A6%AA%E0%A6%B0-%E0%A6%AC%E0%A6%B8%E0%A6%AC%E0%A6%BE%E0%A6%B8-%E0%A6%A4%E0%A6%BE%E0%A6%81%E0%A6%A6%E0%A7%87%E0%A6%B0"
+    ///
+    /// - Parameters: string representation of an url
+    /// - Returns: initated url using the percent encoding
+    public init?(withPercentEncodingOfString string: String) {
+        if let encodedString = string.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) {
+            self.init(string: encodedString)
+        } else {
+            return nil
+        }
+    }
 	/// SwifterSwift: URL with appending query parameters.
 	///
 	///		let url = URL(string: "https://google.com")!

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -15,6 +15,16 @@ final class URLExtensionsTests: XCTestCase {
 	let params = ["q": "swifter swift"]
 	let queryUrl = URL(string: "https://www.google.com?q=swifter%20swift")!
 
+    func testInitWithPercentEncoding() {
+        let urlWithUnicode = "http://www.prothomalo.com/bangladesh/article/1472031/নারায়ণগঞ্জে-গ্যাসবোমার-ওপর-বসবাস-তাঁদের"
+        let percentEncodedURL = "http://www.prothomalo.com/bangladesh/article/1472031/%E0%A6%A8%E0%A6%BE%E0%A6%B0%E0%A6%BE%E0%A6%AF%E0%A6%BC%E0%A6%A3%E0%A6%97%E0%A6%9E%E0%A7%8D%E0%A6%9C%E0%A7%87-%E0%A6%97%E0%A7%8D%E0%A6%AF%E0%A6%BE%E0%A6%B8%E0%A6%AC%E0%A7%8B%E0%A6%AE%E0%A6%BE%E0%A6%B0-%E0%A6%93%E0%A6%AA%E0%A6%B0-%E0%A6%AC%E0%A6%B8%E0%A6%AC%E0%A6%BE%E0%A6%B8-%E0%A6%A4%E0%A6%BE%E0%A6%81%E0%A6%A6%E0%A7%87%E0%A6%B0"
+
+        XCTAssertNil(URL.init(string: urlWithUnicode))
+        XCTAssertNotNil(URL.init(withPercentEncodingOfString: urlWithUnicode))
+        XCTAssertEqual(URL.init(withPercentEncodingOfString: urlWithUnicode)?.absoluteString, percentEncodedURL)
+
+    }
+
 	func testAppendingQueryParameters() {
 		XCTAssertEqual(url.appendingQueryParameters(params), queryUrl)
 	}


### PR DESCRIPTION
…ent encoding.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

While creating a `URL` from string containing Unicode or whitespace character, it requires to apply a percent encoding before creating the `URL` object as follows 


```swift
let encodedString = string.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)
var url : URL? = nil
if let encodedString = encodedString {
    url = URL.init(string: encodedString)
}
```

`init?(withPercentEncodingOfString string: String)` is added to cover everything, just like other `URL.init...` methods.