### PR TITLE
Add new extensions of `DispatchQueue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIColor**
   - Added `whatsApp` color constant. [#581](https://github.com/SwifterSwift/SwifterSwift/pull/581) by [staffler-xyz](https://github.com/staffler-xyz)
 - **DispatchQueue**
-  - Added `isMainQueue` to check if current queue is main queue.
-  - Added `isCurrent(_:)` to check if current queue is specified queue.
+  - Added `isMainQueue` to check if current queue is main queue. [#585](https://github.com/SwifterSwift/SwifterSwift/pull/585) by [jianstm](https://github.com/jianstm)
+  - Added `isCurrent(_:)` to check if current queue is specified queue. [#585](https://github.com/SwifterSwift/SwifterSwift/pull/585) by [jianstm](https://github.com/jianstm)
 ### Changed
 ### Fixed
 - **UIImage**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `Dictionary[path:]` subscript for deep fetching/setting nested values. [#574](https://github.com/SwifterSwift/SwifterSwift/pull/573) by [@calebkleveter](https://github.com/calebkleveter)
 - **UIColor**
   - Added `whatsApp` color constant. [#581](https://github.com/SwifterSwift/SwifterSwift/pull/581) by [staffler-xyz](https://github.com/staffler-xyz)
+- **DispatchQueue**
+  - Added `isMainQueue` to check if current queue is main queue.
+  - Added `isCurrent(_:)` to check if current queue is specified queue.
 ### Changed
 ### Fixed
 - **UIImage**:

--- a/Sources/Extensions/Dispatch/DispatchQueueExtensions.swift
+++ b/Sources/Extensions/Dispatch/DispatchQueueExtensions.swift
@@ -1,0 +1,48 @@
+//
+//  DispatchQueueExtensions.swift
+//  SwifterSwift
+//
+//  Created by Quentin Jin on 2018/10/13.
+//  Copyright © 2018 SwifterSwift
+//
+
+#if canImport(Dispatch)
+import Dispatch
+
+// MARK: - Properties
+public extension DispatchQueue {
+
+    /// SwifterSwift: A Boolean value indicating whether the current
+    /// dispatch queue is the main queue.
+    public static var isMainQueue: Bool {
+        enum Static {
+            static var key: DispatchSpecificKey<Void> = {
+                let key = DispatchSpecificKey<Void>()
+                DispatchQueue.main.setSpecific(key: key, value: ())
+                return key
+            }()
+        }
+        return DispatchQueue.getSpecific(key: Static.key) != nil
+    }
+
+}
+
+// MARK: - Methods
+public extension DispatchQueue {
+
+    /// SwifterSwift: Returns a Boolean value indicating whether the current
+    /// dispatch queue is the specified queue.
+    ///
+    /// - Parameter queue: The queue to compare against.
+    /// - Returns: `true` if the current queue is the specified queue, otherwise `false`.
+    public static func isCurrent(_ queue: DispatchQueue) -> Bool {
+        let key = DispatchSpecificKey<Void>()
+
+        queue.setSpecific(key: key, value: ())
+        defer { queue.setSpecific(key: key, value: nil) }
+
+        return DispatchQueue.getSpecific(key: key) != nil
+    }
+
+}
+#endif

--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -63,4 +63,9 @@ Pod::Spec.new do |s|
     sp.source_files = 'Sources/Extensions/SpriteKit/*.swift'
   end
 
+  # Dispatch Extensions
+  s.subspec 'Dispatch' do |sp|
+    sp.source_files = 'Sources/Extensions/Dispatch/*.swift'
+  end
+
 end

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -333,6 +333,13 @@
 		278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */; };
 		42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */; };
 		42F53FF02039C7140070DC11 /* UIStackViewExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */; };
+		664CB983217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB982217243D200FC87B4 /* DispatchQueueExtensions.swift */; };
+		664CB984217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB982217243D200FC87B4 /* DispatchQueueExtensions.swift */; };
+		664CB985217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB982217243D200FC87B4 /* DispatchQueueExtensions.swift */; };
+		664CB986217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB982217243D200FC87B4 /* DispatchQueueExtensions.swift */; };
+		664CB98A21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB98921724A9100FC87B4 /* DispatchQueueExtensionsTests.swift */; };
+		664CB98B21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB98921724A9100FC87B4 /* DispatchQueueExtensionsTests.swift */; };
+		664CB98C21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB98921724A9100FC87B4 /* DispatchQueueExtensionsTests.swift */; };
 		70269A2B1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
 		70269A2C1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
 		70269A2D1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */; };
@@ -583,6 +590,8 @@
 		278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensionsTests.swift; sourceTree = "<group>"; };
 		42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensions.swift; sourceTree = "<group>"; };
 		42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTest.swift; sourceTree = "<group>"; };
+		664CB982217243D200FC87B4 /* DispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensions.swift; sourceTree = "<group>"; };
+		664CB98921724A9100FC87B4 /* DispatchQueueExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueExtensionsTests.swift; sourceTree = "<group>"; };
 		70269A2A1FB478D100C6C2D0 /* CalendarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensions.swift; sourceTree = "<group>"; };
 		70269A2F1FB47B0C00C6C2D0 /* CalendarExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtensionTest.swift; sourceTree = "<group>"; };
 		734307F72108C2240029CD16 /* CGVectorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGVectorExtensions.swift; sourceTree = "<group>"; };
@@ -776,6 +785,7 @@
 		07898B941F27904200558C97 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				664CB981217243BA00FC87B4 /* Dispatch */,
 				752AC79E20BC974700659E76 /* SpriteKit */,
 				784C752D2051BD01001C48DD /* MapKit */,
 				0726D7751F7C19880028CAB5 /* Shared */,
@@ -868,6 +878,7 @@
 				07C50D241F5EB03200F46E5A /* AppKitTests */,
 				07D8960E1F5ED89A00FC894D /* CoreGraphicsTests */,
 				07D8960F1F5ED8AB00FC894D /* CoreLocationTests */,
+				664CB98821724A3A00FC87B4 /* DispatchTests */,
 				07C50CF91F5EB03200F46E5A /* FoundationTests */,
 				07C50CCD1F5EAF2700F46E5A /* Info.plist */,
 				784C75322051BDCA001C48DD /* MapKitTests */,
@@ -983,6 +994,22 @@
 				07C50D281F5EB03200F46E5A /* CLLocationExtensionsTests.swift */,
 			);
 			path = CoreLocationTests;
+			sourceTree = "<group>";
+		};
+		664CB981217243BA00FC87B4 /* Dispatch */ = {
+			isa = PBXGroup;
+			children = (
+				664CB982217243D200FC87B4 /* DispatchQueueExtensions.swift */,
+			);
+			path = Dispatch;
+			sourceTree = "<group>";
+		};
+		664CB98821724A3A00FC87B4 /* DispatchTests */ = {
+			isa = PBXGroup;
+			children = (
+				664CB98921724A9100FC87B4 /* DispatchQueueExtensionsTests.swift */,
+			);
+			path = DispatchTests;
 			sourceTree = "<group>";
 		};
 		752AC79E20BC974700659E76 /* SpriteKit */ = {
@@ -1508,6 +1535,7 @@
 				07B7F2311F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F20D1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F19D1F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
+				664CB983217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */,
 				07B7F21A1F5EB43C00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F2331F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				B29527AD20F99E9700E1F75D /* RandomAccessCollectionExtensions.swift in Sources */,
@@ -1551,6 +1579,7 @@
 				07B7F2061F5EB43C00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				07B7F1BD1F5EB42000E6F910 /* UIViewExtensions.swift in Sources */,
 				07B7F1AF1F5EB42000E6F910 /* UILabelExtensions.swift in Sources */,
+				664CB984217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */,
 				9D9784DC1FCAE42600D988E7 /* StringProtocolExtensions.swift in Sources */,
 				07B7F1FA1F5EB43C00E6F910 /* BoolExtensions.swift in Sources */,
 				A9AEB78620283ACC0021AACF /* FileManagerExtensions.swift in Sources */,
@@ -1630,6 +1659,7 @@
 				07B7F22C1F5EB45100E6F910 /* CLLocationExtensions.swift in Sources */,
 				07B7F1EA1F5EB43B00E6F910 /* CollectionExtensions.swift in Sources */,
 				07B7F1F11F5EB43B00E6F910 /* IntExtensions.swift in Sources */,
+				664CB985217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */,
 				07B7F1ED1F5EB43B00E6F910 /* DictionaryExtensions.swift in Sources */,
 				07B7F22A1F5EB45100E6F910 /* CGPointExtensions.swift in Sources */,
 				734308092108E4640029CD16 /* CGVectorExtensions.swift in Sources */,
@@ -1718,6 +1748,7 @@
 				07B7F1D51F5EB43B00E6F910 /* ArrayExtensions.swift in Sources */,
 				7832C2B2209BB19300224EED /* ComparableExtensions.swift in Sources */,
 				07B7F21C1F5EB43E00E6F910 /* SwifterSwift.swift in Sources */,
+				664CB986217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */,
 				078CE2A2207643F8001720DF /* UIKitDeprecated.swift in Sources */,
 				B23678EF1FB116AD0027C931 /* SwiftStdlibDeprecated.swift in Sources */,
 				07B7F1D91F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
@@ -1740,6 +1771,7 @@
 				07C50D5C1F5EB05000F46E5A /* DateExtensionsTests.swift in Sources */,
 				077BA09E1F6BEA4900D9C4AC /* URLRequestExtensionsTests.swift in Sources */,
 				07C50D2E1F5EB04600F46E5A /* UICollectionViewExtensionsTests.swift in Sources */,
+				664CB98A21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */,
 				07C50D3C1F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
 				078916DE20760DA700AC0665 /* SignedIntegerExtensionsTests.swift in Sources */,
 				07C50D381F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
@@ -1863,6 +1895,7 @@
 				07C50D531F5EB04700F46E5A /* UITextFieldExtensionsTests.swift in Sources */,
 				07C50D721F5EB05100F46E5A /* URLExtensionsTests.swift in Sources */,
 				07C50D411F5EB04700F46E5A /* UIAlertControllerExtensionsTests.swift in Sources */,
+				664CB98B21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */,
 				07C50D6C1F5EB05100F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				07C50D6B1F5EB05100F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D691F5EB05100F46E5A /* DataExtensionsTests.swift in Sources */,
@@ -1895,6 +1928,7 @@
 				07C50D7F1F5EB05100F46E5A /* StringExtensionsTests.swift in Sources */,
 				70269A311FB47B0C00C6C2D0 /* CalendarExtensionTest.swift in Sources */,
 				07C50D7A1F5EB05100F46E5A /* DoubleExtensionsTests.swift in Sources */,
+				664CB98C21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */,
 				18C8E5E52074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */,
 				182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */,

--- a/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
+++ b/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
@@ -1,0 +1,56 @@
+//
+//  DispatchQueueExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Quentin Jin on 2018/10/13.
+//  Copyright © 2018 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if canImport(Dispatch)
+import Dispatch
+
+final class DispatchQueueExtensionsTests: XCTestCase {
+
+    func testIsMainQueue() {
+        let expect = expectation(description: "isMainQueue")
+        let group = DispatchGroup()
+
+        DispatchQueue.main.async(group: group) {
+            XCTAssertTrue(DispatchQueue.isMainQueue)
+        }
+        DispatchQueue.global().async(group: group) {
+            XCTAssertFalse(DispatchQueue.isMainQueue)
+        }
+
+        group.notify(queue: .main) {
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testIsCurrent() {
+        let expect = expectation(description: "isCurrent")
+        let group = DispatchGroup()
+        let queue = DispatchQueue.global()
+
+        queue.async(group: group) {
+            XCTAssertTrue(DispatchQueue.isCurrent(queue))
+        }
+        DispatchQueue.main.async(group: group) {
+            XCTAssertTrue(DispatchQueue.isCurrent(DispatchQueue.main))
+            XCTAssertFalse(DispatchQueue.isCurrent(queue))
+        }
+
+        group.notify(queue: .main) {
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add `isMainQueue` to check if current queue is main queue, add `isCurrent(_:)` to check if current queue is specified queue. It's very useful to avoid `sync` on a serial queue. eg:

```Swift
if DispatchQueue.isMainQueue { 
    return
}

let logQueue = DispatchQueue(label: "logQueue")
if DispatchQueue.isCurrent(logQueue) {
    return 
}
```

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
