### PR TITLE
Update the CHANGELOG to correctly display what has been changed for the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ---
 
+# [v4.6.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/4.6.0)
+
+### Added
+- **UIView**
+  - Added `ancestorView(where:)` and `ancestorView(withClass:)` to search for a view in the superviews. [#560](https://github.com/SwifterSwift/SwifterSwift/pull/560) by [overovermind](https://github.com/overovermind)
+### Fixed
+- Fixed Cocoapods installation setting the correct Swift version
+
+---
+
 # [v4.5.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/4.5.0)
 
 ### Added
@@ -33,7 +43,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIView**
   - Added `addGestureRecognizers(_:)` which accepts an array of `UIGestureRecognizer` to add multiple gesture recognizers to a view with one call. [#523](https://github.com/SwifterSwift/SwifterSwift/pull/523) by [moyerr](https://github.com/moyerr)
   - Added `removeGestureRecognizers(_:)` which accepts an array of `UIGestureRecognizer` to remove multiple gesture recognizers from a view with one call. [#523](https://github.com/SwifterSwift/SwifterSwift/pull/523) by [moyerr](https://github.com/moyerr)
-  - Added `ancestorView(where:)` and `ancestorView(withClass:)` to search for a view in the superviews. [#560](https://github.com/SwifterSwift/SwifterSwift/pull/560) by [overovermind](https://github.com/overovermind)
 - **UIViewController**
   - Added `addChildViewController(_:toContainerView)` to easily add child view controllers. Accepts a `UIViewController` and a `UIView` to add the child's view to. 
   - Added `removeViewAndControllerFromParentViewController()` to remove a `UIViewController` from its parent.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 SwifterSwift is a collection of **over 500 native Swift extensions**, with handy methods, syntactic sugar, and performance improvements for wide range of primitive data types, UIKit and Cocoa classes –over 500 in 1– for iOS, macOS, tvOS, watchOS and Linux.
 
 
-### [Whats New in v4.5.0?](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG.md#v450)
+### [Whats New in v4.6.0?](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG.md#v460)
 
 ## Requirements:
 - **iOS** 8.0+ / **tvOS** 9.0+ / **watchOS** 2.0+ / **macOS** 10.10+ / **Ubuntu** 14.04+

--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'SwifterSwift'
-  s.version = '4.5.0'
+  s.version = '4.6.0'
   s.summary = 'A handy collection of more than 500 native Swift extensions to boost your productivity.'
   s.description = <<-DESC
   SwifterSwift is a collection of over 500 native Swift extensions, with handy methods, syntactic sugar, and performance improvements for wide range of primitive data types, UIKit and Cocoa classes –over 500 in 1– for iOS, macOS, tvOS and watchOS.


### PR DESCRIPTION
🚀

We need to create a public release to fix the cocoapods issue. Unfortunately https://github.com/SwifterSwift/SwifterSwift/pull/560 was merged before we could create release 4.5.1, so we're stuck with updating the version to 4.6.0.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.