### PR TITLE
Added missing WhatsApp color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 - **Dictionary**
   - Added `Dictionary[path:]` subscript for deep fetching/setting nested values. [#574](https://github.com/SwifterSwift/SwifterSwift/pull/573) by [@calebkleveter](https://github.com/calebkleveter)
+- **UIColor**
+  - Added `whatsApp` color constant. [#581](https://github.com/SwifterSwift/SwifterSwift/pull/581) by [staffler-xyz](https://github.com/staffler-xyz)
 ### Changed
 ### Fixed
 - **UIImage**:

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -441,6 +441,9 @@ public extension Color {
 
         /// red: 255, green: 252, blue: 0
         public static let snapchat = Color(red: 255, green: 252, blue: 0)!
+
+        /// red: 37, green: 211, blue: 102
+        public static let whatsApp = Color(red: 37, green: 211, blue: 102)!
     }
 
 }


### PR DESCRIPTION
WhatsApp color was missing in the social color constants, added it :-)

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
