### PR TITLE
Fix SwiftLint warnings

### DIFF
--- a/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -139,7 +139,7 @@ public extension UICollectionView {
     ///   - bundleClass: Class in which the Bundle instance will be based on.
     public func register<T: UICollectionViewCell>(nibWithCellClass name: T.Type, at bundleClass: AnyClass? = nil) {
         let identifier = String(describing: name)
-        var bundle: Bundle? = nil
+        var bundle: Bundle?
 
         if let bundleName = bundleClass {
             bundle = Bundle(for: bundleName)

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -164,7 +164,7 @@ public extension UITableView {
     ///   - bundleClass: Class in which the Bundle instance will be based on.
     public func register<T: UITableViewCell>(nibWithCellClass name: T.Type, at bundleClass: AnyClass? = nil) {
         let identifier = String(describing: name)
-        var bundle: Bundle? = nil
+        var bundle: Bundle?
 
         if let bundleName = bundleClass {
             bundle = Bundle(for: bundleName)

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -16,7 +16,7 @@ private enum OptionalTestError: Error {
 final class OptionalExtensionsTests: XCTestCase {
 
 	func testUnwrappedOrDefault() {
-		var str: String? = nil
+		var str: String?
 		XCTAssertEqual(str.unwrapped(or: "swift"), "swift")
 
 		str = "swifterswift"
@@ -32,7 +32,7 @@ final class OptionalExtensionsTests: XCTestCase {
 	}
 
 	func testRunBlock() {
-		var str: String? = nil
+		var str: String?
 		var didRun = false
 		str.run { _ in
 			didRun = true


### PR DESCRIPTION
🚀

Just getting rid of some SwiftLint warnings here, nothing too exciting :)

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
