### PR TITLE
Fixed typos in UITableViewExtensions.swift

### DIFF
--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -99,7 +99,7 @@ public extension UITableView {
         return cell
     }
 
-    /// SwiferSwift: Dequeue reusable UITableViewCell using class name for indexPath
+    /// SwifterSwift: Dequeue reusable UITableViewCell using class name for indexPath
     ///
     /// - Parameters:
     ///   - name: UITableViewCell type.
@@ -112,7 +112,7 @@ public extension UITableView {
         return cell
     }
 
-    /// SwiferSwift: Dequeue reusable UITableViewHeaderFooterView using class name
+    /// SwifterSwift: Dequeue reusable UITableViewHeaderFooterView using class name
     ///
     /// - Parameter name: UITableViewHeaderFooterView type
     /// - Returns: UITableViewHeaderFooterView object with associated class name.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x ] New extensions are written in Swift 4.
- [x ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x ] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x ] All extensions are declared as **public**.
- [ x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
