### PR TITLE
Added extension 'isNilOrBlank' to Optional String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `rounded(numberOfDecimalPlaces:rule:)` to get the rounded floating number with the specified number of decimal places. [#583](https://github.com/SwifterSwift/SwifterSwift/pull/583) by [jianstm](https://github.com/jianstm)
 - **UIActivity**
   - Added `ActivityType` constants for iCloud Drive, WhatsApp, LinkedIn and XING. [#580](https://github.com/SwifterSwift/SwifterSwift/pull/580) by [staffler-xyz](https://github.com/staffler-xyz)
+- **Optional**:
+  - Added `isNilOrBlank` property to check whether an optional is nil, empty, white space or new line String.
 ### Changed
 - **Examples**:
   - Replace Examples.md with Examples.playground to let users try some examples out of extensions. [#596](https://github.com/SwifterSwift/SwifterSwift/pull/596) by [maxxx777](https://github.com/maxxx777)

--- a/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/OptionalExtensions.swift
@@ -104,6 +104,17 @@ public extension Optional where Wrapped: Collection {
 
 }
 
+// MARK: - Methods (String)
+public extension Optional where Wrapped == String {
+
+    /// SwifterSwift: Check if optional is nil, empty, white space or new line String.
+    public var isNilOrBlank: Bool {
+        guard let string = self else { return true }
+        return string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+}
+
 // MARK: - Operators
 infix operator ??= : AssignmentPrecedence
 infix operator ?= : AssignmentPrecedence

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -105,4 +105,21 @@ final class OptionalExtensionsTests: XCTestCase {
 
     }
 
+    func testIsNilOrBlank() {
+        let nilString: String? = nil
+        XCTAssertTrue(nilString.isNilOrBlank)
+
+        let emptyString: String? = ""
+        XCTAssertTrue(emptyString.isNilOrBlank)
+
+        let whiteSpace: String? = "\n \n"
+        XCTAssertTrue(whiteSpace.isNilOrBlank)
+
+        let newLine: String? = "\n"
+        XCTAssertTrue(newLine.isNilOrBlank)
+
+        let alphabet: String? = "a"
+        XCTAssertFalse(alphabet.isNilOrBlank)
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
