### PR TITLE
Fixing #616 bug on NSAttributedStringExtensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Update `podspec` to make the group paths in Pods project of SwifterSwift correct with Cocoapods installation. [#590](https://github.com/SwifterSwift/SwifterSwift/pull/590) by [dklinzh](https://github.com/dklinzh)
 - **UIImage**:
   - `cropped(to:)` fixed size checking. [#575](https://github.com/SwifterSwift/SwifterSwift/pull/575) by [ilyahal](https://github.com/ilyahal)
+- **NSAttributedString** 
+  - Fixed `attributes` property crash when the string is empty. [#617](https://github.com/SwifterSwift/SwifterSwift/pull/617) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 ### Deprecated
 - **Date**
   - `random(from:upTo:)` in favor of `random(in:)` and `random(in:using:)`. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576) by [guykogus](https://github.com/guykogus)

--- a/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/Extensions/Foundation/NSAttributedStringExtensions.swift
@@ -46,6 +46,7 @@ public extension NSAttributedString {
 
     /// SwifterSwift: Dictionary of the attributes applied across the whole string
     public var attributes: [NSAttributedString.Key: Any] {
+        guard self.length > 0 else { return [:] }
         return attributes(at: 0, effectiveRange: nil)
     }
 

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -208,6 +208,10 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 
     #if !os(macOS) && !os(tvOS)
     func testAttributes() {
+        let emptyString = NSAttributedString(string: "").bolded.struckthrough.underlined.colored(with: UIColor.blue)
+        let emptyStringAttributes = emptyString.attributes
+        XCTAssert(emptyStringAttributes.isEmpty)
+
         let attrString = NSAttributedString(string: "Test String").bolded.struckthrough.underlined.colored(with: UIColor.blue)
         let attributes = attrString.attributes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
