### PR TITLE
Replace the old Date.random function with ones using the new built-in random API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+- **Date**
+  - `random(in:)` and `random(in:using:)` to generate random dates using the built-in random functions added to Swift 4.2. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576/files) by [guykogus](https://github.com/guykogus)
 - **Dictionary**
   - Added `Dictionary[path:]` subscript for deep fetching/setting nested values. [#574](https://github.com/SwifterSwift/SwifterSwift/pull/573) by [@calebkleveter](https://github.com/calebkleveter)
 ### Changed
@@ -11,6 +13,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIImage**:
   - `cropped(to:)` fixed size checking. [#575](https://github.com/SwifterSwift/SwifterSwift/pull/575) by [ilyahal](https://github.com/ilyahal)
 ### Deprecated
+- **Date**
+  - `random(from:upTo:)` in favor of `random(in:)` and `random(in:using:)`. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576/files) by [guykogus](https://github.com/guykogus)
 ### Removed
 ### Security
 

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -864,7 +864,7 @@ public extension Date {
         return abs(componentValue) <= value
     }
 
-    /// Returns a random date within the specified range.
+    /// SwifterSwift: Returns a random date within the specified range.
     ///
     /// - Parameter range: The range in which to create a random date. `range` must not be empty.
     /// - Returns: A random date within the bounds of `range`.
@@ -873,7 +873,7 @@ public extension Date {
             TimeInterval.random(in: range.lowerBound.timeIntervalSinceReferenceDate..<range.upperBound.timeIntervalSinceReferenceDate))
     }
 
-    /// Returns a random date within the specified range.
+    /// SwifterSwift: Returns a random date within the specified range.
     ///
     /// - Parameter range: The range in which to create a random date.
     /// - Returns: A random date within the bounds of `range`.
@@ -882,7 +882,7 @@ public extension Date {
             TimeInterval.random(in: range.lowerBound.timeIntervalSinceReferenceDate...range.upperBound.timeIntervalSinceReferenceDate))
     }
 
-    /// Returns a random date within the specified range, using the given generator as a source for randomness.
+    /// SwifterSwift: Returns a random date within the specified range, using the given generator as a source for randomness.
     ///
     /// - Parameters:
     ///   - range: The range in which to create a random date. `range` must not be empty.
@@ -894,7 +894,7 @@ public extension Date {
                                 using: &generator))
     }
 
-    /// Returns a random date within the specified range, using the given generator as a source for randomness.
+    /// SwifterSwift: Returns a random date within the specified range, using the given generator as a source for randomness.
     ///
     /// - Parameters:
     ///   - range: The range in which to create a random date.

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -864,28 +864,46 @@ public extension Date {
         return abs(componentValue) <= value
     }
 
-    /// SwifterSwift: Random date between two dates.
+    /// Returns a random date within the specified range.
     ///
-    ///     Date.random()
-    ///     Date.random(from: Date())
-    ///     Date.random(upTo: Date())
-    ///     Date.random(from: Date(), upTo: Date())
+    /// - Parameter range: The range in which to create a random date. `range` must not be empty.
+    /// - Returns: A random date within the bounds of `range`.
+    public static func random(in range: Range<Date>) -> Date {
+        return Date(timeIntervalSinceReferenceDate:
+            TimeInterval.random(in: range.lowerBound.timeIntervalSinceReferenceDate..<range.upperBound.timeIntervalSinceReferenceDate))
+    }
+
+    /// Returns a random date within the specified range.
+    ///
+    /// - Parameter range: The range in which to create a random date.
+    /// - Returns: A random date within the bounds of `range`.
+    public static func random(in range: ClosedRange<Date>) -> Date {
+        return Date(timeIntervalSinceReferenceDate:
+            TimeInterval.random(in: range.lowerBound.timeIntervalSinceReferenceDate...range.upperBound.timeIntervalSinceReferenceDate))
+    }
+
+    /// Returns a random date within the specified range, using the given generator as a source for randomness.
     ///
     /// - Parameters:
