### PR TITLE
Added method to return dominant language of a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `rounded(numberOfDecimalPlaces:rule:)` to get the rounded floating number with the specified number of decimal places. [#583](https://github.com/SwifterSwift/SwifterSwift/pull/583) by [jianstm](https://github.com/jianstm)
 - **UIActivity**
   - Added `ActivityType` constants for iCloud Drive, WhatsApp, LinkedIn and XING. [#580](https://github.com/SwifterSwift/SwifterSwift/pull/580) by [staffler-xyz](https://github.com/staffler-xyz)
+- **String**
+    - Added `dominantLanguage() -> String` which returns the *BCP-47 tag* identifying the dominant language of the string, or the tag `und` if a specific language cannot be determined.`
+
 ### Changed
 - **Examples**:
   - Replace Examples.md with Examples.playground to let users try some examples out of extensions. [#596](https://github.com/SwifterSwift/SwifterSwift/pull/596) by [maxxx777](https://github.com/maxxx777)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIActivity**
   - Added `ActivityType` constants for iCloud Drive, WhatsApp, LinkedIn and XING. [#580](https://github.com/SwifterSwift/SwifterSwift/pull/580) by [staffler-xyz](https://github.com/staffler-xyz)
 - **String**
-    - Added `dominantLanguage() -> String` which returns the *BCP-47 tag* identifying the dominant language of the string, or the tag `und` if a specific language cannot be determined.`
+  - Added `dominantLanguage()` which returns the *BCP-47 tag* identifying the dominant language of the string, or the tag `und` if a specific language cannot be determined.`
 
 ### Changed
 - **Examples**:

--- a/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
@@ -30,6 +30,16 @@ public extension Double {
     }
     #endif
 
+    /// SwifterSwift: Convert from one unit of length measurement to another
+    ///
+    /// - Parameters:
+    ///   - originalUnit: The original unit of measurement
+    ///   - convertedUnit: The unit of measurement to be outputted
+    /// - Returns: The Double's converted unit of measurement
+    @available(iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    func convert(from originalUnit: UnitLength, to convertedUnit: UnitLength) -> Double {
+        return Measurement(value: self, unit: originalUnit).converted(to: convertedUnit).value
+    }
 }
 
 // MARK: - Operators

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -494,8 +494,8 @@ public extension String {
     ///
     /// "中文dda  ".dominantLanguage() -> "und"
     ///
-    /// - Returns: The BCP-47 tag identifying the dominant language of the string, or the tag "und" if a specific language cannot be determined
-    @available(iOS 11.0, *)
+    /// - Returns: The BCP-47 tag identifying the dominant language of the receiver, or the tag "und" if a specific language cannot be determined
+    @available(iOS 11.0, *, macOS 10.13, tvOS 11.0, watchOS 4.0)
     public func dominantLanguage() -> String? {
         return NSLinguisticTagger.dominantLanguage(for: self)
     }

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -484,7 +484,7 @@ public extension String {
     }
     #endif
 
-    /// SwifterSwift: Returns the dominant language of `String`
+    /// SwifterSwift: Returns the dominant language of the receiver
     ///
     /// "这是中国人".dominantLanguage() -> "zh-Hans"
     ///

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -484,6 +484,22 @@ public extension String {
     }
     #endif
 
+    /// SwifterSwift: Returns the dominant language of `String`
+    ///
+    /// "这是中国人".dominantLanguage() -> "zh-Hans"
+    ///
+    /// "Das ist deutsch".dominantLanguage() -> "de"
+    ///
+    /// "이것은 한국어이다".dominantLanguage() -> "ko"
+    ///
+    /// "中文dda  ".dominantLanguage() -> "und"
+    ///
+    /// - Returns: The BCP-47 tag identifying the dominant language of the string, or the tag "und" if a specific language cannot be determined
+    @available(iOS 11.0, *)
+    public func dominantLanguage() -> String? {
+        return NSLinguisticTagger.dominantLanguage(for: self)
+    }
+
     /// SwifterSwift: The most common character in string.
     ///
     ///		"This is a test, since e is appearing everywhere e should be the common character".mostCommonCharacter() -> "e"

--- a/Sources/Extensions/UIKit/UITableViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITableViewExtensions.swift
@@ -99,7 +99,7 @@ public extension UITableView {
         return cell
     }
 
-    /// SwiferSwift: Dequeue reusable UITableViewCell using class name for indexPath
+    /// SwifterSwift: Dequeue reusable UITableViewCell using class name for indexPath
     ///
     /// - Parameters:
     ///   - name: UITableViewCell type.
@@ -112,7 +112,7 @@ public extension UITableView {
         return cell
     }
 
-    /// SwiferSwift: Dequeue reusable UITableViewHeaderFooterView using class name
+    /// SwifterSwift: Dequeue reusable UITableViewHeaderFooterView using class name
     ///
     /// - Parameter name: UITableViewHeaderFooterView type
     /// - Returns: UITableViewHeaderFooterView object with associated class name.

--- a/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
@@ -31,5 +31,17 @@ final class DoubleExtensionsTests: XCTestCase {
         XCTAssertEqual((Double(5.0) ** Double(2.0)), Double(25.0))
         XCTAssertEqual((√Double(25.0)), Double(5.0))
     }
+    
+    func testConvert() {
+        let marathon = 26.2
+        let meters = marathon.convert(from: .miles, to: .meters)
+        XCTAssertEqual(meters, 42_164.708, "Miles to meters conversion is incorrect")
+        let inches = 1.0
+        let centimeters = inches.convert(from: .inches, to: .centimeters)
+        XCTAssertEqual(centimeters, 2.54, "Inches to meters conversion is incorrect")
+        let miles = 1.0
+        let fathoms = miles.convert(from: .miles, to: .fathoms)
+        XCTAssertEqual(fathoms, 879.9978127734033, "Miles to fathoms conversionn is incorrect")
+    }
 
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -386,6 +386,16 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Hello This Tests".count(of: "t", caseSensitive: false), 3)
     }
 
+    func testDominantLanguage() {
+        XCTAssertEqual("这是中国人".dominantLanguage(), "zh-Hans")
+        XCTAssertEqual("Das ist deutsch".dominantLanguage(), "de")
+        XCTAssertEqual("이것은 한국어이다".dominantLanguage(), "ko")
+        XCTAssertEqual("これは日本語です".dominantLanguage(), "ja")
+        XCTAssertEqual("This is English".dominantLanguage(), "en")
+        XCTAssertEqual("C'est français".dominantLanguage(), "fr")
+        XCTAssertEqual("中文dda  ".dominantLanguage(), "und")
+    }
+
     func testEnd() {
         XCTAssert("Hello Test".ends(with: "test", caseSensitive: false))
         XCTAssert("Hello Tests".ends(with: "sts"))

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -387,13 +387,15 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testDominantLanguage() {
-        XCTAssertEqual("这是中国人".dominantLanguage(), "zh-Hans")
-        XCTAssertEqual("Das ist deutsch".dominantLanguage(), "de")
-        XCTAssertEqual("이것은 한국어이다".dominantLanguage(), "ko")
-        XCTAssertEqual("これは日本語です".dominantLanguage(), "ja")
-        XCTAssertEqual("This is English".dominantLanguage(), "en")
-        XCTAssertEqual("C'est français".dominantLanguage(), "fr")
-        XCTAssertEqual("中文dda  ".dominantLanguage(), "und")
+        if #available(iOS 11.0, *, macOS 10.13, tvOS 11.0, watchOS 4.0) {
+            XCTAssertEqual("这是中国人".dominantLanguage(), "zh-Hans")
+            XCTAssertEqual("Das ist deutsch".dominantLanguage(), "de")
+            XCTAssertEqual("이것은 한국어이다".dominantLanguage(), "ko")
+            XCTAssertEqual("これは日本語です".dominantLanguage(), "ja")
+            XCTAssertEqual("This is English".dominantLanguage(), "en")
+            XCTAssertEqual("C'est français".dominantLanguage(), "fr")
+            XCTAssertEqual("中文dda  ".dominantLanguage(), "und")
+        }
     }
 
     func testEnd() {


### PR DESCRIPTION
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
