### PR TITLE
Fix Comparable extensions to used `ClosedRange` vs `min/max`.

### DIFF
--- a/Sources/Extensions/SwiftStdlib/ComparableExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ComparableExtensions.swift
@@ -8,36 +8,34 @@
 
 // MARK: - Methods
 public extension Comparable {
-    /// SwifterSwift: Returns true if value is between provided `min`
-    /// and `max`.
+    /// SwifterSwift: Returns true if value is in the provided range.
     ///
-    ///    1.isBetween(min: 5, max: 7) // false
-    ///    7.isBetween(min: 6, max: 12) // true
-    ///    date.isBetween(min: date1, max: date2)
-    ///    "c".isBetween(min: "a", max: "d") // true
-    ///    0.32.isBetween(min: 0.31, max: 0.33) // true
+    ///    1.isBetween(5...7) // false
+    ///    7.isBetween(6...12) // true
+    ///    date.isBetween(date1...date2)
+    ///    "c".isBetween(a...d) // true
+    ///    0.32.isBetween(0.31...0.33) // true
     ///
     /// - parameter min: Minimum comparable value.
     /// - parameter max: Maximum comparable value.
     ///
     /// - returns: `true` if value is between `min` and `max`, `false` otherwise.
-    public func isBetween(min: Self, max: Self) -> Bool {
-        return self >= min && self <= max
+    public func isBetween(_ range: ClosedRange<Self>) -> Bool {
+        return range ~= self
     }
 
-    /// SwifterSwift: Returns value limited within the provided range
-    /// between `min` and `max`.
+    /// SwifterSwift: Returns value limited within the provided range.
     ///
-    ///     1.clamped(min: 3, max: 8) // 3
-    ///     4.clamped(min: 3, max: 7) // 4
-    ///     "c".clamped(min: "e", max: "g") // "e"
-    ///     0.32.clamped(min: 0.1, max: 0.29) // 0.29
+    ///     1.clamped(to: 3...8) // 3
+    ///     4.clamped(to: 3...7) // 4
+    ///     "c".clamped(to: "e"..."g") // "e"
+    ///     0.32.clamped(to: 0.1...0.29) // 0.29
     ///
     /// - parameter min: Lower bound to limit the value to.
     /// - parameter max: Upper bound to limit the value to.
     ///
     /// - returns: A value limited to the range between `min` and `max`.
-    public func clamped(min minNum: Self, max maxNum: Self) -> Self {
-        return max(minNum, min(self, maxNum))
+    public func clamped(to range: ClosedRange<Self>) -> Self {
+        return max(range.lowerBound, min(self, range.upperBound))
     }
 }

--- a/Tests/SwiftStdlibTests/ComparableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ComparableExtensionsTests.swift
@@ -13,19 +13,19 @@ import XCTest
 final class ComparableExtensionsTests: XCTestCase {
 
     func testIsBetween() {
-        XCTAssertFalse(1.isBetween(min: 5, max: 7), "number range")
-        XCTAssertTrue(7.isBetween(min: 6, max: 12), "number range")
-        XCTAssertTrue(0.32.isBetween(min: 0.31, max: 0.33), "float range")
-        XCTAssertTrue("c".isBetween(min: "a", max: "d"), "string range")
+        XCTAssertFalse(1.isBetween(5...7), "number range")
+        XCTAssertTrue(7.isBetween(6...12), "number range")
+        XCTAssertTrue(0.32.isBetween(0.31...0.33), "float range")
+        XCTAssertTrue("c".isBetween("a"..."d"), "string range")
 
         let date = Date()
-        XCTAssertTrue(date.isBetween(min: date, max: date.addingTimeInterval(1000)), "date range")
+        XCTAssertTrue(date.isBetween(date...date.addingTimeInterval(1000)), "date range")
     }
 
     func testClamped() {
-        XCTAssertEqual(1.clamped(min: 3, max: 8), 3)
-        XCTAssertEqual(4.clamped(min: 3, max: 7), 4)
-        XCTAssertEqual("c".clamped(min: "e", max: "g"), "e")
-        XCTAssertEqual(0.32.clamped(min: 0.37, max: 0.42), 0.37)
+        XCTAssertEqual(1.clamped(to: 3...8), 3)
+        XCTAssertEqual(4.clamped(to: 3...7), 4)
+        XCTAssertEqual("c".clamped(to: "e"..."g"), "e")
+        XCTAssertEqual(0.32.clamped(to: 0.37...0.42), 0.37)
     }
 }


### PR DESCRIPTION
Fixes concerns raised in #466. 

Didn’t add a CHANGELOG since its a recent addition but LMK if its needed.