### PR TITLE
Use 'swift_version' instead of 'pod_target_xcconfig{SWIFT_VERSION}' t…

### DIFF
--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -20,9 +20,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source = { git: 'https://github.com/SwifterSwift/SwifterSwift.git', tag: s.version.to_s }
   s.source_files = 'Sources/**/*.swift'
-  s.pod_target_xcconfig = {
-    'SWIFT_VERSION' => '4.2'
-  }
+  s.swift_version = '4.2'
   s.documentation_url = 'http://swifterswift.com/docs'
 
   # SwiftStdlib Extensions


### PR DESCRIPTION
…o specify Swift version of pod target itself.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
