### PR TITLE
Fix unit test fail of testing date beginning

### DIFF
--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -638,12 +638,12 @@ final class DateExtensionsTests: XCTestCase {
         XCTAssertNotNil(beginningOfWeek)
         XCTAssertEqual(date.beginning(of: .weekOfMonth)?.day, beginningOfWeek?.day)
 
-        let beginningOfMonth = Date(year: 2016, month: 8, day: 1, hour: 5)
+        let beginningOfMonth = Date(timeZone: Date().timeZone, year: 2016, month: 8, day: 1, hour: 5)
         XCTAssertNotNil(date.beginning(of: .month))
         XCTAssertNotNil(beginningOfMonth)
         XCTAssertEqual(date.beginning(of: .month)?.day, beginningOfMonth?.day)
 
-        let beginningOfYear = Date(year: 2016, month: 1, day: 1, hour: 5)
+        let beginningOfYear = Date(timeZone: Date().timeZone, year: 2016, month: 1, day: 1, hour: 5)
         XCTAssertNotNil(date.beginning(of: .year))
         XCTAssertNotNil(beginningOfYear)
         XCTAssertEqual(date.beginning(of: .year)?.day, beginningOfYear?.day)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
👻 Fix unit test failed cause by timezone problem not new feature

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
