### PR TITLE
UIRefreshControl extension added to begin refresh programatically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+-**UIRefreshControl**:
+- `beginRefreshProgramatically(tableView:)` UIRefreshControl extension to begin refresh programatically. 
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 -**UIRefreshControl**:
-- `beginRefreshProgramatically(tableView:)` UIRefreshControl extension to begin refresh programatically. 
+- `beginRefreshProgramatically(tableView:)` UIRefreshControl extension to begin refresh programatically. [#525](https://github.com/SwifterSwift/SwifterSwift/pull/525) by [ratulSharker](https://github.com/ratulSharker)
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `addGestureRecognizers(_:)` which accepts an array of `UIGestureRecognizer` to add multiple gesture recognizers to a view with one call. [#523](https://github.com/SwifterSwift/SwifterSwift/pull/523) by [moyerr](https://github.com/moyerr)
   - Added `removeGestureRecognizers(_:)` which accepts an array of `UIGestureRecognizer` to remove multiple gesture recognizers from a view with one call. [#523](https://github.com/SwifterSwift/SwifterSwift/pull/523) by [moyerr](https://github.com/moyerr)
 
-
 ### Changed
 - **RangeReplaceableCollection**:
   - `rotate(by:)` and `rotated(by:)` array extensions now are more generic `RangeReplaceableCollection` extensions. [#512](https://github.com/SwifterSwift/SwifterSwift/pull/512) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -61,7 +61,7 @@ extension RangeReplaceableCollection {
         guard let index = try index(where: predicate) else { return nil }
         return remove(at: index)
     }
-    
+
     /// SwifterSwift: Remove a random value from the collection.
     @discardableResult public mutating func removeRandomElement() -> Element? {
         guard !isEmpty else { return nil }

--- a/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
+++ b/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
@@ -16,11 +16,19 @@ public extension UIRefreshControl {
     /// SwifterSwift: Programatically begin refresh control inside of UITableView.
     ///
     /// - Parameter tableView: UITableView instance, inside which the refresh control is contained.
-    public func beginRefreshProgramatically(in tableView: UITableView) {
+    /// - Parameter animated: Boolean, indicates that is the content offset changing should be animated or not.
+    /// - Parameter sendAction: Boolean, indicates that should it fire sendActions method for valueChanged UIControlEvents 
+    public func beginRefreshing(in tableView: UITableView, animated: Bool, sendAction: Bool) {
         //https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins/14719658#14719658
+        assert(superview == tableView, "Refresh control does not belong to the receiving table view")
+
         beginRefreshing()
         let offsetPoint = CGPoint(x: 0, y: -frame.height)
-        tableView.setContentOffset(offsetPoint, animated: true)
+        tableView.setContentOffset(offsetPoint, animated: animated)
+
+        if sendAction {
+            sendActions(for: .valueChanged)
+        }
     }
 
 }

--- a/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
+++ b/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
@@ -6,19 +6,19 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 
-#if !os(watchOS)
 // MARK: - Methods
 public extension UIRefreshControl {
 
     /// SwifterSwift: Programatically begin refresh control inside of UITableView.
     ///
-    /// - Parameter tableView: UITableView instance, inside which the refresh control is contained.
-    /// - Parameter animated: Boolean, indicates that is the content offset changing should be animated or not.
-    /// - Parameter sendAction: Boolean, indicates that should it fire sendActions method for valueChanged UIControlEvents 
-    public func beginRefreshing(in tableView: UITableView, animated: Bool, sendAction: Bool) {
+    /// - Parameters:
+    ///   - tableView: UITableView instance, inside which the refresh control is contained.
+    ///   - animated: Boolean, indicates that is the content offset changing should be animated or not.
+    ///   - sendAction: Boolean, indicates that should it fire sendActions method for valueChanged UIControlEvents 
+    public func beginRefreshing(in tableView: UITableView, animated: Bool, sendAction: Bool = false) {
         //https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins/14719658#14719658
         assert(superview == tableView, "Refresh control does not belong to the receiving table view")
 
@@ -33,5 +33,4 @@ public extension UIRefreshControl {
 
 }
 
-#endif
 #endif

--- a/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
+++ b/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
@@ -1,0 +1,29 @@
+//
+//  UIRefreshControlExtensions.swift
+//  SwifterSwift
+//
+//  Created by ratul sharker on 7/24/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if canImport(UIKit)
+import UIKit
+
+#if !os(watchOS)
+// MARK: - Methods
+public extension UIRefreshControl {
+
+    /// SwifterSwift: Programatically begin refresh control inside of UITableView.
+    ///
+    /// - Parameter tableView: UITableView instance, inside which the refresh control is contained.
+    public func beginRefreshProgramatically(in tableView: UITableView) {
+        //https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins/14719658#14719658
+        beginRefreshing()
+        let offsetPoint = CGPoint.init(x: 0, y: -frame.size.height)
+        tableView.setContentOffset(offsetPoint, animated: true)
+    }
+
+}
+
+#endif
+#endif

--- a/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
+++ b/Sources/Extensions/UIKit/UIRefreshControlExtensions.swift
@@ -19,7 +19,7 @@ public extension UIRefreshControl {
     public func beginRefreshProgramatically(in tableView: UITableView) {
         //https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins/14719658#14719658
         beginRefreshing()
-        let offsetPoint = CGPoint.init(x: 0, y: -frame.size.height)
+        let offsetPoint = CGPoint(x: 0, y: -frame.height)
         tableView.setContentOffset(offsetPoint, animated: true)
     }
 

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -424,7 +424,6 @@
 		B29527B320F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29527B120F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift */; };
 		B29527B420F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29527B120F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift */; };
 		CA1317542106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */; };
-		CA1317552106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */; };
 		CA1317582106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1317562106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1761,7 +1760,6 @@
 				07C50D5E1F5EB05000F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTest.swift in Sources */,
 				B247BDE920D37AFE00842ACC /* UIEdgeInsetsExtensionsTests.swift in Sources */,
-				CA1317552106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */,
 				18C8E5E32074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				07C50D5D1F5EB05000F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D5B1F5EB05000F46E5A /* DataExtensionsTests.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -423,6 +423,9 @@
 		B29527B220F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29527B120F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift */; };
 		B29527B320F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29527B120F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift */; };
 		B29527B420F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29527B120F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift */; };
+		CA1317542106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */; };
+		CA1317552106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */; };
+		CA1317582106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1317562106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -604,6 +607,8 @@
 		B247BDE820D37AFE00842ACC /* UIEdgeInsetsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsetsExtensionsTests.swift; sourceTree = "<group>"; };
 		B29527AC20F99E9700E1F75D /* RandomAccessCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomAccessCollectionExtensions.swift; sourceTree = "<group>"; };
 		B29527B120F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomAccessCollectionExtensionsTests.swift; sourceTree = "<group>"; };
+		CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIRefreshControlExtensions.swift; sourceTree = "<group>"; };
+		CA1317562106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIRefreshControlExntesionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -846,6 +851,7 @@
 				86B3F7AB208D3D5C00BC297B /* UIScrollViewExtensions.swift */,
 				0722CB3720C2E46B00C6C1B6 /* UIWindowExtensions.swift */,
 				B247BDE520D376EC00842ACC /* UIEdgeInsetsExtensions.swift */,
