### PR TITLE
Add `contains(_:times:)` to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `subscript[offset:]` to get element with negative offset. [#582](https://github.com/SwifterSwift/SwifterSwift/pull/582) by [jianstm](https://github.com/jianstm)
 - **BinaryFloatingPointExtensions**
   - Added `rounded(numberOfDecimalPlaces:rule:)` to get the rounded floating number with the specified number of decimal places. [#583](https://github.com/SwifterSwift/SwifterSwift/pull/583) by [jianstm](https://github.com/jianstm)
+- **StringExtensions**
+  - Added `contains(_:times:)` to check if the string contains the provided substring exactly `times` times. [#589](https://github.com/SwifterSwift/SwifterSwift/pull/589) by [MrLotU](https://github.com/MrLotU)
 ### Changed
 ### Fixed
 - **UIImage**:

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -677,6 +677,34 @@ public extension String {
         return range(of: string) != nil
     }
     #endif
+    
+    /// SwifterSwift: Check if string contains substring exactly `times` times
+    ///
+    ///     "hellohello".contains("hello", times: 2) -> true
+    ///     "hello".contains("h", times: 2) -> false
+    ///     "hello.contains("l", times: 2) -> true
+    /// - Parameters:
+    ///     - string: substring to search for
+    ///     - times: amount of times substring should appear in the string
+    /// - Returns: true if string contains substring `times` times
+    public func contains<S>(_ string: S, times: Int) -> Bool where S: StringProtocol {
+        var index = self.startIndex
+        var matchEnd = self.index(self.startIndex, offsetBy: string.count - 1)
+        var matches = 0
+        
+        while matchEnd < self.endIndex {
+            if self[index] == string.first {
+                if self[index...matchEnd] == string {
+                    matches += 1
+                }
+            }
+            
+            index = self.index(index, offsetBy: 1)
+            matchEnd = self.index(index, offsetBy: string.count - 1)
+        }
+        
+        return matches == times
+    }
 
     #if canImport(Foundation)
     /// SwifterSwift: Count of substring in string.

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -677,7 +677,7 @@ public extension String {
         return range(of: string) != nil
     }
     #endif
-    
+
     /// SwifterSwift: Check if string contains substring exactly `times` times
     ///
     ///     "hellohello".contains("hello", times: 2) -> true
@@ -691,18 +691,18 @@ public extension String {
         var index = self.startIndex
         var matchEnd = self.index(self.startIndex, offsetBy: string.count - 1)
         var matches = 0
-        
+
         while matchEnd < self.endIndex {
             if self[index] == string.first {
                 if self[index...matchEnd] == string {
                     matches += 1
                 }
             }
-            
+
             index = self.index(index, offsetBy: 1)
             matchEnd = self.index(index, offsetBy: string.count - 1)
         }
-        
+
         return matches == times
     }
 

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -682,7 +682,7 @@ public extension String {
     ///
     ///     "hellohello".contains("hello", times: 2) -> true
     ///     "hello".contains("h", times: 2) -> false
-    ///     "hello.contains("l", times: 2) -> true
+    ///     "hello".contains("l", times: 2) -> true
     /// - Parameters:
     ///     - string: substring to search for
     ///     - times: amount of times substring should appear in the string

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -378,6 +378,13 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssert("Hello Tests".contains("Hello", caseSensitive: true))
         XCTAssert("Hello Tests".contains("hello", caseSensitive: false))
     }
+    
+    func testContainsTimes() {
+        let str = "hellohello"
+        XCTAssert(str.contains("h", times: 2))
+        XCTAssert(str.contains("hello", times: 2))
+        XCTAssertFalse(str.contains("l", times: 3))
+    }
 
     func testCount() {
         XCTAssertEqual("Hello This Tests".count(of: "T"), 2)

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -378,7 +378,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssert("Hello Tests".contains("Hello", caseSensitive: true))
         XCTAssert("Hello Tests".contains("hello", caseSensitive: false))
     }
-    
+
     func testContainsTimes() {
         let str = "hellohello"
         XCTAssert(str.contains("h", times: 2))


### PR DESCRIPTION
🚀 <!--- Provide a general summary of your changes in the Title above -->
Adds contains(_:times:) to String to check if a String contains specified substring exactly `times` times
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
