### PR TITLE
Add `single(where)` SequenceExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 - **Sequence**
   - added `containsDuplicates()` to check whether a sequence contains duplicates. [#496](https://github.com/SwifterSwift/SwifterSwift/pull/496) by [@vyax](https://github.com/vyax).
+  - Added `single(where:)` to get the only element of a sequence that matches a given condition. [#483](https://github.com/SwifterSwift/SwifterSwift/pull/483) by [andlang](https://github.com/andlang).
 
 ### Changed
 - **UITableView**:

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -135,19 +135,37 @@ public extension Sequence {
         })
     }
 
-    /// SwifterSwift: Get the only element based on optional condition.
+    /// SwifterSwift: Get the only element.
     ///
     ///     [].single() -> nil
     ///     [4].single() -> 4
     ///     [2, 4].single() -> nil
+    ///
+    /// - Returns: The only element in the array. If there are more elements, nil is returned. (optional)
+    public func single() -> Element? {
+        var singleElement: Element?
+        for element in self {
+            guard singleElement == nil else {
+                singleElement = nil
+                break
+            }
+            singleElement = element
+        }
+        return singleElement
+    }
+
+    /// SwifterSwift: Get the only element based on a condition.
+    ///
+    ///     [].single(where: {_ in true}) -> nil
+    ///     [4].single(where: {_ in true}) -> 4
     ///     [1, 4, 7].single(where: {$0 % 2 == 0}) -> 4
     ///     [2, 2, 4, 7].single(where: {$0 % 2 == 0}) -> nil
     ///
-    /// - Parameter condition: condition to evaluate each element against (default is `{_ in true}`).
+    /// - Parameter condition: condition to evaluate each element against.
     /// - Returns: The only element in the array matching the specified condition. If there are more matching elements, nil is returned. (optional)