+				CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -931,6 +937,7 @@
 				90693554208B545100407C4D /* UIGestureRecognizerExtensionsTests.swift */,
 				0722CB3920C2E49900C6C1B6 /* UIWindowExtensionsTests.swift */,
 				B247BDE820D37AFE00842ACC /* UIEdgeInsetsExtensionsTests.swift */,
+				CA1317562106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -1486,6 +1493,7 @@
 				07B7F2121F5EB43C00E6F910 /* DoubleExtensions.swift in Sources */,
 				07B7F2171F5EB43C00E6F910 /* OptionalExtensions.swift in Sources */,
 				074EAF1B1F7BA68B00C74636 /* UIFontExtensions.swift in Sources */,
+				CA1317542106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */,
 				07B7F1921F5EB42000E6F910 /* UIAlertControllerExtensions.swift in Sources */,
 				07B7F22E1F5EB45100E6F910 /* CGColorExtensions.swift in Sources */,
 				07B7F21F1F5EB43F00E6F910 /* SwifterSwift.swift in Sources */,
@@ -1729,6 +1737,7 @@
 				07C50D3E1F5EB04700F46E5A /* UITextViewExtensionsTests.swift in Sources */,
 				074EAF1F1F7BA74700C74636 /* UIFontExtensionsTest.swift in Sources */,
 				07C50D301F5EB04700F46E5A /* UIImageExtensionsTests.swift in Sources */,
