### PR TITLE
Fixes #514

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Fixed
 - **String**:
-  - Used [RFC 5322](http://emailregex.com/) in `isEmail`, an email address regex that 99.99% works. [#514](https://github.com/SwifterSwift/SwifterSwift/issues/514) by [Omar Albeik](https://github.com/omaralbeik)
+  - Used [RFC 5322](http://emailregex.com/) in `isValidEmail`, an email address regex that 99.99% works. [#517](https://github.com/SwifterSwift/SwifterSwift/pull/517) by [Omar Albeik](https://github.com/omaralbeik)
 
 ### Deprecated
+- **String**:
+  - `isEmail` property has been renamed to `isValidEmail`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,26 @@
 # CHANGELOG
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
-> # Upcoming release
->
-> ### Added
+# Upcoming release
+
+### Added
+
 ### Changed
 - **RangeReplaceableCollection**:
   - `rotate(by:)` and `rotated(by:)` array extensions now are more generic `RangeReplaceableCollection` extensions. [#512](https://github.com/SwifterSwift/SwifterSwift/pull/512) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
   - `removeFirst(where:)` array extension now is more generic `RangeReplaceableCollection` extensions. [#516](https://github.com/SwifterSwift/SwifterSwift/pull/516) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **RandomAccessCollection**:
   - `indices(of:)` array extension now is more generic `RandomAccessCollection` extensions. [#516](https://github.com/SwifterSwift/SwifterSwift/pull/516) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
-> ### Deprecated
-> ### Removed
-> ### Fixed
-> ### Security
+
+### Fixed
+- **String**:
+  - Used [RFC 5322](http://emailregex.com/) in `isEmail`, an email address regex that 99.99% works. [#514](https://github.com/SwifterSwift/SwifterSwift/issues/514) by [Omar Albeik](https://github.com/omaralbeik)
+
+### Deprecated
+
+### Removed
+
+### Security
 
 ---
 

--- a/Sources/Extensions/SwiftStdlib/Deprecated/SwiftStdlibDeprecated.swift
+++ b/Sources/Extensions/SwiftStdlib/Deprecated/SwiftStdlibDeprecated.swift
@@ -39,6 +39,20 @@ public extension Bool {
 
 extension String {
 
+	#if canImport(Foundation)
+	/// SwifterSwift: Check if string is valid email format.
+	/// **Note that this property does not validate the email address against an email server. It merely attempts to determine whether its format is suitable for an email address.**.
+	///
+	///		"john@doe.com".isEmail -> true
+	///
+	@available(*, deprecated: 4.5.0, message: "Use isValidEmail instead", renamed: "isValidEmail")
+	public var isEmail: Bool {
+		// http://emailregex.com/
+		let regex = "^(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[\\p{L}0-9](?:[a-z0-9-]*[\\p{L}0-9])?\\.)+[\\p{L}0-9](?:[\\p{L}0-9-]*[\\p{L}0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[\\p{L}0-9-]*[\\p{L}0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+		return range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil
+	}
+	#endif
+
 	/// SwifterSwift: Number of characters in string.
 	///
 	///		"Hello world!".length -> 12

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -157,13 +157,13 @@ public extension String {
 
 	#if canImport(Foundation)
 	/// SwifterSwift: Check if string is valid email format.
+	/// **Note that this property does not validate the email address against an email server. It merely attempts to determine whether its format is suitable for an email address.**.
 	///
 	///		"john@doe.com".isEmail -> true
 	///
-	public var isEmail: Bool {
-		guard self == trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+	public var isValidEmail: Bool {
 		// http://emailregex.com/
-		let regex = "(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[\\p{L}0-9](?:[a-z0-9-]*[\\p{L}0-9])?\\.)+[\\p{L}0-9](?:[\\p{L}0-9-]*[\\p{L}0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[\\p{L}0-9-]*[\\p{L}0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+		let regex = "^(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[\\p{L}0-9](?:[a-z0-9-]*[\\p{L}0-9])?\\.)+[\\p{L}0-9](?:[\\p{L}0-9-]*[\\p{L}0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[\\p{L}0-9-]*[\\p{L}0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
 		return range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil
 	}
 	#endif

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -157,9 +157,10 @@ public extension String {
 
 	#if canImport(Foundation)
 	/// SwifterSwift: Check if string is valid email format.
-	/// **Note that this property does not validate the email address against an email server. It merely attempts to determine whether its format is suitable for an email address.**.
 	///
-	///		"john@doe.com".isEmail -> true
+	/// - Note: Note that this property does not validate the email address against an email server. It merely attempts to determine whether its format is suitable for an email address.
+	///
+	///		"john@doe.com".isValidEmail -> true
 	///
 	public var isValidEmail: Bool {
 		// http://emailregex.com/

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -161,9 +161,10 @@ public extension String {
 	///		"john@doe.com".isEmail -> true
 	///
 	public var isEmail: Bool {
-		// http://stackoverflow.com/questions/25471114/how-to-validate-an-e-mail-address-in-swift
-		return range(of: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}",
-					 options: .regularExpression, range: nil, locale: nil) != nil
+		guard self == trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+		// http://emailregex.com/
+		let regex = "(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[\\p{L}0-9](?:[a-z0-9-]*[\\p{L}0-9])?\\.)+[\\p{L}0-9](?:[\\p{L}0-9-]*[\\p{L}0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[\\p{L}0-9-]*[\\p{L}0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+		return range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil
 	}
 	#endif
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -104,7 +104,10 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("email@domain.com (Joe Smith)".isValidEmail)
         XCTAssertFalse("email@domain".isValidEmail)
         XCTAssertFalse("email@-domain.com".isValidEmail)
-        XCTAssertFalse("email@domain..com".isValidEmail)
+        XCTAssertFalse(" email@domain.com".isValidEmail)
+        XCTAssertFalse("email@domain.com ".isValidEmail)
+        XCTAssertFalse("\nemail@domain.com".isValidEmail)
+        XCTAssertFalse("nemail@domain.com   \n\n".isValidEmail)
     }
 
     func testIsValidUrl() {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -77,7 +77,12 @@ final class StringExtensionsTests: XCTestCase {
     func testIsEmail() {
         XCTAssert("john@appleseed.com".isEmail)
         XCTAssertFalse("john@appleseedcom".isEmail)
-        XCTAssertFalse("johnappleseed.com".isEmail)
+		XCTAssertFalse("johnappleseed.com".isEmail)
+		XCTAssertFalse("john@apple seed.com".isEmail)
+		XCTAssertFalse(" john@appleseed.com".isEmail)
+		XCTAssertFalse("john@appleseed.com ".isEmail)
+		XCTAssertFalse("email.@.email.com".isEmail)
+		XCTAssertFalse("foo@bar".isEmail)
     }
 
     func testIsValidUrl() {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -74,15 +74,37 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("abc".isAlphaNumeric)
     }
 
-    func testIsEmail() {
-        XCTAssert("john@appleseed.com".isEmail)
-        XCTAssertFalse("john@appleseedcom".isEmail)
-		XCTAssertFalse("johnappleseed.com".isEmail)
-		XCTAssertFalse("john@apple seed.com".isEmail)
-		XCTAssertFalse(" john@appleseed.com".isEmail)
-		XCTAssertFalse("john@appleseed.com ".isEmail)
-		XCTAssertFalse("email.@.email.com".isEmail)
-		XCTAssertFalse("foo@bar".isEmail)
+    func testisValidEmail() {
+        // https://blogs.msdn.microsoft.com/testing123/2009/02/06/email-address-test-cases/
+
+        XCTAssert("email@domain.com".isValidEmail)
+        XCTAssert("firstname.lastname@domain.com".isValidEmail)
+        XCTAssert("email@subdomain.domain.com".isValidEmail)
+        XCTAssert("firstname+lastname@domain.com".isValidEmail)
+        XCTAssert("email@123.123.123.123".isValidEmail)
+        XCTAssert("email@[123.123.123.123]".isValidEmail)
+        XCTAssert("\"email\"@domain.com".isValidEmail)
+        XCTAssert("1234567890@domain.com".isValidEmail)
+        XCTAssert("email@domain-one.com".isValidEmail)
+        XCTAssert("_______@domain.com".isValidEmail)
+        XCTAssert("email@domain.name".isValidEmail)
+        XCTAssert("email@domain.co.jp".isValidEmail)
+        XCTAssert("firstname-lastname@domain.com".isValidEmail)
+
+        XCTAssertFalse("".isValidEmail)
+        XCTAssertFalse("plainaddress".isValidEmail)
+        XCTAssertFalse("#@%^%#$@#$@#.com".isValidEmail)
+        XCTAssertFalse("@domain.com".isValidEmail)
+        XCTAssertFalse("Joe Smith <email@domain.com>".isValidEmail)
+        XCTAssertFalse("email.domain.com".isValidEmail)
+        XCTAssertFalse("email@domain@domain.com".isValidEmail)
+        XCTAssertFalse(".email@domain.com".isValidEmail)
+        XCTAssertFalse("email.@domain.com".isValidEmail)
+        XCTAssertFalse("email..email@domain.com".isValidEmail)
+        XCTAssertFalse("email@domain.com (Joe Smith)".isValidEmail)
+        XCTAssertFalse("email@domain".isValidEmail)
+        XCTAssertFalse("email@-domain.com".isValidEmail)
+        XCTAssertFalse("email@domain..com".isValidEmail)
     }
 
     func testIsValidUrl() {


### PR DESCRIPTION
Used [RFC 5322](http://emailregex.com/) in `isEmail`, an email address regex that 99.99% works.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
