### PR TITLE
Dictionary Key-Path Subscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+- **Dictionary**
+  - Added `Dictionary[path:]` subscript for deep fetching/setting nested values. [#573](https://github.com/SwifterSwift/SwifterSwift/pull/573) by [@calebkleveter](https://github.com/calebkleveter)
 ### Changed
 ### Fixed
 ### Deprecated

--- a/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DictionaryExtensions.swift
@@ -145,7 +145,47 @@ public extension Dictionary where Key: StringProtocol {
             }
         }
     }
+}
 
+// MARK: - Subscripts
+public extension Dictionary {
+
+    /// SwifterSwift: Deep fetch or set a value from nested dictionaries.
+    ///
+    ///        var dict =  ["key": ["key1": ["key2": "value"]]]
+    ///        dict[path: ["key", "key1", "key2"]] = "newValue"
+    ///        dict[path: ["key", "key1", "key2"]] -> "newValue"
+    ///
+    /// - Note: Value fetching is iterative, while setting is recursive.
+    ///
+    /// - Complexity: O(N), _N_ being the length of the path passed in.
+    ///
+    /// - Parameter path: An array of keys to the desired value.
+    ///
+    /// - Returns: The value for the key-path passed in. `nil` if no value is found.
+    public subscript(path path: [Key]) -> Any? {
+        get {
+            return path.reduce(self) { result, key -> Any? in
+                if let element = (result as? [Key: Any])?[key] {
+                    return element
+                } else {
+                    return nil
+                }
+            }
+        }
+        set {
+            if let first = path.first {
+                if path.count == 1, let new = newValue as? Value {
+                    return self[first] = new
+                }
+                if var nested = self[first] as? [Key: Any] {
+                    nested[path: Array(path.dropFirst())] = newValue
+                    return self[first] = nested as? Value
+                }
+            }
+            return
+        }
+    }
 }
 
 // MARK: - Operators

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -78,6 +78,14 @@ final class DictionaryExtensionsTests: XCTestCase {
         XCTAssertEqual(dict, ["testkey": "value"])
     }
 
+    func testSubscriptKeypath() {
+        var json = ["key": ["key1": ["key2": "value"]]]
+
+        XCTAssertEqual(json[path: ["key", "key1", "key2"]] as? String, "value")
+        json[path: ["key", "key1", "key2"]] = "newValue"
+        XCTAssertEqual(json[path: ["key", "key1", "key2"]] as? String, "newValue")
+    }
+
     func testOperatorPlus() {
         let dict: [String: String] = ["key1": "value1"]
         let dict2: [String: String] = ["key2": "value2"]


### PR DESCRIPTION
Fixes https://github.com/SwifterSwift/SwifterSwift/issues/565

```swift
var dict =  ["key": ["key1": ["key2": "value"]]]
dict[path: ["key", "key1", "key2"]] = "newValue"
dict[path: ["key", "key1", "key2"]] -> "newValue"
```

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
