### PR TITLE
Add contains(_:times:) to Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **BinaryFloatingPointExtensions**
   - Added `rounded(numberOfDecimalPlaces:rule:)` to get the rounded floating number with the specified number of decimal places. [#583](https://github.com/SwifterSwift/SwifterSwift/pull/583) by [jianstm](https://github.com/jianstm)
 - **SequenceExtensions**
-  - Added `contains(_:times:)` to check if the sequence contains the provided element exactly `n` times. [#588](https://github.com/SwifterSwift/SwifterSwift/pull/588) by [MrLotU](https://github.com/MrLotU)
+  - Added `contains(_:times:)` to check if the sequence contains the provided element exactly `times` times. [#588](https://github.com/SwifterSwift/SwifterSwift/pull/588) by [MrLotU](https://github.com/MrLotU)
 ### Changed
 ### Fixed
 - **UIImage**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `subscript[offset:]` to get element with negative offset. [#582](https://github.com/SwifterSwift/SwifterSwift/pull/582) by [jianstm](https://github.com/jianstm)
 - **BinaryFloatingPointExtensions**
   - Added `rounded(numberOfDecimalPlaces:rule:)` to get the rounded floating number with the specified number of decimal places. [#583](https://github.com/SwifterSwift/SwifterSwift/pull/583) by [jianstm](https://github.com/jianstm)
+- **SequenceExtensions**
+  - Added `contains(_:times:)` to check if the sequence contains the provided element exactly `n` times. [#588](https://github.com/SwifterSwift/SwifterSwift/pull/588) by [MrLotU](https://github.com/MrLotU)
 ### Changed
 ### Fixed
 - **UIImage**:

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -180,6 +180,26 @@ public extension Sequence where Element: Equatable {
         return true
     }
 
+    /// SwifterSwift: Check if sequence contains element exactly `n` times
+    ///
+    ///     [1, 2, 3, 1].contains(1, times: 1) -> False
+    ///     [1, 2, 3, 1].contains(1, times: 2) -> True
+    ///     ["h", "e", "l", "l", "o"].contains("l", times: 2) -> true
+    ///
+    /// - Parameter element: element to check
+    /// - Parameter n: amount of times element should appear in the sequence
+    /// - Returns: true if sequence contains element n times
+    public func contains(_ element: Element, times n: Int) -> Bool {
+        var matches = 0
+        
+        for item in self {
+            if item == element {
+                matches += 1
+            }
+        }
+        
+        return matches == n
+    }
 }
 
 public extension Sequence where Element: Hashable {

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -189,7 +189,7 @@ public extension Sequence where Element: Equatable {
     /// - Parameters:
     ///     - element: element to check
     ///     - times: amount of times element should appear in the sequence
-    /// - Returns: true if sequence contains element n times
+    /// - Returns: true if sequence contains element `times` times
     public func contains(_ element: Element, times: Int) -> Bool {
         var matches = 0
 

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -192,13 +192,11 @@ public extension Sequence where Element: Equatable {
     /// - Returns: true if sequence contains element n times
     public func contains(_ element: Element, times n: Int) -> Bool {
         var matches = 0
-        
-        for item in self {
-            if item == element {
-                matches += 1
-            }
+
+        for item in self where item == element {
+            matches += 1
         }
-        
+
         return matches == n
     }
 }

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -180,7 +180,7 @@ public extension Sequence where Element: Equatable {
         return true
     }
 
-    /// SwifterSwift: Check if sequence contains element exactly `n` times
+    /// SwifterSwift: Check if sequence contains element exactly `times` times
     ///
     ///     [1, 2, 3, 1].contains(1, times: 1) -> false
     ///     [1, 2, 3, 1].contains(1, times: 2) -> true
@@ -188,16 +188,16 @@ public extension Sequence where Element: Equatable {
     ///
     /// - Parameters:
     ///     - element: element to check
-    ///     - n: amount of times element should appear in the sequence
+    ///     - times: amount of times element should appear in the sequence
     /// - Returns: true if sequence contains element n times
-    public func contains(_ element: Element, times n: Int) -> Bool {
+    public func contains(_ element: Element, times: Int) -> Bool {
         var matches = 0
 
         for item in self where item == element {
             matches += 1
         }
 
-        return matches == n
+        return matches == times
     }
 }
 

--- a/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SequenceExtensions.swift
@@ -182,12 +182,13 @@ public extension Sequence where Element: Equatable {
 
     /// SwifterSwift: Check if sequence contains element exactly `n` times
     ///
-    ///     [1, 2, 3, 1].contains(1, times: 1) -> False
-    ///     [1, 2, 3, 1].contains(1, times: 2) -> True
+    ///     [1, 2, 3, 1].contains(1, times: 1) -> false
+    ///     [1, 2, 3, 1].contains(1, times: 2) -> true
     ///     ["h", "e", "l", "l", "o"].contains("l", times: 2) -> true
     ///
-    /// - Parameter element: element to check
-    /// - Parameter n: amount of times element should appear in the sequence
+    /// - Parameters:
+    ///     - element: element to check
+    ///     - n: amount of times element should appear in the sequence
     /// - Returns: true if sequence contains element n times
     public func contains(_ element: Element, times n: Int) -> Bool {
         var matches = 0

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -93,6 +93,15 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssert([1, 2, 3].contains([1, 3]))
         XCTAssertFalse([1, 2, 3].contains([4, 5]))
     }
+    
+    func testContainsTimes() {
+        let collection = [1, 2, 3, 4, 5, 1, 3, 4, 5, 1]
+        XCTAssert(collection.contains(1, times: 3))
+        XCTAssert(collection.contains(2, times: 1))
+        XCTAssertFalse(collection.contains(5, times: 1))
+        XCTAssertFalse(collection.contains(1, times: 0))
+        XCTAssert(collection.contains(6, times: 0))
+    }
 
     func testContainsDuplicates() {
         XCTAssertFalse([String]().containsDuplicates())

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -93,7 +93,7 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssert([1, 2, 3].contains([1, 3]))
         XCTAssertFalse([1, 2, 3].contains([4, 5]))
     }
-    
+
     func testContainsTimes() {
         let collection = [1, 2, 3, 4, 5, 1, 3, 4, 5, 1]
         XCTAssert(collection.contains(1, times: 3))


### PR DESCRIPTION
🚀<!--- Provide a general summary of your changes in the Title above -->
Adds `contains(_:times:)` to Sequence to check if a Sequence contains specified element exactly `n` times

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
