### PR TITLE
 UIViewControllerExtensions simplify page jump

### DIFF
--- a/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -77,7 +77,38 @@ public extension UIViewController {
         present(alertController, animated: true, completion: nil)
         return alertController
     }
-
+    /// SwifterSwift: Replace the "navigationController?.pushViewController" method
+    public func push(_ viewController: UIViewController, animated: Bool = true) {
+        navigationController?.pushViewController(viewController, animated: animated)
+    }
+    /// SwifterSwift: Replace the "navigationController?.popViewController" method
+    @discardableResult public func pop(animated: Bool = true) -> UIViewController? {
+        return navigationController?.popViewController(animated: animated)
+    }
+    /// SwifterSwift: Replace the "navigationController?.popToRootViewController" method
+    @discardableResult public func popToRoot(animated: Bool = true) -> [UIViewController]? {
+        return navigationController?.popToRootViewController(animated: animated)
+    }
+    /// SwifterSwift: Replace the "navigationController?.popToViewController" method
+    @discardableResult public func popToViewController(_ viewController: UIViewController, animated: Bool = true) -> [UIViewController]? {
+        return navigationController?.popToViewController(viewController, animated: animated)
+    }
+    /// SwifterSwift: Replace the "present" method
+    public func present(_ viewControllerToPresent: UIViewController, _ completion: (() -> Swift.Void)? = nil) {
+        present(viewControllerToPresent, animated: true, completion: completion)
+    }
+    /// SwifterSwift: Replace the "present" method
+    public func present(_ viewControllerToPresent: UIViewController, animated: Bool) {
+        present(viewControllerToPresent, animated: animated, completion: nil)
+    }
+    /// SwifterSwift: Replace the "dismiss" method
+    public func dismiss(_ completion: (() -> Swift.Void)? = nil) {
+        dismiss(animated: true, completion: completion)
+    }
+    /// SwifterSwift: Replace the "dismiss" method
+    public func dismiss(animated: Bool) {
+        dismiss(animated: animated, completion: nil)
+    }
 }
 #endif
 

--- a/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -77,35 +77,65 @@ public extension UIViewController {
         present(alertController, animated: true, completion: nil)
         return alertController
     }
-    /// SwifterSwift: Replace the "navigationController?.pushViewController" method
+    /// SwifterSwift: Replace the "navigationController?.pushViewController" method.
+    ///
+    /// - Parameters:
+    ///   - viewController: viewController.
+    ///   - animated: (Optional)The default value of “true”.
     public func push(_ viewController: UIViewController, animated: Bool = true) {
         navigationController?.pushViewController(viewController, animated: animated)
     }
-    /// SwifterSwift: Replace the "navigationController?.popViewController" method
+    /// SwifterSwift: Replace the "navigationController?.popViewController" method.
+    ///
+    /// - Parameters:
+    ///   - animated: (Optional)The default value of “true”.
     @discardableResult public func pop(animated: Bool = true) -> UIViewController? {
         return navigationController?.popViewController(animated: animated)
     }
-    /// SwifterSwift: Replace the "navigationController?.popToRootViewController" method
+    /// SwifterSwift: Replace the "navigationController?.popToRootViewController" method.
+    ///
+    /// - Parameters:
+    ///   - animated: (Optional)The default value of “true”.
+    /// - Returns: [UIViewController]? (discardable).
     @discardableResult public func popToRoot(animated: Bool = true) -> [UIViewController]? {
         return navigationController?.popToRootViewController(animated: animated)
     }
-    /// SwifterSwift: Replace the "navigationController?.popToViewController" method
+    /// SwifterSwift: Replace the "navigationController?.popToViewController" method.
+    ///
+    /// - Parameters:
+    ///   - viewController: viewController.
+    ///   - animated: (Optional)The default value of “true”.
+    /// - Returns: [UIViewController]? (discardable).
     @discardableResult public func popToViewController(_ viewController: UIViewController, animated: Bool = true) -> [UIViewController]? {
         return navigationController?.popToViewController(viewController, animated: animated)
     }
-    /// SwifterSwift: Replace the "present" method
+    /// SwifterSwift: Replace the "present" method.
+    ///
+    /// - Parameters:
+    ///   - viewControllerToPresent: viewControllerToPresent.
+    ///   - completion: (Optional)The default value of “nil”.
     public func present(_ viewControllerToPresent: UIViewController, _ completion: (() -> Swift.Void)? = nil) {
         present(viewControllerToPresent, animated: true, completion: completion)
     }
-    /// SwifterSwift: Replace the "present" method
+    /// SwifterSwift: Replace the "present" method.
+    ///
+    /// - Parameters:
+    ///   - viewControllerToPresent: viewControllerToPresent.
+    ///   - animated: animated.
     public func present(_ viewControllerToPresent: UIViewController, animated: Bool) {
         present(viewControllerToPresent, animated: animated, completion: nil)
     }
-    /// SwifterSwift: Replace the "dismiss" method
+    /// SwifterSwift: Replace the "dismiss" method.
+    ///
+    /// - Parameters:
+    ///   - completion: (Optional)The default value of “nil”.
     public func dismiss(_ completion: (() -> Swift.Void)? = nil) {
         dismiss(animated: true, completion: completion)
     }
-    /// SwifterSwift: Replace the "dismiss" method
+    /// SwifterSwift: Replace the "dismiss" method.
+    ///
+    /// - Parameters:
+    ///   - animated: animated.
     public func dismiss(animated: Bool) {
         dismiss(animated: animated, completion: nil)
     }

--- a/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
@@ -78,5 +78,45 @@ final class UIViewControllerExtensionsTests: XCTestCase {
 		XCTAssertEqual(alertController.preferredAction, alertController.actions[preferredButtonIndex])
 	}
 
+    func testPush() {
+        let rootViewControoler = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewControoler)
+        UIApplication.shared.keyWindow?.rootViewController = navigationController
+        let viewController = UIViewController()
+        XCTAssertNoThrow(rootViewControoler.push(viewController))
+        XCTAssertNoThrow(rootViewControoler.push(viewController, animated: true))
+    }
+
+    func testPop() {
+        let rootViewControoler = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewControoler)
+        UIApplication.shared.keyWindow?.rootViewController = navigationController
+        let viewController = UIViewController()
+        XCTAssertNoThrow(viewController.pop())
+        XCTAssertNoThrow(viewController.pop(animated: true))
+    }
+
+    func testPopToViewController() {
+        let rootViewControoler = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewControoler)
+        UIApplication.shared.keyWindow?.rootViewController = navigationController
+        let viewController = UIViewController()
+        XCTAssertNoThrow(viewController.popToViewController(rootViewControoler))
+        XCTAssertNoThrow(viewController.popToViewController(rootViewControoler, animated: true))
+    }
+
+    func testPresent() {
+        let viewControoler = UIViewController()
+        XCTAssertNoThrow(viewControoler.present(UIViewController()))
+        XCTAssertNoThrow(viewControoler.present(UIViewController()) { })
+        XCTAssertNoThrow(viewControoler.present(UIViewController(), animated: true))
+    }
+
+    func testDismiss() {
+        let viewControoler = UIViewController()
+        XCTAssertNoThrow(viewControoler.dismiss())
+        XCTAssertNoThrow(viewControoler.dismiss(animated: true))
+        XCTAssertNoThrow(viewControoler.dismiss({ }))
+    }
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
