### PR TITLE
Add `insetBy(top:left:bottom:right:)` and `insetBy(horizontal:vertical)` to UIEdgeInsets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIViewController**
   - Added `addChildViewController(_:toContainerView)` to easily add child view controllers. Accepts a `UIViewController` and a `UIView` to add the child's view to. 
   - Added `removeViewAndControllerFromParentViewController()` to remove a `UIViewController` from its parent.
+- **UIEdgeInsets**
+  - Added  `insetBy(top:)`, `insetBy(left:)`, `insetBy(bottom:)`, `insetBy(right:)`, `insetBy(horizontal:)` and `insetBy(vertical:)` to creates an `UIEdgeInsets` based on current value and adjusted by given offset. [#532](https://github.com/SwifterSwift/SwifterSwift/pull/532) by [VincentSit](https://github.com/VincentSit).
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/Sources/Extensions/UIKit/UIEdgeInsetsExtensions.swift
+++ b/Sources/Extensions/UIKit/UIEdgeInsetsExtensions.swift
@@ -44,6 +44,60 @@ extension UIEdgeInsets {
     public init(horizontal: CGFloat, vertical: CGFloat) {
         self.init(top: vertical/2, left: horizontal/2, bottom: vertical/2, right: horizontal/2)
     }
+
+    /// SwifterSwift: Creates an `UIEdgeInsets` based on current value and top offset.
+    ///
+    /// - Parameters:
+    ///   - top: Offset to be applied in to the top edge.
+    /// - Returns: UIEdgeInsets offset with given offset.
+    public func insetBy(top: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: self.top + top, left: left, bottom: bottom, right: right)
+    }
+
+    /// SwifterSwift: Creates an `UIEdgeInsets` based on current value and left offset.
+    ///
+    /// - Parameters:
+    ///   - left: Offset to be applied in to the left edge.
+    /// - Returns: UIEdgeInsets offset with given offset.
+    public func insetBy(left: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: top, left: self.left + left, bottom: bottom, right: right)
+    }
+
+    /// SwifterSwift: Creates an `UIEdgeInsets` based on current value and bottom offset.
+    ///
+    /// - Parameters:
+    ///   - bottom: Offset to be applied in to the bottom edge.
+    /// - Returns: UIEdgeInsets offset with given offset.
+    public func insetBy(bottom: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: top, left: left, bottom: self.bottom + bottom, right: right)
+    }
+
+    /// SwifterSwift: Creates an `UIEdgeInsets` based on current value and right offset.
+    ///
+    /// - Parameters:
+    ///   - right: Offset to be applied in to the right edge.
+    /// - Returns: UIEdgeInsets offset with given offset.
+    public func insetBy(right: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: top, left: left, bottom: bottom, right: self.right + right)
+    }
+
+    /// SwifterSwift: Creates an `UIEdgeInsets` based on current value and horizontal value equally divided and applied to right offset and left offset.
+    ///
+    /// - Parameters:
+    ///   - horizontal: Offset to be applied to right and left.
+    /// - Returns: UIEdgeInsets offset with given offset.
+    public func insetBy(horizontal: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: top, left: left + horizontal/2, bottom: bottom, right: right + horizontal/2)
+    }
+
+    /// SwifterSwift: Creates an `UIEdgeInsets` based on current value and vertical value equally divided and applied to top and bottom.
+    ///
+    /// - Parameters:
+    ///   - vertical: Offset to be applied to top and bottom.
+    /// - Returns: UIEdgeInsets offset with given offset.
+    public func insetBy(vertical: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: top + vertical/2, left: left, bottom: bottom + vertical/2, right: right)
+    }
 }
 
 #endif

--- a/Tests/UIKitTests/UIEdgeInsetsExtensionsTests.swift
+++ b/Tests/UIKitTests/UIEdgeInsetsExtensionsTests.swift
@@ -38,6 +38,125 @@ final class UIEdgeInsetsExtensionsTests: XCTestCase {
         XCTAssertEqual(inset.right, 10.0)
         XCTAssertEqual(inset.left, 10.0)
     }