+				CA1317582106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift in Sources */,
 				07C50D3A1F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */,
 				07C50D341F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */,
 				752AC7A520BC9FF500659E76 /* SpriteKitTests.swift in Sources */,
@@ -1750,6 +1759,7 @@
 				07C50D5E1F5EB05000F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTest.swift in Sources */,
 				B247BDE920D37AFE00842ACC /* UIEdgeInsetsExtensionsTests.swift in Sources */,
+				CA1317552106D35E002F1B0D /* UIRefreshControlExtensions.swift in Sources */,
 				18C8E5E32074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				07C50D5D1F5EB05000F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D5B1F5EB05000F46E5A /* DataExtensionsTests.swift in Sources */,

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -1,0 +1,28 @@
+//
+//  UIRefreshControlExntesionsTests.swift
+//  SwifterSwift
+//
+//  Created by ratul sharker on 7/24/18.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if os(iOS)
+
+import XCTest
+@testable import SwifterSwift
+
+final class UIRefreshControlExtensionTests: XCTestCase {
+
+    func testBeginRefreshProgramatically() {
+        let tableFrame = CGRect.init(x: 0, y: 0, width: 400, height: 400)
+        let tableView = UITableView.init(frame: tableFrame)
+        XCTAssertEqual(tableView.contentOffset, CGPoint.zero)
+        let refreshControl = UIRefreshControl.init()
+        tableView.addSubview(refreshControl)
+        refreshControl.beginRefreshProgramatically(in: tableView)
+        XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.size.height)
+    }
+
+}
+
+#endif

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -29,7 +29,7 @@ final class UIRefreshControlExtensionTests: XCTestCase {
             let tableview = UITableView()
             XCTAssertEqual(tableview.contentOffset, .zero)
             tableview.refreshControl = UIRefreshControl()
-            tableview.refreshControl?.beginRefreshing(in: tableview, animated: true)
+            tableview.refreshControl?.beginRefreshing(in: tableview, animated: true, sendAction: true)
 
             XCTAssertTrue(tableview.refreshControl!.isRefreshing)
             XCTAssertEqual(tableview.contentOffset.y, -tableview.refreshControl!.frame.height)

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -14,13 +14,14 @@ import XCTest
 final class UIRefreshControlExtensionTests: XCTestCase {
 
     func testBeginRefreshProgramatically() {
-        let tableFrame = CGRect.init(x: 0, y: 0, width: 400, height: 400)
+        let tableFrame = CGRect(x: 0, y: 0, width: 400, height: 400)
         let tableView = UITableView.init(frame: tableFrame)
-        XCTAssertEqual(tableView.contentOffset, CGPoint.zero)
+        XCTAssertEqual(tableView.contentOffset, .zero)
         let refreshControl = UIRefreshControl.init()
         tableView.addSubview(refreshControl)
         refreshControl.beginRefreshProgramatically(in: tableView)
-        XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.size.height)
+        XCTAssertTrue(refreshControl.isRefreshing)
+        XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.height)
     }
 
 }

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -22,17 +22,15 @@ final class UIRefreshControlExtensionTests: XCTestCase {
 
         XCTAssertTrue(refreshControl.isRefreshing)
         XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.height)
-    }
 
