### PR TITLE
Adding convenience method to present a popover.

### DIFF
--- a/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -96,5 +96,29 @@ public extension UIViewController {
         removeFromParent()
         view.removeFromSuperview()
     }
+
+    /// SwifterSwift: Helper method to present a UIViewController as a popover.
+    ///
+    /// - Parameters:
+    ///   - popoverContent: the view controller to add as a popover.
+    ///   - sourcePoint: the point in which to anchor the popover.
+    ///   - size: the size of the popover. Default uses the popover preferredContentSize.
+    ///   - delegate: the popover's presentationController delegate. Default is nil.
+    ///   - completion: The block to execute after the presentation finishes. Default is nil.
+    public func presentPopover(_ popoverContent: UIViewController, sourcePoint: CGPoint, size: CGSize? = nil, delegate: UIPopoverPresentationControllerDelegate? = nil, completion: ( () -> Void)? = nil) {
+
+        popoverContent.modalPresentationStyle = .popover
+
+        if let size = size {
+            popoverContent.preferredContentSize = size
+        }
+
+        let popoverPresentationVC = popoverContent.popoverPresentationController!
+        popoverPresentationVC.sourceView = self.view
+        popoverPresentationVC.sourceRect = CGRect(origin: sourcePoint, size: .zero)
+        popoverPresentationVC.delegate = delegate
+
+        self.present(popoverContent, animated: true, completion: completion)
+    }
 }
 #endif

--- a/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
@@ -119,6 +119,17 @@ final class UIViewControllerExtensionsTests: XCTestCase {
 
         XCTAssertNil(childViewController.parent)
     }
+    
+    func testPresentPopover() {
+        let popover = UIViewController()
+        let vc = UIViewController()
+        
+        vc.presentPopover(popover, sourcePoint: vc.view.center) {
+            XCTAssertEqual(vc.presentedViewController, popover)
+            XCTAssertEqual(popover.presentingViewController, vc)
+            XCTAssertEqual(popover.modalPresentationStyle, .popover)
+        }
+    }
 
 }
 #endif


### PR DESCRIPTION
This PR adds a methods to present a view controller as a popover, which usually requires multiple lines of code.
I'm not sure the test is exhaustive enough, so I'm happy to receive suggestions.
## Checklist
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x] New extensions are written in Swift 4.
- [x ] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.