-    ///   - fromDate: minimum date (default is Date.distantPast)
-    ///   - toDate: maximum date (default is Date.distantFuture)
-    /// - Returns: random date between two dates.
-    public static func random(from fromDate: Date = Date.distantPast, upTo toDate: Date = Date.distantFuture) -> Date {
-        guard fromDate != toDate else {
-            return fromDate
-        }
+    ///   - range: The range in which to create a random date. `range` must not be empty.
+    ///   - generator: The random number generator to use when creating the new random date.
+    /// - Returns: A random date within the bounds of `range`.
+    public static func random<T>(in range: Range<Date>, using generator: inout T) -> Date where T: RandomNumberGenerator {
+        return Date(timeIntervalSinceReferenceDate:
+            TimeInterval.random(in: range.lowerBound.timeIntervalSinceReferenceDate..<range.upperBound.timeIntervalSinceReferenceDate,
+                                using: &generator))
+    }
 
-        let diff = llabs(Int64(toDate.timeIntervalSinceReferenceDate - fromDate.timeIntervalSinceReferenceDate))
-        var randomValue: Int64 = Int64.random(in: Int64.min...Int64.max)
-        randomValue = llabs(randomValue%diff)
-
-        let startReferenceDate = toDate > fromDate ? fromDate : toDate
-        return startReferenceDate.addingTimeInterval(TimeInterval(randomValue))
+    /// Returns a random date within the specified range, using the given generator as a source for randomness.
+    ///
+    /// - Parameters:
+    ///   - range: The range in which to create a random date.
+    ///   - generator: The random number generator to use when creating the new random date.
+    /// - Returns: A random date within the bounds of `range`.
+    public static func random<T>(in range: ClosedRange<Date>, using generator: inout T) -> Date where T: RandomNumberGenerator {
+        return Date(timeIntervalSinceReferenceDate:
+            TimeInterval.random(in: range.lowerBound.timeIntervalSinceReferenceDate...range.upperBound.timeIntervalSinceReferenceDate,
+                                using: &generator))
     }
 
 }

--- a/Sources/Extensions/Foundation/Deprecated/FoundationDeprecated.swift
+++ b/Sources/Extensions/Foundation/Deprecated/FoundationDeprecated.swift
@@ -1,0 +1,40 @@
+//
+//  FoundationDeprecated.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 04/10/2018.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if canImport(Foundation)
+import Foundation
+
+extension Date {
+
+    /// SwifterSwift: Random date between two dates.
+    ///
+    ///     Date.random()
+    ///     Date.random(from: Date())
+    ///     Date.random(upTo: Date())
+    ///     Date.random(from: Date(), upTo: Date())
+    ///
+    /// - Parameters:
+    ///   - fromDate: minimum date (default is Date.distantPast)
+    ///   - toDate: maximum date (default is Date.distantFuture)
+    /// - Returns: random date between two dates.
+    @available(*, deprecated: 4.7.0, message: "Use random(in:) or random(in:using:) instead")
+    public static func random(from fromDate: Date = Date.distantPast, upTo toDate: Date = Date.distantFuture) -> Date {
+        guard fromDate != toDate else {
+            return fromDate
+        }
+
+        let diff = llabs(Int64(toDate.timeIntervalSinceReferenceDate - fromDate.timeIntervalSinceReferenceDate))
+        var randomValue: Int64 = Int64.random(in: Int64.min...Int64.max)
+        randomValue = llabs(randomValue%diff)
+
+        let startReferenceDate = toDate > fromDate ? fromDate : toDate
+        return startReferenceDate.addingTimeInterval(TimeInterval(randomValue))
+    }
+
+}
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 		CAC5EBCF2125272A00AB27EC /* test.json in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBC22125270A00AB27EC /* test.json */; };
 		CAC5EBD02125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
 		CAC5EBD12125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