-    public func single(where condition: ((Element) throws -> Bool) = { _ in true }) -> Element? {
+    public func single(where condition: ((Element) throws -> Bool)) rethrows -> Element? {
         var singleElement: Element?
-        for element in self where (try? condition(element)) ?? false {
+        for element in self where try condition(element) {
             guard singleElement == nil else {
                 singleElement = nil
                 break

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -135,25 +135,6 @@ public extension Sequence {
         })
     }
 
-    /// SwifterSwift: Get the only element.
-    ///
-    ///     [].single() -> nil
-    ///     [4].single() -> 4
-    ///     [2, 4].single() -> nil
-    ///
-    /// - Returns: The only element in the array. If there are more elements, nil is returned. (optional)
-    public func single() -> Element? {
-        var singleElement: Element?
-        for element in self {
-            guard singleElement == nil else {
-                singleElement = nil
-                break
-            }
-            singleElement = element
-        }
-        return singleElement
-    }
-
     /// SwifterSwift: Get the only element based on a condition.
     ///
     ///     [].single(where: {_ in true}) -> nil

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -137,6 +137,7 @@ public extension Sequence {
 
     /// SwifterSwift: Get the only element based on optional condition.
     ///
+    ///     [].single() -> nil
     ///     [4].single() -> 4
     ///     [2, 4].single() -> nil
     ///     [1, 4, 7].single(where: {$0 % 2 == 0}) -> 4
@@ -145,11 +146,15 @@ public extension Sequence {
     /// - Parameter condition: condition to evaluate each element against (default is `{_ in true}`).
     /// - Returns: The only element in the array matching the specified condition. If there are more matching elements, nil is returned. (optional)
     public func single(where condition: ((Element) throws -> Bool) = { _ in true }) -> Element? {
-        if let filtered = try? filter(condition),
-            filtered.count == 1 {
-            return filtered.first
+        var singleElement: Element?
+        for element in self where (try? condition(element)) ?? false {
+            guard singleElement == nil else {
+                singleElement = nil
+                break
+            }
+            singleElement = element
         }
-        return nil
+        return singleElement
     }
 }
 

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -135,6 +135,22 @@ public extension Sequence {
         })
     }
 
+    /// SwifterSwift: Get the only element based on optional condition.
+    ///
+    ///     [4].single() -> 4
+    ///     [2, 4].single() -> nil
+    ///     [1, 4, 7].single(where: {$0 % 2 == 0}) -> 4
+    ///     [2, 2, 4, 7].single(where: {$0 % 2 == 0}) -> nil
+    ///
+    /// - Parameter condition: condition to evaluate each element against (default is `{_ in true}`).
+    /// - Returns: The only element in the array matching the specified condition. If there are more matching elements, nil is returned. (optional)
+    public func single(where condition: ((Element) throws -> Bool) = { _ in true }) -> Element? {
+        if let filtered = try? filter(condition),
+            filtered.count == 1 {
+            return filtered.first
+        }
+        return nil
+    }
 }
 
 public extension Sequence where Element: Equatable {

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -72,6 +72,13 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(["2", "4"], result)
     }
 
+    func testSingle() {
+        XCTAssertEqual([4].single(), 4)
+        XCTAssertNil([2, 4].single())
+        XCTAssertEqual([1, 4, 7].single(where: {$0 % 2 == 0}), 4)
+        XCTAssertNil([2, 2, 4, 7].single(where: {$0 % 2 == 0}))
+    }
+
     func testContains() {
         XCTAssert([Int]().contains([]))
         XCTAssertFalse([Int]().contains([1, 2]))

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -77,12 +77,6 @@ final class SequenceExtensionsTests: XCTestCase {
     }
 
     func testSingle() {
-        XCTAssertNil([].single())
-        XCTAssertEqual([4].single(), 4)
-        XCTAssertNil([2, 4].single())
-    }
-
-    func testSingleWhere() {
         XCTAssertNil([].single(where: { _ in true }))
         XCTAssertEqual([4].single(where: { _ in true }), 4)
         XCTAssertNil([2, 4].single(where: { _ in true }))

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -9,6 +9,10 @@
 import XCTest
 @testable import SwifterSwift
 
+private enum SequenceTestError: Error {
+    case closureThrows
+}
+
 final class SequenceExtensionsTests: XCTestCase {
 
     func testAllMatch() {
@@ -76,9 +80,15 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertNil([].single())
         XCTAssertEqual([4].single(), 4)
         XCTAssertNil([2, 4].single())
-        XCTAssertEqual([1, 4, 7].single(where: {$0 % 2 == 0}), 4)
-        XCTAssertNil([2, 2, 4, 7].single(where: {$0 % 2 == 0}))
-        XCTAssertNil([2].single(where: { _ in throw NSError() }))
+    }
+
+    func testSingleWhere() {
+        XCTAssertNil([].single(where: { _ in true }))
+        XCTAssertEqual([4].single(where: { _ in true }), 4)
+        XCTAssertNil([2, 4].single(where: { _ in true }))
+        XCTAssertEqual([1, 4, 7].single(where: { $0 % 2 == 0 }), 4)
+        XCTAssertNil([2, 2, 4, 7].single(where: { $0 % 2 == 0 }))
+        XCTAssertThrowsError(try [2].single(where: { _ in throw SequenceTestError.closureThrows }))
     }
 
     func testContains() {

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -73,10 +73,12 @@ final class SequenceExtensionsTests: XCTestCase {
     }
 
     func testSingle() {
+        XCTAssertNil([].single())
         XCTAssertEqual([4].single(), 4)
         XCTAssertNil([2, 4].single())
         XCTAssertEqual([1, 4, 7].single(where: {$0 % 2 == 0}), 4)
         XCTAssertNil([2, 2, 4, 7].single(where: {$0 % 2 == 0}))
+        XCTAssertNil([2].single(where: { _ in throw NSError() }))
     }
 
     func testContains() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
