### PR TITLE
Data extension for converting to a JSON object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `init(expression:count:)` to create a collection of a given count initialized with an expression.[#537](https://github.com/SwifterSwift/SwifterSwift/pull/537) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **Optional**:
   - Added `?=` operator to assign to nil optionals only. [#538](https://github.com/SwifterSwift/SwifterSwift/pull/538) by [viktart](https://github.com/viktart)
+- **Data**:
+  - Added `jsonObject(options:)` to convert a data object into a JSON object. [#542](https://github.com/SwifterSwift/SwifterSwift/pull/542) by [guykogus](https://github.com/guykogus)
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/Sources/Extensions/Foundation/DataExtensions.swift
+++ b/Sources/Extensions/Foundation/DataExtensions.swift
@@ -31,5 +31,16 @@ public extension Data {
 		return String(data: self, encoding: encoding)
 	}
 
+    /// SwifterSwift: Returns a Foundation object from given JSON data.
+    ///
+    /// - Parameter options: Options for reading the JSON data and creating the Foundation object.
+    ///
+    ///   For possible values, see `JSONSerialization.ReadingOptions`.
+    /// - Returns: A Foundation object from the JSON data in the receiver, or `nil` if an error occurs.
+    /// - Throws: An `NSError` if the receiver does not represent a valid JSON object.
+    public func jsonObject(options: JSONSerialization.ReadingOptions = []) throws -> Any {
+        return try JSONSerialization.jsonObject(with: self, options: options)
+    }
+
 }
 #endif

--- a/Tests/FoundationTests/DataExtensionsTests.swift
+++ b/Tests/FoundationTests/DataExtensionsTests.swift
@@ -25,4 +25,24 @@ final class DataExtensionsTests: XCTestCase {
         XCTAssertEqual(bytes?.count, 5)
     }
 
+    func testJsonObject() {
+        let invalidData = "hello".data(using: .utf8)
+        XCTAssertThrowsError(try invalidData?.jsonObject())
+        XCTAssertThrowsError(try invalidData?.jsonObject(options: [.allowFragments]))
+
+        let stringData = "\"hello\"".data(using: .utf8)
+        XCTAssertThrowsError(try stringData?.jsonObject())
+        XCTAssertEqual((try? stringData?.jsonObject(options: [.allowFragments])) as? String, "hello")
+
+        let objectData = "{\"message\": \"hello\"}".data(using: .utf8)
+        let object = (try? objectData?.jsonObject()) as? [String: String]
+        XCTAssertNotNil(object)
+        XCTAssertEqual(object?["message"], "hello")
+
+        let arrayData = "[\"hello\"]".data(using: .utf8)
+        let array = (try? arrayData?.jsonObject()) as? [String]
+        XCTAssertNotNil(array)
+        XCTAssertEqual(array?.first, "hello")
+    }
+
 }


### PR DESCRIPTION
🚀

I've found this extension particularly useful when debugging JSON web responses. If you try and just print out the strings lldb prints them out as one big jumbled line, but if you print out these `jsonObject` responses it's _much_ cleaner.

What do you think about this being added to `String` as well?

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
