### PR TITLE
set translatesAutoresizingMaskIntoConstraints when adding subview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 
+- added `addSubviews(_:translatesAutoresizingMaskIntoConstraints:)` and `addSubview(_:translatesAutoresizingMaskIntoConstraints:)`
+
 ### Changed
 - **RangeReplaceableCollection**:
   - `rotate(by:)` and `rotated(by:)` array extensions now are more generic `RangeReplaceableCollection` extensions. [#512](https://github.com/SwifterSwift/SwifterSwift/pull/512) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -278,7 +278,7 @@ public extension UIView {
 	///
 	/// - Parameter subviews: array of subviews to add to self.
 	public func addSubviews(_ subviews: [UIView]) {
-		subviews.forEach({ self.addSubview($0) })
+		subviews.forEach({ addSubview($0) })
 	}
     
     /// SwifterSwift: Add array of subviews to view and set translatesAutoresizingMaskIntoConstraints.
@@ -286,7 +286,7 @@ public extension UIView {
     /// - Parameter subviews: array of subviews to add to self.
     /// - Parameter translatesAutoresizingMaskIntoConstraints: set translatesAutoresizingMaskIntoConstraints of the added subviews.
     public func addSubviews(_ subviews: [UIView], translatesAutoresizingMaskIntoConstraints: Bool) {
-        subviews.forEach({ self.addSubview($0, translatesAutoresizingMaskIntoConstraints: translatesAutoresizingMaskIntoConstraints) })
+        subviews.forEach({ addSubview($0, translatesAutoresizingMaskIntoConstraints: translatesAutoresizingMaskIntoConstraints) })
     }
     
     /// SwifterSwift: Add subview to view and set translatesAutoresizingMaskIntoConstraints.

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -280,6 +280,23 @@ public extension UIView {
 	public func addSubviews(_ subviews: [UIView]) {
 		subviews.forEach({ self.addSubview($0) })
 	}
+    
+    /// SwifterSwift: Add array of subviews to view and set translatesAutoresizingMaskIntoConstraints.
+    ///
+    /// - Parameter subviews: array of subviews to add to self.
+    /// - Parameter translatesAutoresizingMaskIntoConstraints: set translatesAutoresizingMaskIntoConstraints of the added subviews.
+    public func addSubviews(_ subviews: [UIView], translatesAutoresizingMaskIntoConstraints: Bool) {
+        subviews.forEach({ self.addSubview($0, translatesAutoresizingMaskIntoConstraints: translatesAutoresizingMaskIntoConstraints) })
+    }
+    
+    /// SwifterSwift: Add subview to view and set translatesAutoresizingMaskIntoConstraints.
+    ///
+    /// - Parameter subview: subview to add to self.
+    /// - Parameter translatesAutoresizingMaskIntoConstraints: set translatesAutoresizingMaskIntoConstraints of the added subview.
+    public func addSubview(_ subview: UIView, translatesAutoresizingMaskIntoConstraints: Bool) {
+        subview.translatesAutoresizingMaskIntoConstraints = translatesAutoresizingMaskIntoConstraints
+        addSubview(subview)
+    }
 
 	/// SwifterSwift: Fade in view.
 	///

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -206,6 +206,38 @@ final class UIViewExtensionsTests: XCTestCase {
 		view.addSubviews([UIView(), UIView()])
 		XCTAssertEqual(view.subviews.count, 2)
 	}
+    
+    func testAddSubViewsWithTranslatesAutoresizingMaskIntoConstraints() {
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let view = UIView(frame: frame)
+        XCTAssertEqual(view.subviews.count, 0)
+        
+        let subview1 = UIView()
+        view.addSubviews([subview1], translatesAutoresizingMaskIntoConstraints: false)
+        XCTAssertEqual(view.subviews.count, 1)
+        XCTAssertEqual(subview1.translatesAutoresizingMaskIntoConstraints, false)
+        
+        let subview2 = UIView()
+        view.addSubviews([subview2], translatesAutoresizingMaskIntoConstraints: true)
+        XCTAssertEqual(view.subviews.count, 2)
+        XCTAssertEqual(subview2.translatesAutoresizingMaskIntoConstraints, true)
+    }
+    
+    func testAddSubViewWithTranslatesAutoresizingMaskIntoConstraints() {
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let view = UIView(frame: frame)
+        XCTAssertEqual(view.subviews.count, 0)
+        
+        let subview1 = UIView()
+        view.addSubview(subview1, translatesAutoresizingMaskIntoConstraints: false)
+        XCTAssertEqual(view.subviews.count, 1)
+        XCTAssertEqual(subview1.translatesAutoresizingMaskIntoConstraints, false)
+        
+        let subview2 = UIView()
+        view.addSubview(subview2, translatesAutoresizingMaskIntoConstraints: true)
+        XCTAssertEqual(view.subviews.count, 2)
+        XCTAssertEqual(subview2.translatesAutoresizingMaskIntoConstraints, true)
+    }
 
 	func testFadeIn() {
 		let view1 = UIView()


### PR DESCRIPTION
Added a general helper for adding subviews when using constraints.

Before:
```
let subview = UIView()
subview.translatesAutoresizingMaskIntoConstraints = false
view.addSubview(subview)
```

Now:
```
let subview = UIView()
view.addSubview(subview, translatesAutoresizingMaskIntoConstraints: false)
```

Also possibile with array of views. Would love to see this added 😀

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x ] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
