### PR TITLE
Added FileManager.temporaryFileDirectory() to create a directory for saving temporary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 # Upcoming release
 
 ### Added
+- **FileManager**
+  - `temporaryFileDirectory()` to create a directory for saving temporary files. [#???](https://github.com/SwifterSwift/SwifterSwift/pull/???) by [guykogus](https://github.com/guykogus)
 - **UILabel**
     - Added `init(text:style)` to create a `UILabel` with a text and font style. [#607](https://github.com/SwifterSwift/SwifterSwift/pull/607) by [marcocapano](https://github.com/marcocapano)
 - **UIViewController**

--- a/Sources/Extensions/Foundation/FileManagerExtensions.swift
+++ b/Sources/Extensions/Foundation/FileManagerExtensions.swift
@@ -56,5 +56,28 @@ public extension FileManager {
         return nil
     }
 
+    /// Creates a unique directory for saving temporary files.
+    ///
+    /// The directory can be used to create multiple temporary files used for a common purpose.
+    ///
+    ///     let tempDirectory = try fileManager.temporaryFileDirectory()
+    ///     let tempFile1URL = tempDirectory.appendingPathComponent(ProcessInfo().globallyUniqueString)
+    ///     let tempFile2URL = tempDirectory.appendingPathComponent(ProcessInfo().globallyUniqueString)
+    ///
+    /// - Returns: A URL to a new directory for saving temporary files.
+    /// - Throws: An error if a temporary directory cannot be found or created.
+    public func temporaryFileDirectory() throws -> URL {
+        let temporaryDirectoryURL: URL
+        if #available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            temporaryDirectoryURL = temporaryDirectory
+        } else {
+            temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        }
+        return try url(for: .itemReplacementDirectory,
+                       in: .userDomainMask,
+                       appropriateFor: temporaryDirectoryURL,
+                       create: true)
+    }
+
 }
 #endif

--- a/Tests/FoundationTests/FileManagerExtensionsTests.swift
+++ b/Tests/FoundationTests/FileManagerExtensionsTests.swift
@@ -80,6 +80,21 @@ final class FileManagerExtensionsTests: XCTestCase {
         } catch {}
     }
 
+    func testTemporaryFileDirectory() {
+        do {
+            let fileManager = FileManager.default
+            let tempDirectoryPath = try fileManager.temporaryFileDirectory().path
+            XCTAssertFalse(tempDirectoryPath.isEmpty)
+
+            var isDirectory = ObjCBool(false)
+            XCTAssert(fileManager.fileExists(atPath: tempDirectoryPath, isDirectory: &isDirectory))
+            XCTAssertTrue(isDirectory.boolValue)
+            XCTAssert(try fileManager.contentsOfDirectory(atPath: tempDirectoryPath).isEmpty)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
 }
 
 #endif


### PR DESCRIPTION
`FileManager` provides a way to get the user's temporary files directory, but for saving temporary files it's necessary to actually create a new temp folder within it. This helper method allows that to be done correctly.

```Swift
let tempDirectory = try fileManager.temporaryFileDirectory()
let tempFile1URL = tempDirectory.appendingPathComponent(ProcessInfo().globallyUniqueString)
let tempFile2URL = tempDirectory.appendingPathComponent(ProcessInfo().globallyUniqueString)
```

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.