### PR TITLE
Prevent UIAlertController from crashing when displayed on the iPad.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `indices(of:)` array extension now is more generic `RandomAccessCollection` extensions. [#516](https://github.com/SwifterSwift/SwifterSwift/pull/516) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **UIView**:
   - Improved performance in `fillToSuperview()` UIView extension. [#540](https://github.com/SwifterSwift/SwifterSwift/pull/540) by [viktart](https://github.com/viktart)
+- **UIAlertController**:
+  - `show(animated:vibrate:completion:)` now have some optional parameters to control the display on iPad.  [#556](https://github.com/SwifterSwift/SwifterSwift/pull/556) by [VincentSit](https://github.com/VincentSit).
 
 ### Fixed
 - **UIImage**:
@@ -60,6 +62,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **String**:
   - Used [RFC 5322](http://emailregex.com/) in `isValidEmail`, an email address regex that 99.99% works. [#517](https://github.com/SwifterSwift/SwifterSwift/pull/517) by [Omar Albeik](https://github.com/omaralbeik)
   - Fixed `unicodeArray()` not returning the correct unicode value due to Swift 4.2 new hashing system. [#544](https://github.com/SwifterSwift/SwifterSwift/pull/544) by [Omar Albeik](https://github.com/omaralbeik)
+- **UIAlertController**:
+  - Fixed the UIAlertController with `actionSheet` type call  `show(animated:vibrate:completion:)`  will crash on iPad.  [#556](https://github.com/SwifterSwift/SwifterSwift/pull/556) by [VincentSit](https://github.com/VincentSit).
 
 ### Deprecated
 - **String**:
@@ -1251,3 +1255,5 @@ DateExtensions:
 
 UIViewExtensions:
 - **shake**: Completion handler added to shake function
+
+

--- a/Sources/Extensions/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIAlertControllerExtensions.swift
@@ -17,20 +17,74 @@ import AudioToolbox
 // MARK: - Methodss
 public extension UIAlertController {
 
-	/// SwifterSwift: Present alert view controller in the current view controller.
-	///
-	/// - Parameters:
-	///   - animated: set true to animate presentation of alert controller (default is true).
-	///   - vibrate: set true to vibrate the device while presenting the alert (default is false).
-	///   - completion: an optional completion handler to be called after presenting alert controller (default is nil).
-	public func show(animated: Bool = true, vibrate: Bool = false, completion: (() -> Void)? = nil) {
-		UIApplication.shared.keyWindow?.rootViewController?.present(self, animated: animated, completion: completion)
-		if vibrate {
-			#if canImport(AudioToolbox)
-			AudioServicesPlayAlertSound(kSystemSoundID_Vibrate)
-			#endif
-		}
-	}
+  // swiftlint:disable next cyclomatic_complexity
+  /// SwifterSwift: Present alert view controller.
+  ///
+  /// - Parameters:
+  ///   - viewController: a custom view controller to be presented (default is the rootViewController of application's key window).
+  ///   - anchor: specify the anchor for the popover’s arrow points to (default is nil).
+  ///   - arrowDirection: specify the permitted arrow directions for the popover (default is UIPopoverArrowDirection.any).
+  ///   - animated: set true to animate presentation of alert controller (default is true).
+  ///   - vibrate: set true to vibrate the device while presenting the alert (default is false).
+  ///   - completion: an optional completion handler to be called after presenting alert controller (default is nil).
+  public func show(in viewController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController, anchor: AnyObject? = nil, arrowDirection: UIPopoverArrowDirection = .any, animated: Bool = true, vibrate: Bool = false, completion: (() -> Void)? = nil) {
+    // https://github.com/steipete/PSTAlertController/blob/master/PSTAlertController/PSTAlertController.m#L278
+    // We absolutely need a controller going forward.
+    guard var viewController = viewController else {
+      assertionFailure("Can't show alert because there is no root view controller.")
+      return
+    }
+
+    // Use the frontmost viewController for presentation.
+    while let frontViewController = viewController.presentedViewController, !frontViewController.isBeingDismissed {
+      viewController = frontViewController
+    }
+
+    // If it has already been set, we should not overwrite it. Will do nothing on iPhone since the popover is nil.
+    if let popover = popoverPresentationController, popover.sourceView == nil, popover.barButtonItem == nil {
+      switch anchor {
+      case let value as UIBarButtonItem:
+        popover.barButtonItem = value
+      case let value as UIView:
+        popover.sourceView = value
+        popover.sourceRect = value.bounds
+      case let value as NSValue:
+        popover.sourceView = viewController.view
+        popover.sourceRect = value.cgRectValue
+      default:
+        popover.sourceView = viewController.view
+        popover.sourceRect = viewController.view.bounds
+      }
+
+      // Workaround for rdar://18921595. Unsatisfiable constraints when presenting UIAlertController.
+      // If the rect is too large, the action sheet can't be displayed.
+      let sourceRect: CGRect = popover.sourceRect
+      let screen: CGRect = UIScreen.main.bounds
+      if sourceRect.height > screen.height * 0.5 || sourceRect.width > screen.width * 0.5 {
+        popover.sourceRect = CGRect(x: sourceRect.origin.x + sourceRect.width / 2.0, y: sourceRect.origin.y + sourceRect.height / 2.0, width: 1.0, height: 1.0)
+      }
+
+      // Optimize arrow positioning for up and down.
+      popover.permittedArrowDirections = arrowDirection
+      switch arrowDirection {
+      case .down:
+        popover.sourceRect = CGRect(x: sourceRect.origin.x + sourceRect.size.width / 2.0, y: sourceRect.origin.y, width: 1.0, height: 1.0)
+      case .up:
+        popover.sourceRect = CGRect(x: sourceRect.origin.x + sourceRect.size.width / 2.0, y: sourceRect.origin.y + sourceRect.size.height, width: 1.0, height: 1.0)
+      // Left and right is too buggy.
+      default:
+        break
+      }
+    }
+
+    viewController.present(self, animated: animated, completion: completion)
+
+    if vibrate {
+      #if canImport(AudioToolbox)
+      AudioServicesPlayAlertSound(kSystemSoundID_Vibrate)
+      #endif
+    }
+  }
 
 	/// SwifterSwift: Add an action to Alert
 	///

--- a/Sources/Extensions/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIAlertControllerExtensions.swift
@@ -17,7 +17,6 @@ import AudioToolbox
 // MARK: - Methodss
 public extension UIAlertController {
 
-  // swiftlint:disable next cyclomatic_complexity
   /// SwifterSwift: Present alert view controller.
   ///
   /// - Parameters:
@@ -36,12 +35,17 @@ public extension UIAlertController {
     }
 
     // Use the frontmost viewController for presentation.
-    while let frontViewController = viewController.presentedViewController, !frontViewController.isBeingDismissed {
-      viewController = frontViewController
+    while let frontViewController = viewController.presentedViewController,
+      !frontViewController.isBeingDismissed {
+        viewController = frontViewController
     }
 
-    // If it has already been set, we should not overwrite it. Will do nothing on iPhone since the popover is nil.
-    if let popover = popoverPresentationController, popover.sourceView == nil, popover.barButtonItem == nil {
+    // iPad popover support. It is only necessary in type actionSheet. Will do nothing on iPhone since the popover is nil.
+    // If it has already been set, we should not overwrite it.
+    if preferredStyle == .actionSheet,
+      let popover = popoverPresentationController,
+      popover.sourceView == nil,
+      popover.barButtonItem == nil {
       switch anchor {
       case let value as UIBarButtonItem:
         popover.barButtonItem = value
@@ -58,23 +62,13 @@ public extension UIAlertController {
 
       // Workaround for rdar://18921595. Unsatisfiable constraints when presenting UIAlertController.
       // If the rect is too large, the action sheet can't be displayed.
-      let sourceRect: CGRect = popover.sourceRect
-      let screen: CGRect = UIScreen.main.bounds
+      let sourceRect = popover.sourceRect
+      let screen = UIScreen.main.bounds
       if sourceRect.height > screen.height * 0.5 || sourceRect.width > screen.width * 0.5 {
         popover.sourceRect = CGRect(x: sourceRect.origin.x + sourceRect.width / 2.0, y: sourceRect.origin.y + sourceRect.height / 2.0, width: 1.0, height: 1.0)
       }
 
-      // Optimize arrow positioning for up and down.
       popover.permittedArrowDirections = arrowDirection
-      switch arrowDirection {
-      case .down:
-        popover.sourceRect = CGRect(x: sourceRect.origin.x + sourceRect.size.width / 2.0, y: sourceRect.origin.y, width: 1.0, height: 1.0)
-      case .up:
-        popover.sourceRect = CGRect(x: sourceRect.origin.x + sourceRect.size.width / 2.0, y: sourceRect.origin.y + sourceRect.size.height, width: 1.0, height: 1.0)
-      // Left and right is too buggy.
-      default:
-        break
-      }
     }
 
     viewController.present(self, animated: animated, completion: completion)


### PR DESCRIPTION
UIAlertController with `actionSheet` type will crash on iPad because the `popoverPresentationController` is not properly configured in `show(animated:vibrate:completion:)`.

This PR fixes the problem and adds some optional parameters that allow the user to control how it looks on the iPad.

No tests were added because there is no UIApplication to display.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
