### PR TITLE
Performance imporvement in UIView fillToSuperview()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `removeFirst(where:)` array extension now is more generic `RangeReplaceableCollection` extensions. [#516](https://github.com/SwifterSwift/SwifterSwift/pull/516) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **RandomAccessCollection**:
   - `indices(of:)` array extension now is more generic `RandomAccessCollection` extensions. [#516](https://github.com/SwifterSwift/SwifterSwift/pull/516) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+- **UIView**:
+  - `fillToSuperview()` should be more performant. 
 
 ### Fixed
 - **UIImage**:

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -457,10 +457,11 @@ public extension UIView {
 		// https://videos.letsbuildthatapp.com/
 		translatesAutoresizingMaskIntoConstraints = false
 		if let superview = superview {
-			leftAnchor.constraint(equalTo: superview.leftAnchor).isActive = true
-			rightAnchor.constraint(equalTo: superview.rightAnchor).isActive = true
-			topAnchor.constraint(equalTo: superview.topAnchor).isActive = true
-			bottomAnchor.constraint(equalTo: superview.bottomAnchor).isActive = true
+			let left = leftAnchor.constraint(equalTo: superview.leftAnchor)
+			let right = rightAnchor.constraint(equalTo: superview.rightAnchor)
+			let top = topAnchor.constraint(equalTo: superview.topAnchor)
+			let bottom = bottomAnchor.constraint(equalTo: superview.bottomAnchor)
+            NSLayoutConstraint.activate([left, right, top, bottom])
 		}
 	}
 


### PR DESCRIPTION
According to [Apple's documentation](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526955-activate): activating constraints in a bunch is typically more performant than activating them one by one.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.