### PR TITLE
Fixed: Minor typo in UIWindowsExtensions.swift

### DIFF
--- a/Sources/Extensions/UIKit/UIWindowExtensions.swift
+++ b/Sources/Extensions/UIKit/UIWindowExtensions.swift
@@ -18,7 +18,7 @@ public extension UIWindow {
     ///   - viewController: new view controller.
     ///   - animated: set to true to animate view controller change (default is true).
     ///   - duration: animation duration in seconds (default is 0.5).
-    ///   - options: animataion options (default is .transitionFlipFromRight).
+    ///   - options: animation options (default is .transitionFlipFromRight).
     ///   - completion: optional completion handler called after view controller is changed.
     public func switchRootViewController(
         to viewController: UIViewController,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
