### PR TITLE
Create mapping functions for Dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `beginRefresh(in tableView:, animated:, sendAction:)` UIRefreshControl extension to begin refresh programatically. [#525](https://github.com/SwifterSwift/SwifterSwift/pull/525) by [ratulSharker](https://github.com/ratulSharker)
 - **Dictionary**:
   - Added `removeValueForRandomKey()` to remove a value for a random key from a dictionary. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
+  - Added `map(_:)` to map a `Dictionary` into a `Dictionary` with different `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
+  - Added `compactMap(_:)` to map a `Dictionary` into a `Dictionary`, excluding `nil` results, with different `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
 - **RangeReplaceableCollection**:
   - Added `removeRandomElement()` to remove a random element from a collection. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
 - **UIView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `beginRefresh(in tableView:, animated:, sendAction:)` UIRefreshControl extension to begin refresh programatically. [#525](https://github.com/SwifterSwift/SwifterSwift/pull/525) by [ratulSharker](https://github.com/ratulSharker)
 - **Dictionary**:
   - Added `removeValueForRandomKey()` to remove a value for a random key from a dictionary. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
-  - Added `map(_:)` to map a `Dictionary` into a `Dictionary` with different `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
-  - Added `compactMap(_:)` to map a `Dictionary` into a `Dictionary`, excluding `nil` results, with different `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
+  - Added `mapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary` with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
+  - Added `compactMapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary`, excluding `nil` results, with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
 - **RangeReplaceableCollection**:
   - Added `removeRandomElement()` to remove a random element from a collection. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
 - **UIView**

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -177,3 +177,20 @@ public extension Dictionary {
     }
 
 }
+
+extension Dictionary {
+    /// SwifterSwift: Returns a dictionary containing the results of mapping the given closure over the sequence’s elements.
+    /// - Parameter transform: A mapping closure. `transform` accepts an element of this sequence as its parameter and returns a transformed value of the same or of a different type.
+    /// - Returns: A dictionary containing the transformed elements of this sequence.
+    func map<K, V>(_ transform: ((key: Key, value: Value)) throws -> (K, V)) rethrows -> [K: V] {
+        return [K: V](uniqueKeysWithValues: try map(transform))
+    }
+
+    /// SwifterSwift: Returns a dictionary containing the non-`nil` results of calling the given transformation with each element of this sequence.
+    /// - Parameter transform: A closure that accepts an element of this sequence as its argument and returns an optional value.
+    /// - Returns: A dictionary of the non-`nil` results of calling `transform` with each element of the sequence.
+    /// - Complexity: *O(m + n)*, where _m_ is the length of this sequence and _n_ is the length of the result.
+    func compactMap<K, V>(_ transform: ((key: Key, value: Value)) throws -> (K, V)?) rethrows -> [K: V] {
+        return [K: V](uniqueKeysWithValues: try compactMap(transform))
+    }
+}

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -182,7 +182,7 @@ extension Dictionary {
     /// SwifterSwift: Returns a dictionary containing the results of mapping the given closure over the sequence’s elements.
     /// - Parameter transform: A mapping closure. `transform` accepts an element of this sequence as its parameter and returns a transformed value of the same or of a different type.
     /// - Returns: A dictionary containing the transformed elements of this sequence.
-    func map<K, V>(_ transform: ((key: Key, value: Value)) throws -> (K, V)) rethrows -> [K: V] {
+    func mapKeysAndValues<K, V>(_ transform: ((key: Key, value: Value)) throws -> (K, V)) rethrows -> [K: V] {
         return [K: V](uniqueKeysWithValues: try map(transform))
     }
 
@@ -190,7 +190,7 @@ extension Dictionary {
     /// - Parameter transform: A closure that accepts an element of this sequence as its argument and returns an optional value.
     /// - Returns: A dictionary of the non-`nil` results of calling `transform` with each element of the sequence.
     /// - Complexity: *O(m + n)*, where _m_ is the length of this sequence and _n_ is the length of the result.
-    func compactMap<K, V>(_ transform: ((key: Key, value: Value)) throws -> (K, V)?) rethrows -> [K: V] {
+    func compactMapKeysAndValues<K, V>(_ transform: ((key: Key, value: Value)) throws -> (K, V)?) rethrows -> [K: V] {
         return [K: V](uniqueKeysWithValues: try compactMap(transform))
     }
 }

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -102,17 +102,17 @@ final class DictionaryExtensionsTests: XCTestCase {
         XCTAssertFalse(dict.keys.contains("key2"))
     }
 
-    func testMap() {
+    func testMapKeysAndValues() {
         let intToString = [0: "0", 1: "1", 2: "2", 3: "3", 4: "4", 5: "5", 6: "6", 7: "7", 8: "8", 9: "9"]
 
-        let stringToInt: [String: Int] = intToString.map { (key, value) in
+        let stringToInt: [String: Int] = intToString.mapKeysAndValues { (key, value) in
             return (String(describing: key), Int(value)!)
         }
 
         XCTAssertEqual(stringToInt, ["0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9])
     }
 
-    func testCompactMap() {
+    func testCompactMapKeysAndValues() {
         // swiftlint:disable:next nesting
         enum IntWord: String {
             case zero
@@ -126,7 +126,7 @@ final class DictionaryExtensionsTests: XCTestCase {
             2: "two",
             3: "three"
         ]
-        let words: [String: IntWord] = strings.compactMap { (key, value) in
+        let words: [String: IntWord] = strings.compactMapKeysAndValues { (key, value) in
             guard let word = IntWord(rawValue: value) else { return nil }
             return (String(describing: key), word)
         }

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -102,4 +102,36 @@ final class DictionaryExtensionsTests: XCTestCase {
         XCTAssertFalse(dict.keys.contains("key2"))
     }
 
+    func testMap() {
+        let intToString = [0: "0", 1: "1", 2: "2", 3: "3", 4: "4", 5: "5", 6: "6", 7: "7", 8: "8", 9: "9"]
+
+        let stringToInt: [String: Int] = intToString.map { (key, value) in
+            return (String(describing: key), Int(value)!)
+        }
+
+        XCTAssertEqual(stringToInt, ["0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9])
+    }
+
+    func testCompactMap() {
+        // swiftlint:disable:next nesting
+        enum IntWord: String {
+            case zero
+            case one
+            case two
+        }
+
+        let strings = [
+            0: "zero",
+            1: "one",
+            2: "two",
+            3: "three"
+        ]
+        let words: [String: IntWord] = strings.compactMap { (key, value) in
+            guard let word = IntWord(rawValue: value) else { return nil }
+            return (String(describing: key), word)
+        }
+
+        XCTAssertEqual(words, ["0": .zero, "1": .one, "2": .two])
+    }
+
 }


### PR DESCRIPTION
🚀

These versions of `map` and `compactMap` return a `Dictionary`, rather than an `Array`.
I'm a bit unsure of the function names because of the clash with the built-in `map` and `compactMap` functions.

------------------------------------------------

`map` seems to prioritise the new function. E.g. in
```Swift
let intToString = [0: "0", 1: "1", 2: "2"]
let stringToInt = intToString.map { (key, value) in
    return (String(describing: key), Int(value)!)
}
```
`stringToInt ` is of type `[String: Int]`. If you want it to return `[(String, Int)]`, as the original function would do, you need to define the type explicitly. I.e.
```Swift
let stringToInt: [(String, Int)] = intToString.map { (key, value) in
```

------------------------------------------------

`compactMap` actually won't compile in a similar situation because it prioritises the built-in function. E.g.
```Swift
let stringToInt = intToString.compactMap { (key, value) in
    guard let intValue = Int(value) else { return nil }
    return (String(describing: key), intValue)
}
```
will throw a compilation error because it thinks that the the closure passed to `compactMap` should contain a single argument, it won't accept a tuple. You need to explicitly define it as
```Swift
let stringToInt: [String: Int] = intToString.compactMap { (key, value) in
// or
let stringToInt = intToString.compactMap { (key, value) -> (String, Int)? in
```
in order for it to compile and use the new function.

To use the original function you again need to explicitly define the type. I.e.
```Swift
let words: [(String, IntWord)] = strings.compactMap { (key, value) in
```

What do you guys think, should we rename the functions? What names sound good to you?

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.