### PR TITLE
Add '?=' (ConditionalAssignment) operator to Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added  `insetBy(top:)`, `insetBy(left:)`, `insetBy(bottom:)`, `insetBy(right:)`, `insetBy(horizontal:)` and `insetBy(vertical:)` to creates an `UIEdgeInsets` based on current value and adjusted by given offset. [#532](https://github.com/SwifterSwift/SwifterSwift/pull/532) by [VincentSit](https://github.com/VincentSit).
 - **RangeReplaceableCollection**
   - `init(expression:count:)` to create a collection of a given count initialized with an expression.[#537](https://github.com/SwifterSwift/SwifterSwift/pull/537) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+- **Optional**:
+  - Added `?=` operator to assign to nil optionals only. 
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -74,6 +74,22 @@ public extension Optional {
         lhs = rhs
     }
 
+    /// SwifterSwift: Assign an optional value to a variable only if the variable is nil.
+    ///
+    ///     var someText: String? = nil
+    ///     let newText = "Foo"
+    ///     let defaultText = "Bar"
+    ///     someText ?= newText //someText is now "Foo" because it was nil before
+    ///     someText ?= defaultText //someText doesn't change its value because it's not nil
+    ///
+    /// - Parameters:
+    ///   - lhs: Any?
+    ///   - rhs: Any?
+    public static func ?= (lhs: inout Optional, rhs: @autoclosure () -> Optional) {
+        if lhs == nil {
+            lhs = rhs()
+        }
+    }
 }
 
 // MARK: - Methods (Collection)
@@ -89,3 +105,4 @@ public extension Optional where Wrapped: Collection {
 
 // MARK: - Operators
 infix operator ??= : AssignmentPrecedence
+infix operator ?= : AssignmentPrecedence

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -63,6 +63,24 @@ final class OptionalExtensionsTests: XCTestCase {
 		XCTAssert(parameters[key2] == parameter2)
 	}
 
+    func testConditionalAssignment() {
+        var text1: String?
+        text1 ?= "newText1"
+        XCTAssertEqual(text1, "newText1")
+
+        var text2: String? = "text2"
+        text2 ?= "newText2"
+        XCTAssertEqual(text2, "text2")
+
+        var text3: String?
+        text3 ?= nil
+        XCTAssertEqual(text3, nil)
+
+        var text4: String? = "text4"
+        text4 ?= nil
+        XCTAssertEqual(text4, "text4")
+    }
+
     func testIsNilOrEmpty() {
         let nilArray: [String]? = nil
         XCTAssertTrue(nilArray.isNilOrEmpty)


### PR DESCRIPTION
🚀

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.