### PR TITLE
Add method for first char uppercased in String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Character**:
   - Added `randomAlphanumeric()` method to generate a random alphanumeric Character. [#462](https://github.com/SwifterSwift/SwifterSwift/pull/462) by [oliviabrown9](https://github.com/oliviabrown9)
 - **String**:
-  - Added `firstCharacterUppercased()` method to return a string with only the first character uppercased. [#504](https://github.com/SwifterSwift/SwifterSwift/pull/504) by [happiehappie](https://github.com/happiehappie)
+  - Added `firstCharacterUppercased()` method to return a string with only the first character uppercased. [#505](https://github.com/SwifterSwift/SwifterSwift/pull/505) by [happiehappie](https://github.com/happiehappie)
 - **UITextView**:
   - Added `wrapToContent()` method which will remove insets, offsets, paddings which lies within UITextView's `bounds` and `contenSize`. [#458](https://github.com/SwifterSwift/SwifterSwift/pull/458) by [ratulSharker](https://github.com/ratulSharker)
 - **URL**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeFromView()` method to remove recognizer from the view the recognizer is attached to. [#456](https://github.com/SwifterSwift/SwifterSwift/pull/456) by [mmdock](https://github.com/mmdock)
 - **Character**:
   - Added `randomAlphanumeric()` method to generate a random alphanumeric Character. [#462](https://github.com/SwifterSwift/SwifterSwift/pull/462) by [oliviabrown9](https://github.com/oliviabrown9)
+- **String**:
+  - Added `firstCharacterUppercased()` method to return a string with only the first character uppercased. [#504](https://github.com/SwifterSwift/SwifterSwift/pull/504) by [happiehappie](https://github.com/happiehappie)
 - **UITextView**:
   - Added `wrapToContent()` method which will remove insets, offsets, paddings which lies within UITextView's `bounds` and `contenSize`. [#458](https://github.com/SwifterSwift/SwifterSwift/pull/458) by [ratulSharker](https://github.com/ratulSharker)
 - **URL**

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -104,6 +104,7 @@ public extension String {
 		guard let first = self.first else { return nil }
 		return String(first)
 	}
+    
     /// SwifterSwift: First character of string uppercased(if applicable) while keeping the original string.
     ///
     ///        "hello world".firstCharacterUppercased -> Optional("Hello world")

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -104,18 +104,18 @@ public extension String {
 		guard let first = self.first else { return nil }
 		return String(first)
 	}
-    
+
     /// SwifterSwift: First character of string uppercased(if applicable) while keeping the original string.
     ///
     ///        "hello world".firstCharacterUppercased -> Optional("Hello world")
     ///        "".firstCharacterUppercased -> nil
     ///
-    public var firstCharacterUppercased: String? {
-        guard let first = first else { return nil }
+    public var firstCharacterUppercased: String {
+        guard let first = first else { return "" }
         return String(first).uppercased() + dropFirst()
     }
-    
-	#if canImport(Foundation)
+
+    #if canImport(Foundation)
 	/// SwifterSwift: Check if string contains one or more letters.
 	///
 	///		"123abc".hasLetters -> true

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -104,7 +104,12 @@ public extension String {
 		guard let first = self.first else { return nil }
 		return String(first)
 	}
-
+    
+    public var firstCharacterUppercased: String? {
+        guard let first = first else { return nil }
+        return String(first).uppercased() + dropFirst()
+    }
+    
 	#if canImport(Foundation)
 	/// SwifterSwift: Check if string contains one or more letters.
 	///

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -104,7 +104,11 @@ public extension String {
 		guard let first = self.first else { return nil }
 		return String(first)
 	}
-    
+    /// SwifterSwift: First character of string uppercased(if applicable) while keeping the original string.
+    ///
+    ///        "hello world".firstCharacterUppercased -> Optional("Hello world")
+    ///        "".firstCharacterUppercased -> nil
+    ///
     public var firstCharacterUppercased: String? {
         guard let first = first else { return nil }
         return String(first).uppercased() + dropFirst()

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -111,7 +111,7 @@ public extension String {
     ///        "".firstCharacterUppercased -> ""
     ///
     public var firstCharacterUppercased: String {
-        guard let first = first else { return "" }
+        guard let first = first else { return self }
         return String(first).uppercased() + dropFirst()
     }
 

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -107,8 +107,8 @@ public extension String {
 
     /// SwifterSwift: First character of string uppercased(if applicable) while keeping the original string.
     ///
-    ///        "hello world".firstCharacterUppercased -> Optional("Hello world")
-    ///        "".firstCharacterUppercased -> nil
+    ///        "hello world".firstCharacterUppercased -> "Hello world"
+    ///        "".firstCharacterUppercased -> ""
     ///
     public var firstCharacterUppercased: String {
         guard let first = first else { return "" }

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -105,16 +105,6 @@ public extension String {
 		return String(first)
 	}
 
-    /// SwifterSwift: First character of string uppercased(if applicable) while keeping the original string.
-    ///
-    ///        "hello world".firstCharacterUppercased -> "Hello world"
-    ///        "".firstCharacterUppercased -> ""
-    ///
-    public var firstCharacterUppercased: String {
-        guard let first = first else { return self }
-        return String(first).uppercased() + dropFirst()
-    }
-
     #if canImport(Foundation)
 	/// SwifterSwift: Check if string contains one or more letters.
 	///
@@ -644,6 +634,16 @@ public extension String {
 
 		self = first + rest
 	}
+
+    /// SwifterSwift: First character of string uppercased(if applicable) while keeping the original string.
+    ///
+    ///        "hello world".firstCharacterUppercased() -> "Hello world"
+    ///        "".firstCharacterUppercased() -> ""
+    ///
+    public mutating func firstCharacterUppercased() {
+        guard let first = first else { return }
+        self = String(first).uppercased() + dropFirst()
+    }
 
 	/// SwifterSwift: Check if string contains only unique characters.
 	///

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -50,11 +50,6 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Hello".firstCharacterAsString, "H")
     }
 
-    func testFirstCharacterUppercased() {
-        XCTAssertEqual("".firstCharacterUppercased, "")
-        XCTAssertEqual("hello world".firstCharacterUppercased, "Hello world")
-    }
-
     func testHasLetters() {
         XCTAssert("hsj 1 wq3".hasLetters)
         XCTAssertFalse("123".hasLetters)
@@ -326,6 +321,21 @@ final class StringExtensionsTests: XCTestCase {
         str = "helloWorld"
         str.camelize()
         XCTAssertEqual(str, "helloworld")
+    }
+
+    func testFirstCharacterUppercased() {
+        var str = "hello test"
+        str.firstCharacterUppercased()
+        XCTAssertEqual(str, "Hello test")
+
+        str = "helloworld"
+        str.firstCharacterUppercased()
+        XCTAssertEqual(str, "Helloworld")
+
+        str = ""
+        str.firstCharacterUppercased()
+        XCTAssertEqual(str, "")
+
     }
 
     func testHasUniqueCharacters() {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -51,7 +51,7 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testFirstCharacterUppercased() {
-        XCTAssertNotNil("hello world".firstCharacterUppercased)
+        XCTAssertNotNil("".firstCharacterUppercased)
         XCTAssertEqual("hello world".firstCharacterUppercased, "Hello world")
     }
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -49,6 +49,12 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("Hello".firstCharacterAsString)
         XCTAssertEqual("Hello".firstCharacterAsString, "H")
     }
+    
+    func testFirstCharacterUppercased() {
+        XCTAssertNil("".firstCharacterUppercased)
+        XCTAssertNotNil("hello world".firstCharacterUppercased)
+        XCTAssertEqual("hello world".firstCharacterUppercased, "Hello world")
+    }
 
     func testHasLetters() {
         XCTAssert("hsj 1 wq3".hasLetters)

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -51,7 +51,7 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testFirstCharacterUppercased() {
-        XCTAssertNotNil("".firstCharacterUppercased)
+        XCTAssertEqual("".firstCharacterUppercased, "")
         XCTAssertEqual("hello world".firstCharacterUppercased, "Hello world")
     }
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -49,9 +49,8 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("Hello".firstCharacterAsString)
         XCTAssertEqual("Hello".firstCharacterAsString, "H")
     }
-    
+
     func testFirstCharacterUppercased() {
-        XCTAssertNil("".firstCharacterUppercased)
         XCTAssertNotNil("hello world".firstCharacterUppercased)
         XCTAssertEqual("hello world".firstCharacterUppercased, "Hello world")
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ☑︎ I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- ☑︎ New extensions are written in Swift 4.
- ☑︎ New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- ☑︎ I have added tests for new extensions, and they passed.
- ☑︎ All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- ☑︎ All extensions are declared as **public**.
- ☑︎ I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