+		F895F02E21661794000F05E3 /* FoundationDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F895F02D21661794000F05E3 /* FoundationDeprecated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -623,6 +624,7 @@
 		CAC5EBC32125270A00AB27EC /* UITableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UITableViewCell.xib; sourceTree = "<group>"; };
 		CAC5EBC42125270A00AB27EC /* UITableViewHeaderFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UITableViewHeaderFooterView.xib; sourceTree = "<group>"; };
 		CAC5EBC52125270A00AB27EC /* big_buck_bunny_720p_1mb.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = big_buck_bunny_720p_1mb.mp4; sourceTree = "<group>"; };
+		F895F02D21661794000F05E3 /* FoundationDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationDeprecated.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -810,6 +812,7 @@
 		07B7F1651F5EB41600E6F910 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				F895F02A21661756000F05E3 /* Deprecated */,
 				70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */,
 				07B7F16A1F5EB41600E6F910 /* DataExtensions.swift */,
 				07B7F16B1F5EB41600E6F910 /* DateExtensions.swift */,
@@ -1061,6 +1064,14 @@
 				07C50D121F5EB03200F46E5A /* ColorExtensionsTests.swift */,
 			);
 			path = SharedTests;
+			sourceTree = "<group>";
+		};
+		F895F02A21661756000F05E3 /* Deprecated */ = {
+			isa = PBXGroup;
+			children = (
+				F895F02D21661794000F05E3 /* FoundationDeprecated.swift */,
+			);
+			path = Deprecated;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1494,6 +1505,7 @@
 				07B7F1A11F5EB42000E6F910 /* UISwitchExtensions.swift in Sources */,
 				078CE29F207643F8001720DF /* UIKitDeprecated.swift in Sources */,
 				0722CB3820C2E46C00C6C1B6 /* UIWindowExtensions.swift in Sources */,
+				F895F02E21661794000F05E3 /* FoundationDeprecated.swift in Sources */,
 				07B7F1A41F5EB42000E6F910 /* UITextFieldExtensions.swift in Sources */,
 				07B7F20B1F5EB43C00E6F910 /* ArrayExtensions.swift in Sources */,
 				07B7F1A01F5EB42000E6F910 /* UIStoryboardExtensions.swift in Sources */,

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -895,53 +895,62 @@ final class DateExtensionsTests: XCTestCase {
         XCTAssertNil(Date(integerLiteral: 222))
     }
 
-    func testRandom() {
-        var randomDate = Date.random()
-        XCTAssertTrue(randomDate.isBetween(Date.distantPast, Date.distantFuture, includeBounds: true))
-
-        var date = Date(timeIntervalSinceReferenceDate: 0)
-        randomDate = Date.random(from: date)
-        XCTAssertTrue(randomDate.isBetween(date, Date.distantFuture, includeBounds: true))
-
-        date = Date(timeIntervalSince1970: 10000)
-        randomDate = Date.random(from: date)
-        XCTAssertTrue(randomDate.isBetween(date, Date.distantFuture, includeBounds: true))
-
-        date = Date(timeIntervalSince1970: -10000)
-        randomDate = Date.random(from: date)
-        XCTAssertTrue(randomDate.isBetween(date, Date.distantFuture, includeBounds: true))
-
-        date = Date(timeIntervalSinceReferenceDate: 0)
-        randomDate = Date.random(upTo: date)
-        XCTAssertTrue(randomDate.isBetween(Date.distantPast, date, includeBounds: true))
-
-        date = Date(timeIntervalSince1970: 10000)
-        randomDate = Date.random(upTo: date)
-        XCTAssertTrue(randomDate.isBetween(Date.distantPast, date, includeBounds: true))
-
-        date = Date(timeIntervalSince1970: -10000)
-        randomDate = Date.random(upTo: date)
-        XCTAssertTrue(randomDate.isBetween(Date.distantPast, date, includeBounds: true))
-
+    func testRandomRange() {
         var sinceDate = Date(timeIntervalSinceReferenceDate: 0)
         var toDate = Date(timeIntervalSinceReferenceDate: 10000)
-        randomDate = Date.random(from: sinceDate, upTo: toDate)
-        XCTAssertTrue(randomDate.isBetween(sinceDate, toDate, includeBounds: true))
+        XCTAssert(Date.random(in: sinceDate..<toDate).isBetween(sinceDate, toDate, includeBounds: false))
 
         sinceDate = Date(timeIntervalSince1970: -10000)
         toDate = Date(timeIntervalSince1970: -10)
-        randomDate = Date.random(from: sinceDate, upTo: toDate)
-        XCTAssertTrue(randomDate.isBetween(sinceDate, toDate, includeBounds: true))
+        XCTAssert(Date.random(in: sinceDate..<toDate).isBetween(sinceDate, toDate, includeBounds: false))
 
         sinceDate = Date(timeIntervalSinceReferenceDate: -1000)
         toDate = Date(timeIntervalSinceReferenceDate: 10000)
-        randomDate = Date.random(from: sinceDate, upTo: toDate)
-        XCTAssertTrue(randomDate.isBetween(sinceDate, toDate, includeBounds: true))
+        XCTAssert(Date.random(in: sinceDate..<toDate).isBetween(sinceDate, toDate, includeBounds: false))
 
-        sinceDate = Date(timeIntervalSinceReferenceDate: 0)
-        toDate = sinceDate
-        randomDate = Date.random(from: sinceDate, upTo: toDate)
-        XCTAssertTrue(randomDate.isBetween(sinceDate, toDate, includeBounds: true))
+        sinceDate = Date.distantPast
+        toDate = Date.distantFuture
+        XCTAssert(Date.random(in: sinceDate..<toDate).isBetween(sinceDate, toDate, includeBounds: false))
+    }
+
+    func testRandomClosedRange() {
+        var sinceDate = Date(timeIntervalSinceReferenceDate: 0)
+        var toDate = Date(timeIntervalSinceReferenceDate: 10000)
+        XCTAssert(Date.random(in: sinceDate...toDate).isBetween(sinceDate, toDate, includeBounds: true))
+
+        sinceDate = Date(timeIntervalSince1970: -10000)
+        toDate = Date(timeIntervalSince1970: -10)
+        XCTAssert(Date.random(in: sinceDate...toDate).isBetween(sinceDate, toDate, includeBounds: true))
+
+        sinceDate = Date(timeIntervalSinceReferenceDate: -1000)
+        toDate = Date(timeIntervalSinceReferenceDate: 10000)
+        XCTAssert(Date.random(in: sinceDate...toDate).isBetween(sinceDate, toDate, includeBounds: true))
+
+        sinceDate = Date.distantPast
+        toDate = Date.distantFuture
+        XCTAssert(Date.random(in: sinceDate...toDate).isBetween(sinceDate, toDate, includeBounds: true))
+
+        let singleDate = Date(timeIntervalSinceReferenceDate: 0)
+        XCTAssertFalse(Date.random(in: singleDate...singleDate).isBetween(singleDate, singleDate, includeBounds: false))
+        XCTAssert(Date.random(in: singleDate...singleDate).isBetween(singleDate, singleDate, includeBounds: true))
+    }
+
+    func testRandomRangeWithGenerator() {
+        var generator = SystemRandomNumberGenerator()
+        let sinceDate = Date.distantPast
+        let toDate = Date.distantFuture
+        XCTAssert(Date.random(in: sinceDate..<toDate, using: &generator).isBetween(sinceDate, toDate, includeBounds: false))
+    }
+
+    func testRandomClosedRangeWithGenerator() {
+        var generator = SystemRandomNumberGenerator()
+        let sinceDate = Date.distantPast
+        let toDate = Date.distantFuture
+        XCTAssert(Date.random(in: sinceDate...toDate, using: &generator).isBetween(sinceDate, toDate, includeBounds: true))
+
+        let singleDate = Date(timeIntervalSinceReferenceDate: 0)
+        XCTAssertFalse(Date.random(in: singleDate...singleDate, using: &generator).isBetween(singleDate, singleDate, includeBounds: false))
+        XCTAssert(Date.random(in: singleDate...singleDate, using: &generator).isBetween(singleDate, singleDate, includeBounds: true))
     }
 
 }


### PR DESCRIPTION
🚀

I wasn't liking the old random function, it makes more sense to use the built-in style.
I really wished they'd created a `Randomizable` protocol to generalise its usage elsewhere.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
