### PR TITLE
Add `rotated(by:)` functions to `UIImage` for generating rotated images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `?=` operator to assign to nil optionals only. [#538](https://github.com/SwifterSwift/SwifterSwift/pull/538) by [viktart](https://github.com/viktart)
 - **Data**:
   - Added `jsonObject(options:)` to convert a data object into a JSON object. [#542](https://github.com/SwifterSwift/SwifterSwift/pull/542) by [guykogus](https://github.com/guykogus)
-
 - **URL**
   - Added `droppedScheme()` which returns new `URL` that does not have scheme. [#528](https://github.com/SwifterSwift/SwifterSwift/pull/528) by [sammy-sc](https://github.com/sammy-SC)
 - **CGSize**
@@ -44,6 +43,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added operator `CGSize * CGFloat` and `CGFloat * CGSize` to return the multiplication of a CGSize and a CGFloat value.
   - Added operator `CGSize *= CGSize` to multiply a CGSize with another one.
   - Added operator `CGSize *= CGFloat` to multiply a CGSize with a CGFloat value.
+- **UIImage**:
+  - Added `rotate(by:)` for generating rotated versions of images. There are 2 versions, one where the angle is passed directly as a `CGFloat` in radians, the other using the `Measurement` class, which is only available for iOS 10+. [#555](https://github.com/SwifterSwift/SwifterSwift/pull/555) by [guykogus](https://github.com/guykogus)
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added operator `CGSize *= CGSize` to multiply a CGSize with another one.
   - Added operator `CGSize *= CGFloat` to multiply a CGSize with a CGFloat value.
 - **UIImage**:
-  - Added `rotate(by:)` for generating rotated versions of images. There are 2 versions, one where the angle is passed directly as a `CGFloat` in radians, the other using the `Measurement` class, which is only available for iOS 10+. [#555](https://github.com/SwifterSwift/SwifterSwift/pull/555) by [guykogus](https://github.com/guykogus)
+  - Added `rotate(by:)` for generating rotated versions of images. There are 2 versions, one where the angle is passed directly as a `CGFloat` in radians, the other using the `Measurement` class, which is only available for iOS 10+/tvOS 10+/watchOS 3+. [#555](https://github.com/SwifterSwift/SwifterSwift/pull/555) by [guykogus](https://github.com/guykogus)
 
 ### Changed
 - **RangeReplaceableCollection**:

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -96,7 +96,7 @@ public extension UIImage {
 		return newImage
 	}
 
-	/// Creates a copy of the receiver rotated by the given angle.
+    /// SwifterSwift: Creates a copy of the receiver rotated by the given angle.
 	///
 	///     // Rotate the image by 180°
 	///     image.rotated(by: Measurement(value: 180, unit: .degrees))
@@ -129,7 +129,7 @@ public extension UIImage {
 		return newImage
 	}
 
-	/// Creates a copy of the receiver rotated by the given angle (in radians).
+	/// SwifterSwift: Creates a copy of the receiver rotated by the given angle (in radians).
 	///
 	///     // Rotate the image by 180°
 	///     image.rotated(by: .pi)

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -103,7 +103,7 @@ public extension UIImage {
 	///
 	/// - Parameter angle: The angle measurement by which to rotate the image.
 	/// - Returns: A new image rotated by the given angle.
-	@available(iOS 10.0, *)
+	@available(iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 	public func rotated(by angle: Measurement<UnitAngle>) -> UIImage? {
 		let radians = CGFloat(angle.converted(to: .radians).value)
 

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -96,68 +96,68 @@ public extension UIImage {
 		return newImage
 	}
 
-    /// Creates a copy of the receiver rotated by the given angle.
-    ///
-    ///     // Rotate the image by 180°
-    ///     image.rotated(by: Measurement(value: 180, unit: .degrees))
-    ///
-    /// - Parameter angle: The angle measurement by which to rotate the image.
-    /// - Returns: A new image rotated by the given angle.
-    @available(iOS 10.0, *)
-    public func rotated(by angle: Measurement<UnitAngle>) -> UIImage? {
-        let radians = CGFloat(angle.converted(to: .radians).value)
+	/// Creates a copy of the receiver rotated by the given angle.
+	///
+	///     // Rotate the image by 180°
+	///     image.rotated(by: Measurement(value: 180, unit: .degrees))
+	///
+	/// - Parameter angle: The angle measurement by which to rotate the image.
+	/// - Returns: A new image rotated by the given angle.
+	@available(iOS 10.0, *)
+	public func rotated(by angle: Measurement<UnitAngle>) -> UIImage? {
+		let radians = CGFloat(angle.converted(to: .radians).value)
 
-        let destRect = CGRect(origin: .zero, size: size)
-            .applying(CGAffineTransform(rotationAngle: radians))
-        let roundedDestRect = CGRect(x: destRect.origin.x.rounded(),
-                                     y: destRect.origin.y.rounded(),
-                                     width: destRect.width.rounded(),
-                                     height: destRect.height.rounded())
+		let destRect = CGRect(origin: .zero, size: size)
+			.applying(CGAffineTransform(rotationAngle: radians))
+		let roundedDestRect = CGRect(x: destRect.origin.x.rounded(),
+									 y: destRect.origin.y.rounded(),
+									 width: destRect.width.rounded(),
+									 height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContext(roundedDestRect.size)
-        guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
+		UIGraphicsBeginImageContext(roundedDestRect.size)
+		guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
-        contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
-        contextRef.rotate(by: radians)
+		contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
+		contextRef.rotate(by: radians)
 
-        draw(in: CGRect(origin: CGPoint(x: -size.width / 2,
-                                        y: -size.height / 2),
-                        size: size))
+		draw(in: CGRect(origin: CGPoint(x: -size.width / 2,
+										y: -size.height / 2),
+						size: size))
 
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return newImage
-    }
+		let newImage = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		return newImage
+	}
 
-    /// Creates a copy of the receiver rotated by the given angle (in radians).
-    ///
-    ///     // Rotate the image by 180°
-    ///     image.rotated(by: .pi)
-    ///
-    /// - Parameter radians: The angle, in radians, by which to rotate the image.
-    /// - Returns: A new image rotated by the given angle.
-    public func rotated(by radians: CGFloat) -> UIImage? {
-        let destRect = CGRect(origin: .zero, size: size)
-            .applying(CGAffineTransform(rotationAngle: radians))
-        let roundedDestRect = CGRect(x: destRect.origin.x.rounded(),
-                                     y: destRect.origin.y.rounded(),
-                                     width: destRect.width.rounded(),
-                                     height: destRect.height.rounded())
+	/// Creates a copy of the receiver rotated by the given angle (in radians).
+	///
+	///     // Rotate the image by 180°
+	///     image.rotated(by: .pi)
+	///
+	/// - Parameter radians: The angle, in radians, by which to rotate the image.
+	/// - Returns: A new image rotated by the given angle.
+	public func rotated(by radians: CGFloat) -> UIImage? {
+		let destRect = CGRect(origin: .zero, size: size)
+			.applying(CGAffineTransform(rotationAngle: radians))
+		let roundedDestRect = CGRect(x: destRect.origin.x.rounded(),
+									 y: destRect.origin.y.rounded(),
+									 width: destRect.width.rounded(),
+									 height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContext(roundedDestRect.size)
-        guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
+		UIGraphicsBeginImageContext(roundedDestRect.size)
+		guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
-        contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
-        contextRef.rotate(by: radians)
+		contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
+		contextRef.rotate(by: radians)
 
-        draw(in: CGRect(origin: CGPoint(x: -size.width / 2,
-                                        y: -size.height / 2),
-                        size: size))
+		draw(in: CGRect(origin: CGPoint(x: -size.width / 2,
+										y: -size.height / 2),
+						size: size))
 
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return newImage
-    }
+		let newImage = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		return newImage
+	}
 
 	/// SwifterSwift: UIImage filled with color
 	///

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -96,6 +96,69 @@ public extension UIImage {
 		return newImage
 	}
 
+    /// Creates a copy of the receiver rotated by the given angle.
+    ///
+    ///     // Rotate the image by 180°
+    ///     image.rotated(by: Measurement(value: 180, unit: .degrees))
+    ///
+    /// - Parameter angle: The angle measurement by which to rotate the image.
+    /// - Returns: A new image rotated by the given angle.
+    @available(iOS 10.0, *)
+    public func rotated(by angle: Measurement<UnitAngle>) -> UIImage? {
+        let radians = CGFloat(angle.converted(to: .radians).value)
+
+        let destRect = CGRect(origin: .zero, size: size)
+            .applying(CGAffineTransform(rotationAngle: radians))
+        let roundedDestRect = CGRect(x: destRect.origin.x.rounded(),
+                                     y: destRect.origin.y.rounded(),
+                                     width: destRect.width.rounded(),
+                                     height: destRect.height.rounded())
+
+        UIGraphicsBeginImageContext(roundedDestRect.size)
+        guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
+
+        contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
+        contextRef.rotate(by: radians)
+
+        draw(in: CGRect(origin: CGPoint(x: -size.width / 2,
+                                        y: -size.height / 2),
+                        size: size))
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage
+    }
+
+    /// Creates a copy of the receiver rotated by the given angle (in radians).
+    ///
+    ///     // Rotate the image by 180°
+    ///     image.rotated(by: .pi)
+    ///
+    /// - Parameter radians: The angle, in radians, by which to rotate the image.
+    /// - Returns: A new image rotated by the given angle.
+    public func rotated(by radians: CGFloat) -> UIImage? {
+        let destRect = CGRect(origin: .zero, size: size)
+            .applying(CGAffineTransform(rotationAngle: radians))
+        let roundedDestRect = CGRect(x: destRect.origin.x.rounded(),
+                                     y: destRect.origin.y.rounded(),
+                                     width: destRect.width.rounded(),
+                                     height: destRect.height.rounded())
+
+        UIGraphicsBeginImageContext(roundedDestRect.size)
+        guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
+
+        contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
+        contextRef.rotate(by: radians)
+
+        draw(in: CGRect(origin: CGPoint(x: -size.width / 2,
+                                        y: -size.height / 2),
+                        size: size))
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage
+    }
+
 	/// SwifterSwift: UIImage filled with color
 	///
 	/// - Parameter color: color to fill image with.

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -72,7 +72,7 @@ final class UIImageExtensionsTests: XCTestCase {
 		XCTAssertEqual(scaledImage!.size.width, 300, accuracy: 0.1)
 	}
 
-	@available(iOS 10.0, *)
+	@available(iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 	func testRotatedByMeasurement() {
 		let bundle = Bundle.init(for: UIImageExtensionsTests.self)
 		let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -72,34 +72,34 @@ final class UIImageExtensionsTests: XCTestCase {
 		XCTAssertEqual(scaledImage!.size.width, 300, accuracy: 0.1)
 	}
 
-    @available(iOS 10.0, *)
-    func testRotatedByMeasurement() {
-        let bundle = Bundle.init(for: UIImageExtensionsTests.self)
-        let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
+	@available(iOS 10.0, *)
+	func testRotatedByMeasurement() {
+		let bundle = Bundle.init(for: UIImageExtensionsTests.self)
+		let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
 
-        let halfRotatedImage = image.rotated(by: Measurement(value: 90, unit: .degrees))
-        XCTAssertNotNil(halfRotatedImage)
-        XCTAssertEqual(halfRotatedImage!.size, CGSize(width: image.size.height, height: image.size.width))
+		let halfRotatedImage = image.rotated(by: Measurement(value: 90, unit: .degrees))
+		XCTAssertNotNil(halfRotatedImage)
+		XCTAssertEqual(halfRotatedImage!.size, CGSize(width: image.size.height, height: image.size.width))
 
-        let rotatedImage = image.rotated(by: Measurement(value: 180, unit: .degrees))
-        XCTAssertNotNil(rotatedImage)
-        XCTAssertEqual(rotatedImage!.size, image.size)
-        XCTAssertNotEqual(UIImageJPEGRepresentation(image, 1), UIImageJPEGRepresentation(rotatedImage!, 1))
-    }
+		let rotatedImage = image.rotated(by: Measurement(value: 180, unit: .degrees))
+		XCTAssertNotNil(rotatedImage)
+		XCTAssertEqual(rotatedImage!.size, image.size)
+		XCTAssertNotEqual(UIImageJPEGRepresentation(image, 1), UIImageJPEGRepresentation(rotatedImage!, 1))
+	}
 
-    func testRotatedByRadians() {
-        let bundle = Bundle.init(for: UIImageExtensionsTests.self)
-        let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
+	func testRotatedByRadians() {
+		let bundle = Bundle.init(for: UIImageExtensionsTests.self)
+		let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
 
-        let halfRotatedImage = image.rotated(by: .pi / 2)
-        XCTAssertNotNil(halfRotatedImage)
-        XCTAssertEqual(halfRotatedImage!.size, CGSize(width: image.size.height, height: image.size.width))
+		let halfRotatedImage = image.rotated(by: .pi / 2)
+		XCTAssertNotNil(halfRotatedImage)
+		XCTAssertEqual(halfRotatedImage!.size, CGSize(width: image.size.height, height: image.size.width))
 
-        let rotatedImage = image.rotated(by: .pi)
-        XCTAssertNotNil(rotatedImage)
-        XCTAssertEqual(rotatedImage!.size, image.size)
-        XCTAssertNotEqual(UIImageJPEGRepresentation(image, 1), UIImageJPEGRepresentation(rotatedImage!, 1))
-    }
+		let rotatedImage = image.rotated(by: .pi)
+		XCTAssertNotNil(rotatedImage)
+		XCTAssertEqual(rotatedImage!.size, image.size)
+		XCTAssertNotEqual(UIImageJPEGRepresentation(image, 1), UIImageJPEGRepresentation(rotatedImage!, 1))
+	}
 
 	func testFilled() {
 		let image = UIImage(color: .black, size: CGSize(width: 20, height: 20))

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -72,6 +72,35 @@ final class UIImageExtensionsTests: XCTestCase {
 		XCTAssertEqual(scaledImage!.size.width, 300, accuracy: 0.1)
 	}
 
+    @available(iOS 10.0, *)
+    func testRotatedByMeasurement() {
+        let bundle = Bundle.init(for: UIImageExtensionsTests.self)
+        let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
+
+        let halfRotatedImage = image.rotated(by: Measurement(value: 90, unit: .degrees))
+        XCTAssertNotNil(halfRotatedImage)
+        XCTAssertEqual(halfRotatedImage!.size, CGSize(width: image.size.height, height: image.size.width))
+
+        let rotatedImage = image.rotated(by: Measurement(value: 180, unit: .degrees))
+        XCTAssertNotNil(rotatedImage)
+        XCTAssertEqual(rotatedImage!.size, image.size)
+        XCTAssertNotEqual(UIImageJPEGRepresentation(image, 1), UIImageJPEGRepresentation(rotatedImage!, 1))
+    }
+
+    func testRotatedByRadians() {
+        let bundle = Bundle.init(for: UIImageExtensionsTests.self)
+        let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
+
+        let halfRotatedImage = image.rotated(by: .pi / 2)
+        XCTAssertNotNil(halfRotatedImage)
+        XCTAssertEqual(halfRotatedImage!.size, CGSize(width: image.size.height, height: image.size.width))
+
+        let rotatedImage = image.rotated(by: .pi)
+        XCTAssertNotNil(rotatedImage)
+        XCTAssertEqual(rotatedImage!.size, image.size)
+        XCTAssertNotEqual(UIImageJPEGRepresentation(image, 1), UIImageJPEGRepresentation(rotatedImage!, 1))
+    }
+
 	func testFilled() {
 		let image = UIImage(color: .black, size: CGSize(width: 20, height: 20))
 		let image2 = UIImage(color: .yellow, size: CGSize(width: 20, height: 20))


### PR DESCRIPTION
🚀

There are 2 versions, one where the angle is passed directly as a `CGFloat` in radians, the other using the `Measurement` class, which is only available for iOS 10+.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.