### PR TITLE
Changing rotate/rotated Array extensions to RangeReplacebleCollection extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 > # Upcoming release
 >
 > ### Added
-> ### Changed
+### Changed
+- **RangeReplaceableCollection**:
+  - `rotate(by:)` and `rotated(by:)` array extensions now are more generic `RangeReplaceableCollection` extensions. [#512](https://github.com/SwifterSwift/SwifterSwift/pull/512) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).z
 > ### Deprecated
 > ### Removed
 > ### Fixed

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -96,46 +96,6 @@ public extension Array {
 		return (matching, nonMatching)
 	}
 
-	/// SwifterSwift: Returns a new rotated array by the given places.
-	///
-	///     [1, 2, 3, 4].rotated(by: 1) -> [4,1,2,3]
-	///     [1, 2, 3, 4].rotated(by: 3) -> [2,3,4,1]
-	///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
-	///
-	/// - Parameter places: Number of places that the array be rotated. If the value is positive the end becomes the start, if it negative it's that start becom the end.
-	/// - Returns: The new rotated array
-	public func rotated(by places: Int) -> [Element] {
-		//Inspired by: https://ruby-doc.org/core-2.2.0/Array.html#method-i-rotate
-		guard places != 0 && places < count else { return self }
-		var array: [Element] = self
-		if places > 0 {
-			let range = (array.count - places)..<array.endIndex
-			let slice = array[range]
-			array.removeSubrange(range)
-			array.insert(contentsOf: slice, at: 0)
-		} else {
-			let range = array.startIndex..<(places * -1)
-			let slice = array[range]
-			array.removeSubrange(range)
-			array.append(contentsOf: slice)
-		}
-		return array
-	}
-
-	/// SwifterSwift: Rotate the array by the given places.
-	///
-	///     [1, 2, 3, 4].rotate(by: 1) -> [4,1,2,3]
-	///     [1, 2, 3, 4].rotate(by: 3) -> [2,3,4,1]
-	///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
-	///
-	/// - Parameter places: The number of places that the array should be rotated. If the value is positive the end becomes the start, if it negative it's that start become the end.
-	/// - Returns: self after rotating.
-	@discardableResult
-	public mutating func rotate(by places: Int) -> [Element] {
-		self = rotated(by: places)
-		return self
-	}
-
 	/// SwifterSwift: Shuffle array. (Using Fisher-Yates Algorithm)
 	///
 	///		[1, 2, 3, 4, 5].shuffle() // shuffles array

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -9,21 +9,21 @@
 // MARK: - Methods
 extension RangeReplaceableCollection {
 
-    /// SwifterSwift: Returns a new rotated array by the given places.
+    /// SwifterSwift: Returns a new rotated collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotated(by: 1) -> [4,1,2,3]
     ///     [1, 2, 3, 4].rotated(by: 3) -> [2,3,4,1]
     ///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
     ///
-    /// - Parameter places: Number of places that the array be rotated. If the value is positive the end becomes the start, if it negative it's that start becom the end.
-    /// - Returns: The new rotated array
+    /// - Parameter places: Number of places that the array be rotated. If the value is positive the end becomes the start, if it negative it's that start becom the end.
+    /// - Returns: The new rotated collection.
     public func rotated(by places: Int) -> Self {
         //Inspired by: https://ruby-doc.org/core-2.2.0/Array.html#method-i-rotate
         var copy = self
         return copy.rotate(by: places)
     }
 
-    /// SwifterSwift: Rotate the array by the given places.
+    /// SwifterSwift: Rotate the collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotate(by: 1) -> [4,1,2,3]
     ///     [1, 2, 3, 4].rotate(by: 3) -> [2,3,4,1]

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -36,7 +36,7 @@ extension RangeReplaceableCollection {
         guard places != 0 else { return self }
         let placesToMove = abs(places) >= count ? places%count : places
         if placesToMove > 0 {
-            let range = index(endIndex, offsetBy: -placeToMove)...
+            let range = index(endIndex, offsetBy: -placesToMove)...
             let slice = self[range]
             removeSubrange(range)
             insert(contentsOf: slice, at: startIndex)

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -33,14 +33,15 @@ extension RangeReplaceableCollection {
     /// - Returns: self after rotating.
     @discardableResult
     public mutating func rotate(by places: Int) -> Self {
-        guard places != 0 && abs(places) < count else { return self }
-        if places > 0 {
-            let range = index(endIndex, offsetBy: -places)...
+        guard places != 0 else { return self }
+        let placeToMove = abs(places) >= count ? places%count : places
+        if placeToMove > 0 {
+            let range = index(endIndex, offsetBy: -placeToMove)...
             let slice = self[range]
             removeSubrange(range)
             insert(contentsOf: slice, at: startIndex)
         } else {
-            let range = startIndex..<index(startIndex, offsetBy: -places)
+            let range = startIndex..<index(startIndex, offsetBy: -placeToMove)
             let slice = self[range]
             removeSubrange(range)
             append(contentsOf: slice)

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -1,0 +1,50 @@
+//
+//  RangeReplaceableCollectionExtensions.swift
+//  SwifterSwift
+//
+//  Created by Luciano Almeida on 7/2/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+// MARK: - Methods
+extension RangeReplaceableCollection {
+
+    /// SwifterSwift: Returns a new rotated array by the given places.
+    ///
+    ///     [1, 2, 3, 4].rotated(by: 1) -> [4,1,2,3]
+    ///     [1, 2, 3, 4].rotated(by: 3) -> [2,3,4,1]
+    ///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
+    ///
+    /// - Parameter places: Number of places that the array be rotated. If the value is positive the end becomes the start, if it negative it's that start becom the end.
+    /// - Returns: The new rotated array
+    public func rotated(by places: Int) -> Self {
+        //Inspired by: https://ruby-doc.org/core-2.2.0/Array.html#method-i-rotate
+        var copy = self
+        return copy.rotate(by: places)
+    }
+
+    /// SwifterSwift: Rotate the array by the given places.
+    ///
+    ///     [1, 2, 3, 4].rotate(by: 1) -> [4,1,2,3]
+    ///     [1, 2, 3, 4].rotate(by: 3) -> [2,3,4,1]
+    ///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
+    ///
+    /// - Parameter places: The number of places that the array should be rotated. If the value is positive the end becomes the start, if it negative it's that start become the end.
+    /// - Returns: self after rotating.
+    @discardableResult
+    public mutating func rotate(by places: Int) -> Self {
+        guard places != 0 && places < count else { return self }
+        if places > 0 {
+            let range = index(endIndex, offsetBy: -places)..<endIndex
+            let slice = self[range]
+            removeSubrange(range)
+            insert(contentsOf: slice, at: startIndex)
+        } else {
+            let range = startIndex..<index(startIndex, offsetBy: -places)
+            let slice = self[range]
+            removeSubrange(range)
+            append(contentsOf: slice)
+        }
+        return self
+    }
+}

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -35,7 +35,7 @@ extension RangeReplaceableCollection {
     public mutating func rotate(by places: Int) -> Self {
         guard places != 0 && places < count else { return self }
         if places > 0 {
-            let range = index(endIndex, offsetBy: -places)..<endIndex
+            let range = index(endIndex, offsetBy: -places)...
             let slice = self[range]
             removeSubrange(range)
             insert(contentsOf: slice, at: startIndex)

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -34,7 +34,7 @@ extension RangeReplaceableCollection {
     @discardableResult
     public mutating func rotate(by places: Int) -> Self {
         guard places != 0 else { return self }
-        let placesToMove = abs(places) >= count ? places%count : places
+        let placesToMove = places%count
         if placesToMove > 0 {
             let range = index(endIndex, offsetBy: -placesToMove)...
             let slice = self[range]

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -34,14 +34,14 @@ extension RangeReplaceableCollection {
     @discardableResult
     public mutating func rotate(by places: Int) -> Self {
         guard places != 0 else { return self }
-        let placeToMove = abs(places) >= count ? places%count : places
-        if placeToMove > 0 {
+        let placesToMove = abs(places) >= count ? places%count : places
+        if placesToMove > 0 {
             let range = index(endIndex, offsetBy: -placeToMove)...
             let slice = self[range]
             removeSubrange(range)
             insert(contentsOf: slice, at: startIndex)
         } else {
-            let range = startIndex..<index(startIndex, offsetBy: -placeToMove)
+            let range = startIndex..<index(startIndex, offsetBy: -placesToMove)
             let slice = self[range]
             removeSubrange(range)
             append(contentsOf: slice)

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -33,7 +33,7 @@ extension RangeReplaceableCollection {
     /// - Returns: self after rotating.
     @discardableResult
     public mutating func rotate(by places: Int) -> Self {
-        guard places != 0 && places < count else { return self }
+        guard places != 0 && abs(places) < count else { return self }
         if places > 0 {
             let range = index(endIndex, offsetBy: -places)...
             let slice = self[range]

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -401,6 +401,13 @@
 		A9FF467220245AC90084C40F /* test.json in Resources */ = {isa = PBXBuildFile; fileRef = A9FF467020245ABA0084C40F /* test.json */; };
 		A9FF467320245AC90084C40F /* test.json in Resources */ = {isa = PBXBuildFile; fileRef = A9FF467020245ABA0084C40F /* test.json */; };
 		A9FF467420245AC90084C40F /* test.json in Resources */ = {isa = PBXBuildFile; fileRef = A9FF467020245ABA0084C40F /* test.json */; };
+		B22EB2B720E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
+		B22EB2B920E9E814001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */; };
+		B22EB2BA20E9E81B001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
+		B22EB2BB20E9E81C001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
+		B22EB2BC20E9E81C001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
+		B22EB2BD20E9EA1F001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */; };
+		B22EB2BE20E9EA20001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */; };
 		B23678EC1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
 		B23678ED1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
 		B23678EE1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */; };
@@ -583,6 +590,8 @@
 		A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensionsTests.swift; sourceTree = "<group>"; };
 		A9CD166720242AF900DBE263 /* UICollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UICollectionViewCell.xib; sourceTree = "<group>"; };
 		A9FF467020245ABA0084C40F /* test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test.json; sourceTree = "<group>"; };
+		B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionExtensions.swift; sourceTree = "<group>"; };
+		B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionTests.swift; sourceTree = "<group>"; };
 		B23678EB1FB116AD0027C931 /* SwiftStdlibDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftStdlibDeprecated.swift; sourceTree = "<group>"; };
 		B247BDE520D376EC00842ACC /* UIEdgeInsetsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsetsExtensions.swift; sourceTree = "<group>"; };
 		B247BDE820D37AFE00842ACC /* UIEdgeInsetsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsetsExtensionsTests.swift; sourceTree = "<group>"; };
@@ -679,6 +688,7 @@
 				07B7F1771F5EB41600E6F910 /* StringExtensions.swift */,
 				9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */,
 				07B7F1761F5EB41600E6F910 /* SignedNumericExtensions.swift */,
+				B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */,
 				B23678EA1FB116680027C931 /* Deprecated */,
 			);
 			path = SwiftStdlib;
@@ -703,6 +713,7 @@
 				07C50D061F5EB03200F46E5A /* StringExtensionsTests.swift */,
 				9D9784DF1FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift */,
 				07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */,
+				B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */,
 			);
 			path = SwiftStdlibTests;
 			sourceTree = "<group>";
@@ -1455,6 +1466,7 @@
 				07B7F2331F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				0713066F1FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F1971F5EB42000E6F910 /* UIImageExtensions.swift in Sources */,
+				B22EB2B720E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				077BA08A1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
 				07B7F2131F5EB43C00E6F910 /* FloatExtensions.swift in Sources */,
@@ -1533,6 +1545,7 @@
 				074EAF1C1F7BA68B00C74636 /* UIFontExtensions.swift in Sources */,
 				07B7F1A81F5EB42000E6F910 /* UIAlertControllerExtensions.swift in Sources */,
 				07B7F2341F5EB45200E6F910 /* CGColorExtensions.swift in Sources */,
+				B22EB2BA20E9E81B001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				07B7F21E1F5EB43F00E6F910 /* SwifterSwift.swift in Sources */,
 				70269A2C1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */,
 				07B7F2041F5EB43C00E6F910 /* LocaleExtensions.swift in Sources */,
@@ -1591,6 +1604,7 @@
 				071306711FB597920023A9D8 /* FoundationDeprecated.swift in Sources */,
 				07B7F1C31F5EB42200E6F910 /* UIImageExtensions.swift in Sources */,
 				077BA08C1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
+				B22EB2BB20E9E81C001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				9D4914851F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
 				07B7F1EF1F5EB43B00E6F910 /* FloatExtensions.swift in Sources */,
 				07B7F1EE1F5EB43B00E6F910 /* DoubleExtensions.swift in Sources */,
@@ -1637,6 +1651,7 @@
 				07B7F1E31F5EB43B00E6F910 /* SignedNumericExtensions.swift in Sources */,
 				07B7F2241F5EB44600E6F910 /* CLLocationExtensions.swift in Sources */,
 				1875A8FA20BDE50D00A6D258 /* SKNodeExtensions.swift in Sources */,
+				B22EB2BC20E9E81C001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				278CA08D1F9A9232004918BD /* NSImageExtensions.swift in Sources */,
 				07B7F1E21F5EB43B00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				07B7F1E51F5EB43B00E6F910 /* URLExtensions.swift in Sources */,
@@ -1690,6 +1705,7 @@
 				07C50D391F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */,
 				784C75372051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
 				0722CB3A20C2E49A00C6C1B6 /* UIWindowExtensionsTests.swift in Sources */,
+				B22EB2B920E9E814001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */,
 				9D9784E41FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
 				07C50D361F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */,
 				07C50D8C1F5EB06000F46E5A /* CGFloatExtensionsTests.swift in Sources */,
@@ -1747,6 +1763,7 @@
 				07C50D451F5EB04700F46E5A /* ColorExtensionsTests.swift in Sources */,
 				784C75382051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
 				07C50D491F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */,
+				B22EB2BD20E9EA1F001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */,
 				07C50D561F5EB04700F46E5A /* UIViewExtensionsTests.swift in Sources */,
 				07C50D471F5EB04700F46E5A /* UIImageViewExtensionsTests.swift in Sources */,
 				07C50D421F5EB04700F46E5A /* UIBarButtonExtensionsTests.swift in Sources */,
@@ -1821,6 +1838,7 @@
 				07C50D801F5EB05100F46E5A /* URLExtensionsTests.swift in Sources */,
 				07C50D771F5EB05100F46E5A /* DataExtensionsTests.swift in Sources */,
 				07C50D831F5EB05800F46E5A /* CGSizeExtensionsTests.swift in Sources */,
+				B22EB2BE20E9EA20001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */,
 				077BA0BB1F6BEA6B00D9C4AC /* UserDefaultsExtensionsTests.swift in Sources */,
 				784C75392051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
 				07C50D751F5EB05100F46E5A /* CharacterExtensionsTests.swift in Sources */,

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -94,26 +94,6 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(tuple.1, [1, 3, 5])
     }
 
-    func testRotated() {
-        let array: [Int] = [1, 2, 3, 4]
-        XCTAssertEqual(array.rotated(by: 0), [1, 2, 3, 4])
-        XCTAssertEqual(array.rotated(by: 4), [1, 2, 3, 4])
-        XCTAssertEqual(array.rotated(by: 1), [4, 1, 2, 3])
-        XCTAssertEqual(array.rotated(by: 3), [2, 3, 4, 1])
-        XCTAssertEqual(array.rotated(by: -1), [2, 3, 4, 1])
-        XCTAssertEqual(array.rotated(by: -3), [4, 1, 2, 3])
-    }
-
-    func testRotate() {
-        var array: [Int] = [1, 2, 3, 4]
-        array.rotate(by: 0)
-        XCTAssertEqual(array, [1, 2, 3, 4])
-        array.rotate(by: 2)
-        XCTAssertEqual(array, [3, 4, 1, 2])
-        array.rotate(by: -1)
-        XCTAssertEqual(array, [4, 1, 2, 3])
-    }
-
     func testShuffle() {
         var arr = ["a"]
         arr.shuffle()

--- a/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
@@ -1,0 +1,33 @@
+//
+//  RangeReplaceableCollectionTests.swift
+//  SwifterSwift
+//
+//  Created by Luciano Almeida on 7/2/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+class RangeReplaceableCollectionTests: XCTestCase {
+
+    func testRotated() {
+        let array: [Int] = [1, 2, 3, 4]
+        XCTAssertEqual(array.rotated(by: 0), [1, 2, 3, 4])
+        XCTAssertEqual(array.rotated(by: 4), [1, 2, 3, 4])
+        XCTAssertEqual(array.rotated(by: 1), [4, 1, 2, 3])
+        XCTAssertEqual(array.rotated(by: 3), [2, 3, 4, 1])
+        XCTAssertEqual(array.rotated(by: -1), [2, 3, 4, 1])
+        XCTAssertEqual(array.rotated(by: -3), [4, 1, 2, 3])
+    }
+
+    func testRotate() {
+        var array: [Int] = [1, 2, 3, 4]
+        array.rotate(by: 0)
+        XCTAssertEqual(array, [1, 2, 3, 4])
+        array.rotate(by: 2)
+        XCTAssertEqual(array, [3, 4, 1, 2])
+        array.rotate(by: -1)
+        XCTAssertEqual(array, [4, 1, 2, 3])
+    }
+}

--- a/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
@@ -14,13 +14,13 @@ class RangeReplaceableCollectionTests: XCTestCase {
     func testRotated() {
         let array: [Int] = [1, 2, 3, 4]
         XCTAssertEqual(array.rotated(by: 0), [1, 2, 3, 4])
-        XCTAssertEqual(array.rotated(by: 5), [1, 2, 3, 4])
+        XCTAssertEqual(array.rotated(by: 5), [4, 1, 2, 3])
         XCTAssertEqual(array.rotated(by: 4), [1, 2, 3, 4])
         XCTAssertEqual(array.rotated(by: 1), [4, 1, 2, 3])
         XCTAssertEqual(array.rotated(by: 3), [2, 3, 4, 1])
         XCTAssertEqual(array.rotated(by: -1), [2, 3, 4, 1])
         XCTAssertEqual(array.rotated(by: -3), [4, 1, 2, 3])
-        XCTAssertEqual(array.rotated(by: -5), [1, 2, 3, 4])
+        XCTAssertEqual(array.rotated(by: -5), [2, 3, 4, 1])
 
     }
 

--- a/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
@@ -14,11 +14,14 @@ class RangeReplaceableCollectionTests: XCTestCase {
     func testRotated() {
         let array: [Int] = [1, 2, 3, 4]
         XCTAssertEqual(array.rotated(by: 0), [1, 2, 3, 4])
+        XCTAssertEqual(array.rotated(by: 5), [1, 2, 3, 4])
         XCTAssertEqual(array.rotated(by: 4), [1, 2, 3, 4])
         XCTAssertEqual(array.rotated(by: 1), [4, 1, 2, 3])
         XCTAssertEqual(array.rotated(by: 3), [2, 3, 4, 1])
         XCTAssertEqual(array.rotated(by: -1), [2, 3, 4, 1])
         XCTAssertEqual(array.rotated(by: -3), [4, 1, 2, 3])
+        XCTAssertEqual(array.rotated(by: -5), [1, 2, 3, 4])
+
     }
 
     func testRotate() {


### PR DESCRIPTION
This is still related to #427 
Notice that still has some array extensions that could be refactored. 
@omaralbeik Should we reopened that? Create a new one what do you think? 
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
