### PR TITLE
Add addition operator to `UIEdgeInsets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeViewAndControllerFromParentViewController()` to remove a `UIViewController` from its parent.
 - **UIEdgeInsets**
   - Added  `insetBy(top:)`, `insetBy(left:)`, `insetBy(bottom:)`, `insetBy(right:)`, `insetBy(horizontal:)` and `insetBy(vertical:)` to creates an `UIEdgeInsets` based on current value and adjusted by given offset. [#532](https://github.com/SwifterSwift/SwifterSwift/pull/532) by [VincentSit](https://github.com/VincentSit).
+  - Added `func +(_:,_:)` to add two insets together in order to extend them. [#557](https://github.com/SwifterSwift/SwifterSwift/pull/557) by [guykogus](https://github.com/guykogus)
 - **RangeReplaceableCollection**
   - `init(expression:count:)` to create a collection of a given count initialized with an expression.[#537](https://github.com/SwifterSwift/SwifterSwift/pull/537) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **Optional**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeViewAndControllerFromParentViewController()` to remove a `UIViewController` from its parent.
 - **UIEdgeInsets**
   - Added  `insetBy(top:)`, `insetBy(left:)`, `insetBy(bottom:)`, `insetBy(right:)`, `insetBy(horizontal:)` and `insetBy(vertical:)` to creates an `UIEdgeInsets` based on current value and adjusted by given offset. [#532](https://github.com/SwifterSwift/SwifterSwift/pull/532) by [VincentSit](https://github.com/VincentSit).
-  - Added `func +(_:,_:)` to add two insets together in order to extend them. [#557](https://github.com/SwifterSwift/SwifterSwift/pull/557) by [guykogus](https://github.com/guykogus)
+  - Added operators `+` and `+=` to add two insets together in order to extend them. [#557](https://github.com/SwifterSwift/SwifterSwift/pull/557) by [guykogus](https://github.com/guykogus)
 - **RangeReplaceableCollection**
   - `init(expression:count:)` to create a collection of a given count initialized with an expression.[#537](https://github.com/SwifterSwift/SwifterSwift/pull/537) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 - **Optional**:

--- a/Sources/Extensions/UIKit/UIEdgeInsetsExtensions.swift
+++ b/Sources/Extensions/UIKit/UIEdgeInsetsExtensions.swift
@@ -116,6 +116,18 @@ extension UIEdgeInsets {
                             right: lhs.right + rhs.right)
     }
 
+    /// SwifterSwift: Add all the properties of two `UIEdgeInsets` to the left-hand instance.
+    ///
+    /// - Parameters:
+    ///   - lhs: The left-hand expression to be mutated
+    ///   - rhs: The right-hand expression
+    public static func += (_ lhs: inout UIEdgeInsets, _ rhs: UIEdgeInsets) {
+        lhs.top += rhs.top
+        lhs.left += rhs.left
+        lhs.bottom += rhs.bottom
+        lhs.right += rhs.right
+    }
+
 }
 
 #endif

--- a/Sources/Extensions/UIKit/UIEdgeInsetsExtensions.swift
+++ b/Sources/Extensions/UIKit/UIEdgeInsetsExtensions.swift
@@ -99,4 +99,23 @@ extension UIEdgeInsets {
 		return UIEdgeInsets(top: top + vertical/2, left: left, bottom: bottom + vertical/2, right: right)
 	}
 }
+
+// MARK: - Operators
+extension UIEdgeInsets {
+
+    /// SwifterSwift: Add all the properties of two `UIEdgeInsets` to create their addition.
+    ///
+    /// - Parameters:
+    ///   - lhs: The left-hand expression
+    ///   - rhs: The right-hand expression
+    /// - Returns: A new `UIEdgeInsets` instance where the values of `lhs` and `rhs` are added together.
+    public static func + (_ lhs: UIEdgeInsets, _ rhs: UIEdgeInsets) -> UIEdgeInsets {
+        return UIEdgeInsets(top: lhs.top + rhs.top,
+                            left: lhs.left + rhs.left,
+                            bottom: lhs.bottom + rhs.bottom,
+                            right: lhs.right + rhs.right)
+    }
+
+}
+
 #endif

--- a/Tests/UIKitTests/UIEdgeInsetsExtensionsTests.swift
+++ b/Tests/UIKitTests/UIEdgeInsetsExtensionsTests.swift
@@ -158,5 +158,19 @@ final class UIEdgeInsetsExtensionsTests: XCTestCase {
 		XCTAssertEqual(negativeComposedInset.top, 10)
 		XCTAssertEqual(negativeComposedInset.bottom, 5.0)
 	}
+
+    func testAddition() {
+        XCTAssertEqual(UIEdgeInsets.zero + UIEdgeInsets.zero, UIEdgeInsets.zero)
+
+        let inset1 = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+        let inset2 = UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
+        let expected = UIEdgeInsets(top: 6, left: 8, bottom: 10, right: 12)
+        XCTAssertEqual(inset1 + inset2, expected)
+
+        let negativeInset1 = UIEdgeInsets(top: -1, left: -2, bottom: -3, right: -4)
+        let negativeInset2 = UIEdgeInsets(top: -5, left: -6, bottom: -7, right: -8)
+        let negativeExpected = UIEdgeInsets(top: -6, left: -8, bottom: -10, right: -12)
+        XCTAssertEqual(negativeInset1 + negativeInset2, negativeExpected)
+    }
 }
 #endif

--- a/Tests/UIKitTests/UIEdgeInsetsExtensionsTests.swift
+++ b/Tests/UIKitTests/UIEdgeInsetsExtensionsTests.swift
@@ -162,15 +162,31 @@ final class UIEdgeInsetsExtensionsTests: XCTestCase {
     func testAddition() {
         XCTAssertEqual(UIEdgeInsets.zero + UIEdgeInsets.zero, UIEdgeInsets.zero)
 
-        let inset1 = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
-        let inset2 = UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
+        let insets1 = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+        let insets2 = UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
         let expected = UIEdgeInsets(top: 6, left: 8, bottom: 10, right: 12)
-        XCTAssertEqual(inset1 + inset2, expected)
+        XCTAssertEqual(insets1 + insets2, expected)
 
-        let negativeInset1 = UIEdgeInsets(top: -1, left: -2, bottom: -3, right: -4)
-        let negativeInset2 = UIEdgeInsets(top: -5, left: -6, bottom: -7, right: -8)
+        let negativeInsets1 = UIEdgeInsets(top: -1, left: -2, bottom: -3, right: -4)
+        let negativeInsets2 = UIEdgeInsets(top: -5, left: -6, bottom: -7, right: -8)
         let negativeExpected = UIEdgeInsets(top: -6, left: -8, bottom: -10, right: -12)
-        XCTAssertEqual(negativeInset1 + negativeInset2, negativeExpected)
+        XCTAssertEqual(negativeInsets1 + negativeInsets2, negativeExpected)
+    }
+
+    func testInPlaceAddition() {
+        var zero = UIEdgeInsets.zero
+        zero += UIEdgeInsets.zero
+        XCTAssertEqual(zero, UIEdgeInsets.zero)
+
+        var insets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+        insets += UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
+        let expected = UIEdgeInsets(top: 6, left: 8, bottom: 10, right: 12)
+        XCTAssertEqual(insets, expected)
+
+        var negativeInsets = UIEdgeInsets(top: -1, left: -2, bottom: -3, right: -4)
+        negativeInsets += UIEdgeInsets(top: -5, left: -6, bottom: -7, right: -8)
+        let negativeExpected = UIEdgeInsets(top: -6, left: -8, bottom: -10, right: -12)
+        XCTAssertEqual(negativeInsets, negativeExpected)
     }
 }
 #endif


### PR DESCRIPTION
🚀

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.