-    func testBeginRefreshAsRefreshControlProperty() {
         if #available(iOS 10.0, *) {
-            let tableview = UITableView()
-            XCTAssertEqual(tableview.contentOffset, .zero)
-            tableview.refreshControl = UIRefreshControl()
-            tableview.refreshControl?.beginRefreshing(in: tableview, animated: true, sendAction: true)
+            let anotherTableview = UITableView()
+            XCTAssertEqual(anotherTableview.contentOffset, .zero)
+            anotherTableview.refreshControl = UIRefreshControl()
+            anotherTableview.refreshControl?.beginRefreshing(in: anotherTableview, animated: true, sendAction: true)
 
-            XCTAssertTrue(tableview.refreshControl!.isRefreshing)
-            XCTAssertEqual(tableview.contentOffset.y, -tableview.refreshControl!.frame.height)
+            XCTAssertTrue(anotherTableview.refreshControl!.isRefreshing)
+            XCTAssertEqual(anotherTableview.contentOffset.y, -anotherTableview.refreshControl!.frame.height)
         }
     }
 

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -14,11 +14,11 @@ import XCTest
 final class UIRefreshControlExtensionTests: XCTestCase {
 
     func testBeginRefreshAsRefreshControlSubview() {
-        let tableView = UITableView.init()
+        let tableView = UITableView()
         XCTAssertEqual(tableView.contentOffset, .zero)
-        let refreshControl = UIRefreshControl.init()
+        let refreshControl = UIRefreshControl()
         tableView.addSubview(refreshControl)
-        refreshControl.beginRefreshing(in: tableView, animated: true, sendAction: false)
+        refreshControl.beginRefreshing(in: tableView, animated: true)
 
         XCTAssertTrue(refreshControl.isRefreshing)
         XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.height)
@@ -26,10 +26,10 @@ final class UIRefreshControlExtensionTests: XCTestCase {
 
     func testBeginRefreshAsRefreshControlProperty() {
         if #available(iOS 10.0, *) {
-            let tableview = UITableView.init()
+            let tableview = UITableView()
             XCTAssertEqual(tableview.contentOffset, .zero)
-            tableview.refreshControl = UIRefreshControl.init()
-            tableview.refreshControl?.beginRefreshing(in: tableview, animated: true, sendAction: false)
+            tableview.refreshControl = UIRefreshControl()
+            tableview.refreshControl?.beginRefreshing(in: tableview, animated: true)
 
             XCTAssertTrue(tableview.refreshControl!.isRefreshing)
             XCTAssertEqual(tableview.contentOffset.y, -tableview.refreshControl!.frame.height)

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -13,15 +13,27 @@ import XCTest
 
 final class UIRefreshControlExtensionTests: XCTestCase {
 
-    func testBeginRefreshProgramatically() {
-        let tableFrame = CGRect(x: 0, y: 0, width: 400, height: 400)
-        let tableView = UITableView.init(frame: tableFrame)
+    func testBeginRefreshAsRefreshControlSubview() {
+        let tableView = UITableView.init()
         XCTAssertEqual(tableView.contentOffset, .zero)
         let refreshControl = UIRefreshControl.init()
         tableView.addSubview(refreshControl)
-        refreshControl.beginRefreshProgramatically(in: tableView)
+        refreshControl.beginRefreshing(in: tableView, animated: true, sendAction: false)
+
         XCTAssertTrue(refreshControl.isRefreshing)
         XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.height)
+    }
+
+    func testBeginRefreshAsRefreshControlProperty() {
+        if #available(iOS 10.0, *) {
+            let tableview = UITableView.init()
+            XCTAssertEqual(tableview.contentOffset, .zero)
+            tableview.refreshControl = UIRefreshControl.init()
+            tableview.refreshControl?.beginRefreshing(in: tableview, animated: true, sendAction: false)
+
+            XCTAssertTrue(tableview.refreshControl!.isRefreshing)
+            XCTAssertEqual(tableview.contentOffset.y, -tableview.refreshControl!.frame.height)
+        }
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md)

When a UIRefreshControl is added as a subview inside of UITableView, then calling the `beginRefresh` method does not show up the UIRefreshControl inside the UITableView. Developer had to manually change the content offset of the UITableView instance.

Source: [Stack Overflow](https://stackoverflow.com/questions/14718850/uirefreshcontrol-beginrefreshing-not-working-when-uitableviewcontroller-is-ins/14719658#14719658)
