### PR TITLE
Removed self. when not needed

### DIFF
--- a/Sources/Extensions/AppKit/NSImageExtensions.swift
+++ b/Sources/Extensions/AppKit/NSImageExtensions.swift
@@ -18,8 +18,8 @@ extension NSImage {
     /// - Returns: scaled NSImage
     public func scaled(toMaxSize: NSSize) -> NSImage {
         var ratio: Float = 0.0
-        let imageWidth = Float(self.size.width)
-        let imageHeight = Float(self.size.height)
+        let imageWidth = Float(size.width)
+        let imageHeight = Float(size.height)
         let maxWidth = Float(toMaxSize.width)
         let maxHeight = Float(toMaxSize.height)
 
@@ -40,8 +40,8 @@ extension NSImage {
         let newSize: NSSize = NSSize(width: Int(newWidth), height: Int(newHeight))
 
         // Cast the NSImage to a CGImage
-        var imageRect: CGRect = CGRect(x: 0, y: 0, width: self.size.width, height: self.size.height)
-        let imageRef = self.cgImage(forProposedRect: &imageRect, context: nil, hints: nil)
+        var imageRect: CGRect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+        let imageRef = cgImage(forProposedRect: &imageRect, context: nil, hints: nil)
 
         // Create NSImage from the CGImage using the new size
         let imageWithNewSize = NSImage(cgImage: imageRef!, size: newSize)

--- a/Sources/Extensions/AppKit/NSViewExtensions.swift
+++ b/Sources/Extensions/AppKit/NSViewExtensions.swift
@@ -132,7 +132,7 @@ extension NSView {
     ///
     /// - Parameter subviews: array of subviews to add to self.
     public func addSubviews(_ subviews: [NSView]) {
-        subviews.forEach({self.addSubview($0)})
+        subviews.forEach({addSubview($0)})
     }
 
     /// SwifterSwift: Remove all subviews in view.

--- a/Sources/Extensions/AppKit/NSViewExtensions.swift
+++ b/Sources/Extensions/AppKit/NSViewExtensions.swift
@@ -132,12 +132,12 @@ extension NSView {
     ///
     /// - Parameter subviews: array of subviews to add to self.
     public func addSubviews(_ subviews: [NSView]) {
-        subviews.forEach({addSubview($0)})
+        subviews.forEach { addSubview($0) }
     }
 
     /// SwifterSwift: Remove all subviews in view.
     public func removeSubviews() {
-        subviews.forEach({$0.removeFromSuperview()})
+        subviews.forEach { $0.removeFromSuperview() }
     }
 
 }

--- a/Sources/Extensions/Foundation/URLExtensions.swift
+++ b/Sources/Extensions/Foundation/URLExtensions.swift
@@ -70,7 +70,7 @@ public extension URL {
     ///
     /// - Parameter key: The key of a query value.
     public func queryValue(for key: String) -> String? {
-        let stringURL = self.absoluteString
+        let stringURL = absoluteString
         guard let items = URLComponents(string: stringURL)?.queryItems else { return nil }
         for item in items where item.name == key {
             return item.value
@@ -108,8 +108,8 @@ public extension URL {
     ///        let url = URL(string: "https://domain.com")!
     ///        print(url.droppedScheme()) // prints "domain.com"
     public func droppedScheme() -> URL? {
-        if let scheme = self.scheme {
-            let droppedScheme = String(self.absoluteString.dropFirst(scheme.count + 3))
+        if let scheme = scheme {
+            let droppedScheme = String(absoluteString.dropFirst(scheme.count + 3))
             return URL(string: droppedScheme)
         }
 

--- a/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
+++ b/Sources/Extensions/Foundation/UserDefaultsExtensions.swift
@@ -48,7 +48,7 @@ public extension UserDefaults {
     ///   - decoder: Custom JSONDecoder instance. Defaults to `JSONDecoder()`.
     /// - Returns: Codable object for key (if exists).
     public func object<T: Codable>(_ type: T.Type, with key: String, usingDecoder decoder: JSONDecoder = JSONDecoder()) -> T? {
-        guard let data = self.value(forKey: key) as? Data else { return nil }
+        guard let data = value(forKey: key) as? Data else { return nil }
         return try? decoder.decode(type.self, from: data)
     }
 
@@ -60,7 +60,7 @@ public extension UserDefaults {
     ///   - encoder: Custom JSONEncoder instance. Defaults to `JSONEncoder()`.
     public func set<T: Codable>(object: T, forKey key: String, usingEncoder encoder: JSONEncoder = JSONEncoder()) {
         let data = try? encoder.encode(object)
-        self.set(data, forKey: key)
+        set(data, forKey: key)
     }
 
 }

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -231,7 +231,7 @@ public extension Color {
     public func lighten(by percentage: CGFloat = 0.2) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         return Color(red: min(red + percentage, 1.0),
                      green: min(green + percentage, 1.0),
                      blue: min(blue + percentage, 1.0),
@@ -248,7 +248,7 @@ public extension Color {
     public func darken(by percentage: CGFloat = 0.2) -> Color {
         // https://stackoverflow.com/questions/38435308/swift-get-lighter-and-darker-color-variations-for-a-given-uicolor
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         return Color(red: max(red - percentage, 0),
                      green: max(green - percentage, 0),
                      blue: max(blue - percentage, 0),

--- a/Sources/Extensions/SwiftStdlib/IntExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/IntExtensions.swift
@@ -70,7 +70,7 @@ public extension Int {
     public var digits: [Int] {
         guard self != 0 else { return [0] }
         var digits = [Int]()
-        var number = self.abs
+        var number = abs
 
         while number != 0 {
             let xNumber = number % 10
@@ -85,7 +85,7 @@ public extension Int {
     /// SwifterSwift: Number of digits of integer value.
     public var digitsCount: Int {
         guard self != 0 else { return 1 }
-        let number = Double(self.abs)
+        let number = Double(abs)
         return Int(log10(number) + 1)
     }
 

--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -57,7 +57,7 @@ public extension Optional {
     /// - Parameter block: a block to run if self is not nil.
     public func run(_ block: (Wrapped) -> Void) {
         // http://www.russbishop.net/improving-optionals
-        _ = self.map(block)
+        _ = map(block)
     }
 
     /// SwifterSwift: Assign an optional value to a variable only if the value is not nil.

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -100,7 +100,7 @@ public extension String {
     ///		"".firstCharacterAsString -> nil
     ///
     public var firstCharacterAsString: String? {
-        guard let first = self.first else { return nil }
+        guard let first = first else { return nil }
         return String(first)
     }
 
@@ -259,7 +259,7 @@ public extension String {
     ///		"".lastCharacterAsString -> nil
     ///
     public var lastCharacterAsString: String? {
-        guard let last = self.last else { return nil }
+        guard let last = last else { return nil }
         return String(last)
     }
 
@@ -400,7 +400,7 @@ public extension String {
     #if canImport(Foundation)
     /// SwifterSwift: Check if the given string contains only white spaces
     public var isWhitespace: Bool {
-        return self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
     #endif
 
@@ -408,7 +408,7 @@ public extension String {
     /// SwifterSwift: Check if the given string spelled correctly
     public var isSpelledCorrectly: Bool {
         let checker = UITextChecker()
-        let range = NSRange(location: 0, length: self.utf16.count)
+        let range = NSRange(location: 0, length: utf16.count)
 
         let misspelledRange = checker.rangeOfMisspelledWord(in: self, range: range, startingAt: 0, wrap: false, language: Locale.preferredLanguages.first ?? "en")
         return misspelledRange.location == NSNotFound
@@ -775,7 +775,7 @@ public extension String {
     ///   - i: string index the slicing should start from.
     ///   - length: amount of characters to be sliced after given index.
     public mutating func slice(from i: Int, length: Int) {
-        if let str = self.slicing(from: i, length: length) {
+        if let str = slicing(from: i, length: length) {
             self = String(str)
         }
     }

--- a/Sources/Extensions/UIKit/UIButtonExtensions.swift
+++ b/Sources/Extensions/UIKit/UIButtonExtensions.swift
@@ -145,21 +145,21 @@ public extension UIButton {
     ///
     /// - Parameter image: UIImage.
     public func setImageForAllStates(_ image: UIImage) {
-        states.forEach { self.setImage(image, for: $0) }
+        states.forEach { setImage(image, for: $0) }
     }
 
     /// SwifterSwift: Set title color for all states.
     ///
     /// - Parameter color: UIColor.
     public func setTitleColorForAllStates(_ color: UIColor) {
-        states.forEach { self.setTitleColor(color, for: $0) }
+        states.forEach { setTitleColor(color, for: $0) }
     }
 
     /// SwifterSwift: Set title for all states.
     ///
     /// - Parameter title: title string.
     public func setTitleForAllStates(_ title: String) {
-        states.forEach { self.setTitle(title, for: $0) }
+        states.forEach { setTitle(title, for: $0) }
     }
 
     /// SwifterSwift: Center align title text and image on UIButton

--- a/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UICollectionViewExtensions.swift
@@ -33,7 +33,7 @@ public extension UICollectionView {
     public func numberOfItems() -> Int {
         var section = 0
         var itemsCount = 0
-        while section < self.numberOfSections {
+        while section < numberOfSections {
             itemsCount += numberOfItems(inSection: section)
             section += 1
         }

--- a/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIGestureRecognizerExtensions.swift
@@ -14,7 +14,7 @@ public extension UIGestureRecognizer {
 
     /// SwifterSwift: Remove Gesture Recognizer from its view.
     public func removeFromView() {
-        self.view?.removeGestureRecognizer(self)
+        view?.removeGestureRecognizer(self)
     }
 
 }

--- a/Sources/Extensions/UIKit/UIImageExtensions.swift
+++ b/Sources/Extensions/UIKit/UIImageExtensions.swift
@@ -173,7 +173,7 @@ public extension UIImage {
         context.setBlendMode(CGBlendMode.normal)
 
         let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        guard let mask = self.cgImage else { return self }
+        guard let mask = cgImage else { return self }
         context.clip(to: rect, mask: mask)
         context.fill(rect)
 

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -177,7 +177,7 @@ public extension UITableView {
     /// - Parameter indexPath: An IndexPath to check
     /// - Returns: Boolean value for valid or invalid IndexPath
     public func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section < self.numberOfSections && indexPath.row < self.numberOfRows(inSection: indexPath.section)
+        return indexPath.section < numberOfSections && indexPath.row < numberOfRows(inSection: indexPath.section)
     }
 
     /// SwifterSwift: Safely scroll to possibly invalid IndexPath

--- a/Sources/Extensions/UIKit/UITextFieldExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextFieldExtensions.swift
@@ -154,7 +154,7 @@ public extension UITextField {
         imageView.contentMode = .center
         leftView = imageView
         leftView?.frame.size = CGSize(width: image.size.width + padding, height: image.size.height)
-        leftViewMode = UITextField.ViewMode.always
+        leftViewMode = .always
     }
 
 }

--- a/Sources/Extensions/UIKit/UITextFieldExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextFieldExtensions.swift
@@ -132,7 +132,7 @@ public extension UITextField {
     /// - Parameter color: placeholder text color.
     public func setPlaceHolderTextColor(_ color: UIColor) {
         guard let holder = placeholder, !holder.isEmpty else { return }
-        self.attributedPlaceholder = NSAttributedString(string: holder, attributes: [.foregroundColor: color])
+        attributedPlaceholder = NSAttributedString(string: holder, attributes: [.foregroundColor: color])
     }
 
     /// SwifterSwift: Add padding to the left of the textfield rect.
@@ -152,9 +152,9 @@ public extension UITextField {
     public func addPaddingLeftIcon(_ image: UIImage, padding: CGFloat) {
         let imageView = UIImageView(image: image)
         imageView.contentMode = .center
-        self.leftView = imageView
-        self.leftView?.frame.size = CGSize(width: image.size.width + padding, height: image.size.height)
-        self.leftViewMode = UITextField.ViewMode.always
+        leftView = imageView
+        leftView?.frame.size = CGSize(width: image.size.width + padding, height: image.size.height)
+        leftViewMode = UITextField.ViewMode.always
     }
 
 }

--- a/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -15,7 +15,7 @@ public extension UIViewController {
     /// SwifterSwift: Check if ViewController is onscreen and not hidden.
     public var isVisible: Bool {
         // http://stackoverflow.com/questions/2777438/how-to-tell-if-uiviewcontrollers-view-is-visible
-        return self.isViewLoaded && view.window != nil
+        return isViewLoaded && view.window != nil
     }
 
 }

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -280,7 +280,7 @@ public extension UIView {
     ///
     /// - Parameter subviews: array of subviews to add to self.
     public func addSubviews(_ subviews: [UIView]) {
-        subviews.forEach({ self.addSubview($0) })
+        subviews.forEach({ addSubview($0) })
     }
 
     /// SwifterSwift: Fade in view.

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -280,7 +280,7 @@ public extension UIView {
     ///
     /// - Parameter subviews: array of subviews to add to self.
     public func addSubviews(_ subviews: [UIView]) {
-        subviews.forEach({ addSubview($0) })
+        subviews.forEach { addSubview($0) }
     }
 
     /// SwifterSwift: Fade in view.


### PR DESCRIPTION
Removed "self." calls where not needed. According to most code style guides (for example https://github.com/raywenderlich/swift-style-guide#use-of-self) they should be avoided where possible. What is your opinion about this?

I didn't add a changelog because it's only a style change (or should I?).

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