+
+    func testInsetByTop() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let insetByTop = inset.insetBy(top: 5.0)
+        XCTAssertNotEqual(inset, insetByTop)
+        XCTAssertEqual(insetByTop.top, 15.0)
+        XCTAssertEqual(insetByTop.left, 10.0)
+        XCTAssertEqual(insetByTop.bottom, 10.0)
+        XCTAssertEqual(insetByTop.right, 10.0)
+
+        let negativeInsetByTop = inset.insetBy(top: -5.0)
+        XCTAssertNotEqual(inset, negativeInsetByTop)
+        XCTAssertEqual(negativeInsetByTop.top, 5.0)
+        XCTAssertEqual(negativeInsetByTop.left, 10.0)
+        XCTAssertEqual(negativeInsetByTop.bottom, 10.0)
+        XCTAssertEqual(negativeInsetByTop.right, 10.0)
+    }
+
+    func testInsetByLeft() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let insetByLeft = inset.insetBy(left: 5.0)
+        XCTAssertNotEqual(inset, insetByLeft)
+        XCTAssertEqual(insetByLeft.top, 10.0)
+        XCTAssertEqual(insetByLeft.left, 15.0)
+        XCTAssertEqual(insetByLeft.bottom, 10.0)
+        XCTAssertEqual(insetByLeft.right, 10.0)
+
+        let negativeInsetByLeft = inset.insetBy(left: -5.0)
+        XCTAssertNotEqual(inset, negativeInsetByLeft)
+        XCTAssertEqual(negativeInsetByLeft.top, 10.0)
+        XCTAssertEqual(negativeInsetByLeft.left, 5.0)
+        XCTAssertEqual(negativeInsetByLeft.bottom, 10.0)
+        XCTAssertEqual(negativeInsetByLeft.right, 10.0)
+    }
+
+    func testInsetByBottom() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let insetByBottom = inset.insetBy(bottom: 5.0)
+        XCTAssertNotEqual(inset, insetByBottom)
+        XCTAssertEqual(insetByBottom.top, 10.0)
+        XCTAssertEqual(insetByBottom.left, 10.0)
+        XCTAssertEqual(insetByBottom.bottom, 15.0)
+        XCTAssertEqual(insetByBottom.right, 10.0)
+
+        let negativeInsetByBottom = inset.insetBy(bottom: -5.0)
+        XCTAssertNotEqual(inset, negativeInsetByBottom)
+        XCTAssertEqual(negativeInsetByBottom.top, 10.0)
+        XCTAssertEqual(negativeInsetByBottom.left, 10.0)
+        XCTAssertEqual(negativeInsetByBottom.bottom, 5.0)
+        XCTAssertEqual(negativeInsetByBottom.right, 10.0)
+    }
+
+    func testInsetByRight() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let insetByRight = inset.insetBy(right: 5.0)
+        XCTAssertNotEqual(inset, insetByRight)
+        XCTAssertEqual(insetByRight.top, 10.0)
+        XCTAssertEqual(insetByRight.left, 10.0)
+        XCTAssertEqual(insetByRight.bottom, 10.0)
+        XCTAssertEqual(insetByRight.right, 15.0)
+
+        let negativeInsetByRight = inset.insetBy(right: -5.0)
+        XCTAssertNotEqual(inset, negativeInsetByRight)
+        XCTAssertEqual(negativeInsetByRight.top, 10.0)
+        XCTAssertEqual(negativeInsetByRight.left, 10.0)
+        XCTAssertEqual(negativeInsetByRight.bottom, 10.0)
+        XCTAssertEqual(negativeInsetByRight.right, 5.0)
+    }
+
+    func testInsetByHorizontal() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let insetByHorizontal = inset.insetBy(horizontal: 5.0)
+        XCTAssertNotEqual(inset, insetByHorizontal)
+        XCTAssertEqual(insetByHorizontal.left, 12.5)
+        XCTAssertEqual(insetByHorizontal.right, 12.5)
+        XCTAssertEqual(insetByHorizontal.top, 10.0)
+        XCTAssertEqual(insetByHorizontal.bottom, 10.0)
+
+        let negativeInsetByHorizontal = inset.insetBy(horizontal: -5.0)
+        XCTAssertNotEqual(inset, negativeInsetByHorizontal)
+        XCTAssertEqual(negativeInsetByHorizontal.left, 7.5)
+        XCTAssertEqual(negativeInsetByHorizontal.right, 7.5)
+        XCTAssertEqual(negativeInsetByHorizontal.top, 10.0)
+        XCTAssertEqual(negativeInsetByHorizontal.bottom, 10.0)
+    }
+
+    func testInsetByVertical() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let insetByVertical = inset.insetBy(vertical: 5.0)
+        XCTAssertNotEqual(inset, insetByVertical)
+        XCTAssertEqual(insetByVertical.left, 10.0)
+        XCTAssertEqual(insetByVertical.right, 10.0)
+        XCTAssertEqual(insetByVertical.top, 12.5)
+        XCTAssertEqual(insetByVertical.bottom, 12.5)
+
+        let negativeInsetByVertical = inset.insetBy(vertical: -5.0)
+        XCTAssertNotEqual(inset, negativeInsetByVertical)
+        XCTAssertEqual(negativeInsetByVertical.left, 10.0)
+        XCTAssertEqual(negativeInsetByVertical.right, 10.0)
+        XCTAssertEqual(negativeInsetByVertical.top, 7.5)
+        XCTAssertEqual(negativeInsetByVertical.bottom, 7.5)
+    }
+
+    func testInsetComposing() {
+        let inset = UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
+        let composedInset = inset.insetBy(bottom: 5.0).insetBy(horizontal: 5.0)
+        XCTAssertNotEqual(inset, composedInset)
+        XCTAssertEqual(composedInset.left, 12.5)
+        XCTAssertEqual(composedInset.right, 12.5)
+        XCTAssertEqual(composedInset.top, 10)
+        XCTAssertEqual(composedInset.bottom, 15.0)
+
+        let negativeComposedInset = inset.insetBy(bottom: -5.0).insetBy(horizontal: -5.0)
+        XCTAssertNotEqual(inset, negativeComposedInset)
+        XCTAssertEqual(negativeComposedInset.left, 7.5)
+        XCTAssertEqual(negativeComposedInset.right, 7.5)
+        XCTAssertEqual(negativeComposedInset.top, 10)
+        XCTAssertEqual(negativeComposedInset.bottom, 5.0)
+    }
 }
 
 #endif


### PR DESCRIPTION
This is useful in some situations, for example:

```
  let insets = UIEdgeInsets(top: 10, left: 15, bottom: 20, right: 25)
  view.frame.inset(by: insets.insetBy(bottom: 5))
```
vs

```
  let insets = UIEdgeInsets(top: 10, left: 15, bottom: 20, right: 25)
  let insets2 = UIEdgeInsets(top: insets.top, left: insets.left, bottom: insets.bottom + 5, right: insets.bottom)
  view.frame.inset(by: insets2)
```

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
