### PR TITLE
Added 'key(forValue: Value)' method to DictionaryExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeValueForRandomKey()` to remove a value for a random key from a dictionary. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
   - Added `mapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary` with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
   - Added `compactMapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary`, excluding `nil` results, with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
-  - Added `keys(forValue: value)` which returns an array of all keys that have the given value in dictionary (if applicable). [#561](https://github.com/SwifterSwift/SwifterSwift/pull/561) by [mauliksharma](https://github.com/mauliksharma).
+  - Added `keys(forValue: Value)` which returns an array of all keys that have the given value in dictionary. [#561](https://github.com/SwifterSwift/SwifterSwift/pull/561) by [mauliksharma](https://github.com/mauliksharma).
 - **RangeReplaceableCollection**:
   - Added `removeRandomElement()` to remove a random element from a collection. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
 - **UIView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeValueForRandomKey()` to remove a value for a random key from a dictionary. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
   - Added `mapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary` with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
   - Added `compactMapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary`, excluding `nil` results, with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
-  - Added `keys(forValue: Value)` which returns an array of all keys that have the given value in dictionary. [#561](https://github.com/SwifterSwift/SwifterSwift/pull/561) by [mauliksharma](https://github.com/mauliksharma).
+  - Added `keys(forValue:)` which returns an array of all keys that have the given value in dictionary. [#561](https://github.com/SwifterSwift/SwifterSwift/pull/561) by [mauliksharma](https://github.com/mauliksharma).
 - **RangeReplaceableCollection**:
   - Added `removeRandomElement()` to remove a random element from a collection. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
 - **UIView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeValueForRandomKey()` to remove a value for a random key from a dictionary. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
   - Added `mapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary` with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
   - Added `compactMapKeysAndValues(_:)` to map a `Dictionary` into a `Dictionary`, excluding `nil` results, with different (or same) `Key` and `Value` types. [#546](https://github.com/SwifterSwift/SwifterSwift/pull/546) by [guykogus](https://github.com/guykogus)
+  - Added `keys(forValue: value)` which returns an array of all keys that have the given value in dictionary (if applicable). [#561](https://github.com/SwifterSwift/SwifterSwift/pull/561) by [mauliksharma](https://github.com/mauliksharma).
 - **RangeReplaceableCollection**:
   - Added `removeRandomElement()` to remove a random element from a collection. [#497](https://github.com/SwifterSwift/SwifterSwift/pull/497) by [vyax](https://github.com/vyax).
 - **UIView**

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -120,7 +120,7 @@ public extension Dictionary where Value: Equatable {
     ///        dict.keys(forValue: "value2") -> ["key3"]
     ///        dict.keys(forValue: "value3") -> []
     ///
-    /// - Parameter forValue: Value for which keys are to be fetched.
+    /// - Parameter value: Value for which keys are to be fetched.
     /// - Returns: An array containing keys that have the given value.
     public func keys(forValue value: Value) -> [Key] {
         return keys.filter { self[$0] == value }

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -112,21 +112,20 @@ public extension Dictionary {
 
 // MARK: - Methods (Value: Equatable)
 public extension Dictionary where Value: Equatable {
-    
-    /// SwifterSwift: Returns an array of all keys that have the given value in dictionary (if applicable).
+
+    /// SwifterSwift: Returns an array of all keys that have the given value in dictionary.
     ///
     ///        let dict = ["key1": "value1", "key2": "value1", "key3": "value2"]
-    ///        dict.keys(forValue: "value1") -> Optional(["key1", "key2"])
-    ///        dict.keys(forValue: "value2") -> Optional(["key3"])
-    ///        dict.keys(forValue: "value3") -> nil //no key that has the value "value3"
+    ///        dict.keys(forValue: "value1") -> ["key1", "key2"]
+    ///        dict.keys(forValue: "value2") -> ["key3"]
+    ///        dict.keys(forValue: "value3") -> []
     ///
     /// - Parameter forValue: Value for which keys are to be fetched.
-    /// - Returns: An array containing keys that have the given value (if applicable).
-    public func keys(forValue value: Value) -> [Key]? {
-        let result = self.compactMap{ $1 == value ? $0 : nil }
-        return !result.isEmpty ? result : nil
+    /// - Returns: An array containing keys that have the given value.
+    public func keys(forValue value: Value) -> [Key] {
+        return keys.filter { self[$0] == value }
     }
-    
+
 }
 
 // MARK: - Methods (ExpressibleByStringLiteral)

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -110,6 +110,25 @@ public extension Dictionary {
 
 }
 
+// MARK: - Methods (Value: Equatable)
+public extension Dictionary where Value: Equatable {
+    
+    /// SwifterSwift: Returns an array of all keys that have the given value in dictionary (if applicable).
+    ///
+    ///        let dict = ["key1": "value1", "key2": "value1", "key3": "value2"]
+    ///        dict.keys(forValue: "value1") -> Optional(["key1", "key2"])
+    ///        dict.keys(forValue: "value2") -> Optional(["key3"])
+    ///        dict.keys(forValue: "value3") -> nil //no key that has the value "value3"
+    ///
+    /// - Parameter forValue: Value for which keys are to be fetched.
+    /// - Returns: An array containing keys that have the given value (if applicable).
+    public func keys(forValue value: Value) -> [Key]? {
+        let result = self.compactMap{ $1 == value ? $0 : nil }
+        return !result.isEmpty ? result : nil
+    }
+    
+}
+
 // MARK: - Methods (ExpressibleByStringLiteral)
 public extension Dictionary where Key: StringProtocol {
 

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -63,14 +63,13 @@ final class DictionaryExtensionsTests: XCTestCase {
 		XCTAssertNil(["key": NSObject()].jsonString())
 		XCTAssertNil([1: 2].jsonString())
 	}
-    
+
     func testKeysForValue() {
         let dict = ["key1": "value1", "key2": "value1", "key3": "value2"]
         let result = dict.keys(forValue: "value1")
-        XCTAssertNotNil(result)
-        XCTAssertEqual(result?.contains("key1"), true)
-        XCTAssertEqual(result?.contains("key2"), true)
-        XCTAssertNotEqual(result?.contains("key3"), true)
+        XCTAssertTrue(result.contains("key1"))
+        XCTAssertTrue(result.contains("key2"))
+        XCTAssertFalse(result.contains("key3"))
     }
 
 	func testLowercaseAllKeys() {

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -63,6 +63,15 @@ final class DictionaryExtensionsTests: XCTestCase {
 		XCTAssertNil(["key": NSObject()].jsonString())
 		XCTAssertNil([1: 2].jsonString())
 	}
+    
+    func testKeysForValue() {
+        let dict = ["key1": "value1", "key2": "value1", "key3": "value2"]
+        let result = dict.keys(forValue: "value1")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.contains("key1"), true)
+        XCTAssertEqual(result?.contains("key2"), true)
+        XCTAssertNotEqual(result?.contains("key3"), true)
+    }
 
 	func testLowercaseAllKeys() {
 		var dict = ["tEstKeY": "value"]


### PR DESCRIPTION
🚀
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x ] New extensions are written in Swift 4.
- [x ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x ] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x ] All extensions are declared as **public**.
- [x ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.