### PR TITLE
Removing Dictionary specialised version of count(where:)

### DIFF
--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -76,20 +76,6 @@ public extension Dictionary {
         return String(data: jsonData, encoding: .utf8)
     }
 
-    /// SwifterSwift: Count dictionary entries that where function returns true.
-    ///
-    /// - Parameter where: condition to evaluate each tuple entry against.
-    /// - Returns: Count of entries that matches the where clousure.
-    public func count(where condition: @escaping ((key: Key, value: Value)) throws -> Bool) rethrows -> Int {
-        var count: Int = 0
-        try self.forEach {
-            if try condition($0) {
-                count += 1
-            }
-        }
-        return count
-    }
-
 }
 
 // MARK: - Methods (ExpressibleByStringLiteral)

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -53,14 +53,6 @@ final class DictionaryExtensionsTests: XCTestCase {
         XCTAssertNil([1: 2].jsonString())
     }
 
-    func testCountWhere() {
-        let dict: [String: String] = ["key1": "value", "key2": "value", "key3": "value3"]
-        let count = dict.count { (tuple) -> Bool in
-            return tuple.0 == "key1" || tuple.1 == "value"
-        }
-        XCTAssertEqual(count, 2)
-    }
-
     func testLowercaseAllKeys() {
         var dict = ["tEstKeY": "value"]
         dict.lowercaseAllKeys()


### PR DESCRIPTION
Since now we made count(where:) of Array generic to a Sequence extension and [Dictionary](https://developer.apple.com/documentation/swift/dictionary) conforms to sequence, I think this specialized version is not needed anymore. 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
