### PR TITLE
Remove `timeZone` from `Date` extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Date**
-  - `random(in:)` and `random(in:using:)` to generate random dates using the built-in random functions added to Swift 4.2. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576/files) by [guykogus](https://github.com/guykogus)
+  - `random(in:)` and `random(in:using:)` to generate random dates using the built-in random functions added to Swift 4.2. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576) by [guykogus](https://github.com/guykogus)
 - **Dictionary**
   - Added `Dictionary[path:]` subscript for deep fetching/setting nested values. [#574](https://github.com/SwifterSwift/SwifterSwift/pull/573) by [@calebkleveter](https://github.com/calebkleveter)
 - **UIColor**
@@ -23,7 +23,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `cropped(to:)` fixed size checking. [#575](https://github.com/SwifterSwift/SwifterSwift/pull/575) by [ilyahal](https://github.com/ilyahal)
 ### Deprecated
 - **Date**
-  - `random(from:upTo:)` in favor of `random(in:)` and `random(in:using:)`. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576/files) by [guykogus](https://github.com/guykogus)
+  - `random(from:upTo:)` in favor of `random(in:)` and `random(in:using:)`. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576) by [guykogus](https://github.com/guykogus)
+  - `timeZone` should never have been added because `Date`s are timezone-agnostic. This came to my attention during unit testing over daylight savings changes. [#594](https://github.com/SwifterSwift/SwifterSwift/pull/594) by [guykogus](https://github.com/guykogus)
 ### Removed
 ### Security
 
@@ -635,7 +636,7 @@ N/A
 
 - New **Array** extensions
     - added `groupByKey` to group the elements of the array by key in a dictionary. [#181](https://github.com/SwifterSwift/SwifterSwift/pull/181) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
-    - added `forEach(slice:body:)` to iterate by specified slice size and call a closure. [#194](https://github.com/SwifterSwift/SwifterSwift/pull/194/files) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+    - added `forEach(slice:body:)` to iterate by specified slice size and call a closure. [#194](https://github.com/SwifterSwift/SwifterSwift/pull/194) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 - New **Dictionary** extensions
     - add `count(where:)` to count dictionary elements where the condition returns true. [#193](https://github.com/SwifterSwift/SwifterSwift/pull/193) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -449,14 +449,6 @@ public extension Date {
         return Calendar.current.date(byAdding: .hour, value: 1, to: date)!
     }
 
-    /// SwifterSwift: Time zone used currently by system.
-    ///
-    ///		Date().timeZone -> Europe/Istanbul (current)
-    ///
-    public var timeZone: TimeZone {
-        return Calendar.current.timeZone
-    }
-
     /// SwifterSwift: Yesterday date.
     ///
     ///     let date = Date() // "Oct 3, 2018, 10:57:11"

--- a/Sources/Extensions/Foundation/Deprecated/FoundationDeprecated.swift
+++ b/Sources/Extensions/Foundation/Deprecated/FoundationDeprecated.swift
@@ -36,5 +36,14 @@ extension Date {
         return startReferenceDate.addingTimeInterval(TimeInterval(randomValue))
     }
 
+    /// SwifterSwift: Time zone used currently by system.
+    ///
+    ///        Date().timeZone -> Europe/Istanbul (current)
+    ///
+    @available(*, deprecated: 4.7.0, message: "`Date` objects are timezone-agnostic. Please use Calendar.current.timeZone instead.")
+    public var timeZone: TimeZone {
+        return Calendar.current.timeZone
+    }
+
 }
 #endif

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -458,10 +458,6 @@ final class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(date3.nearestHour, date.adding(.hour, value: 1))
     }
 
-    func testTimezone() {
-        XCTAssertEqual(Date().timeZone, Calendar.current.timeZone)
-    }
-
     func testUnixTimestamp() {
         let date = Date()
         XCTAssertEqual(date.unixTimestamp, date.timeIntervalSince1970)


### PR DESCRIPTION
🚀
`Date` objects do not have any information about timezones. They're a representation of a specific point in time, doesn't matter where in the world. This was causing confusion in some of the unit tests that were using it without realising that it was wrong, which were fixed in https://github.com/SwifterSwift/SwifterSwift/pull/592.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.