### PR TITLE
Just making removeAllkeys more generic 

### DIFF
--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -30,8 +30,8 @@ public extension Dictionary {
     ///		dict.keys.contains("key2") -> false
     ///
     /// - Parameter keys: keys to be removed
-    public mutating func removeAll(keys: [Key]) {
-        keys.forEach({ removeValue(forKey: $0)})
+    mutating func removeAll<S: Sequence>(keys: S) where S.Element == Key {
+        Set<Key>(keys).forEach({ removeValue(forKey: $0) })
     }
 
     /// SwifterSwift: JSON Data from dictionary.
@@ -79,7 +79,7 @@ public extension Dictionary {
 }
 
 // MARK: - Methods (ExpressibleByStringLiteral)
-public extension Dictionary where Key: ExpressibleByStringLiteral {
+public extension Dictionary where Key: StringProtocol {
 
     /// SwifterSwift: Lowercase all keys in dictionary.
     ///
@@ -148,7 +148,7 @@ public extension Dictionary {
     ///   - lhs: dictionary
     ///   - rhs: array with the keys to be removed.
     /// - Returns: a new dictionary with keys removed.
-    public static func - (lhs: [Key: Value], keys: [Key]) -> [Key: Value] {
+    public static func - <S: Sequence>(lhs: [Key: Value], keys: S) -> [Key: Value] where S.Element == Key {
         var result = lhs
         result.removeAll(keys: keys)
         return result
@@ -165,7 +165,7 @@ public extension Dictionary {
     /// - Parameters:
     ///   - lhs: dictionary
     ///   - rhs: array with the keys to be removed.
-    public static func -= (lhs: inout [Key: Value], keys: [Key]) {
+    public static func -= <S: Sequence>(lhs: inout [Key: Value], keys: S) where S.Element == Key {
         lhs.removeAll(keys: keys)
     }
 

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -30,7 +30,7 @@ public extension Dictionary {
     ///		dict.keys.contains("key2") -> false
     ///
     /// - Parameter keys: keys to be removed
-    mutating func removeAll<S: Sequence>(keys: S) where S.Element == Key {
+    public mutating func removeAll<S: Sequence>(keys: S) where S.Element == Key {
         Set<Key>(keys).forEach({ removeValue(forKey: $0) })
     }
 


### PR DESCRIPTION
Just making removeAllkeys more generic so we can pass any sequence.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
