### PR TITLE
Making some array extensions, generic collection extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Replace Examples.md with Examples.playground to let users try some examples out of extensions. [#596](https://github.com/SwifterSwift/SwifterSwift/pull/596) by [maxxx777](https://github.com/maxxx777)
 - **StringProtocol**
   - Removing Index constraint on `commonSuffix` extension and improving performance and tests. [#606](https://github.com/SwifterSwift/SwifterSwift/pull/606) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+- **RangeReplaceableCollection**
+  - `Array` extensions `keep(while: )`, `take(while: )` and `skip(while:)` are now `RangeReplaceableCollection` extensions. [#634](https://github.com/SwifterSwift/SwifterSwift/pull/634) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+  
 ### Fixed
 - **Installation**:
   - Update `podspec` to make the group paths in Pods project of SwifterSwift correct with Cocoapods installation. [#590](https://github.com/SwifterSwift/SwifterSwift/pull/590) by [dklinzh](https://github.com/dklinzh)

--- a/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/ArrayExtensions.swift
@@ -37,48 +37,6 @@ public extension Array {
         swapAt(index, otherIndex)
     }
 
-    /// SwifterSwift: Keep elements of Array while condition is true.
-    ///
-    ///        [0, 2, 4, 7].keep( where: {$0 % 2 == 0}) -> [0, 2, 4]
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: self after applying provided condition.
-    /// - Throws: provided condition exception.
-    @discardableResult
-    public mutating func keep(while condition: (Element) throws -> Bool) rethrows -> [Element] {
-        for (index, element) in lazy.enumerated() where try !condition(element) {
-            self = Array(self[startIndex..<index])
-            break
-        }
-        return self
-    }
-
-    /// SwifterSwift: Take element of Array while condition is true.
-    ///
-    ///        [0, 2, 4, 7, 6, 8].take( where: {$0 % 2 == 0}) -> [0, 2, 4]
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: All elements up until condition evaluates to false.
-    public func take(while condition: (Element) throws -> Bool) rethrows -> [Element] {
-        for (index, element) in lazy.enumerated() where try !condition(element) {
-            return Array(self[startIndex..<index])
-        }
-        return self
-    }
-
-    /// SwifterSwift: Skip elements of Array while condition is true.
-    ///
-    ///        [0, 2, 4, 7, 6, 8].skip( where: {$0 % 2 == 0}) -> [6, 8]
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: All elements after the condition evaluates to false.
-    public func skip(while condition: (Element) throws-> Bool) rethrows -> [Element] {
-        for (index, element) in lazy.enumerated() where try !condition(element) {
-            return Array(self[index..<endIndex])
-        }
-        return [Element]()
-    }
-
     /// SwifterSwift: Separates an array into 2 arrays based on a predicate.
     ///
     ///     [0, 1, 2, 3, 4, 5].divided { $0 % 2 == 0 } -> ( [0, 2, 4], [1, 3, 5] )

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -6,10 +6,6 @@
 //  Copyright © 2018 SwifterSwift
 //
 
-#if canImport(Foundation)
-import Foundation
-#endif
-
 // MARK: - Initializers
 extension RangeReplaceableCollection {
 
@@ -91,12 +87,64 @@ extension RangeReplaceableCollection {
         return remove(at: index)
     }
 
-    #if canImport(Foundation)
     /// SwifterSwift: Remove a random value from the collection.
     @discardableResult public mutating func removeRandomElement() -> Element? {
         guard let randomIndex = indices.randomElement() else { return nil }
         return remove(at: randomIndex)
     }
-    #endif
+
+    /// SwifterSwift: Keep elements of Array while condition is true.
+    ///
+    ///        [0, 2, 4, 7].keep(while: { $0 % 2 == 0 }) -> [0, 2, 4]
+    ///
+    /// - Parameter condition: condition to evaluate each element against.
+    /// - Returns: self after applying provided condition.
+    /// - Throws: provided condition exception.
+    @discardableResult
+    public mutating func keep(while condition: (Element) throws -> Bool) rethrows -> Self {
+        var idx = startIndex
+        for element in self {
+            if try !condition(element) {
+                removeSubrange(idx...)
+                break
+            }
+            formIndex(after: &idx)
+        }
+        return self
+    }
+
+    /// SwifterSwift: Take element of Array while condition is true.
+    ///
+    ///        [0, 2, 4, 7, 6, 8].take( where: {$0 % 2 == 0}) -> [0, 2, 4]
+    ///
+    /// - Parameter condition: condition to evaluate each element against.
+    /// - Returns: All elements up until condition evaluates to false.
+    public func take(while condition: (Element) throws -> Bool) rethrows -> Self {
+        var idx = startIndex
+        for element in self {
+            if try !condition(element) {
+                return Self(self[startIndex..<idx])
+            }
+            formIndex(after: &idx)
+        }
+        return self
+    }
+
+    /// SwifterSwift: Skip elements of Array while condition is true.
+    ///
+    ///        [0, 2, 4, 7, 6, 8].skip( where: {$0 % 2 == 0}) -> [6, 8]
+    ///
+    /// - Parameter condition: condition to evaluate each element against.
+    /// - Returns: All elements after the condition evaluates to false.
+    public func skip(while condition: (Element) throws-> Bool) rethrows -> Self {
+        var idx = startIndex
+        for element in self {
+            if try !condition(element) {
+                return Self(self[idx...])
+            }
+            formIndex(after: &idx)
+        }
+        return Self()
+    }
 
 }

--- a/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -102,13 +102,8 @@ extension RangeReplaceableCollection {
     /// - Throws: provided condition exception.
     @discardableResult
     public mutating func keep(while condition: (Element) throws -> Bool) rethrows -> Self {
-        var idx = startIndex
-        for element in self {
-            if try !condition(element) {
-                removeSubrange(idx...)
-                break
-            }
-            formIndex(after: &idx)
+        if let idx = try firstIndex(where: { try !condition($0) }) {
+            removeSubrange(idx...)
         }
         return self
     }
@@ -120,14 +115,7 @@ extension RangeReplaceableCollection {
     /// - Parameter condition: condition to evaluate each element against.
     /// - Returns: All elements up until condition evaluates to false.
     public func take(while condition: (Element) throws -> Bool) rethrows -> Self {
-        var idx = startIndex
-        for element in self {
-            if try !condition(element) {
-                return Self(self[startIndex..<idx])
-            }
-            formIndex(after: &idx)
-        }
-        return self
+        return Self(try prefix(while: condition))
     }
 
     /// SwifterSwift: Skip elements of Array while condition is true.
@@ -137,14 +125,8 @@ extension RangeReplaceableCollection {
     /// - Parameter condition: condition to evaluate each element against.
     /// - Returns: All elements after the condition evaluates to false.
     public func skip(while condition: (Element) throws-> Bool) rethrows -> Self {
-        var idx = startIndex
-        for element in self {
-            if try !condition(element) {
-                return Self(self[idx...])
-            }
-            formIndex(after: &idx)
-        }
-        return Self()
+        guard let idx = try firstIndex(where: { try !condition($0) }) else { return Self() }
+        return Self(self[idx...])
     }
 
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -46,40 +46,6 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(swappedEmptyArray, emptyArray)
     }
 
-    func testKeepWhile() {
-        var input = [2, 4, 6, 7, 8, 9, 10]
-        input.keep(while: {$0 % 2 == 0 })
-        XCTAssertEqual(input, [2, 4, 6])
-
-        input = [7, 7, 8, 10]
-        input.keep(while: {$0 % 2 == 0 })
-        XCTAssertEqual(input, [Int]())
-    }
-
-    func testTakeWhile() {
-        var input = [2, 4, 6, 7, 8, 9, 10]
-        var output = input.take(while: {$0 % 2 == 0 })
-        XCTAssertEqual(output, [2, 4, 6])
-
-        input = [7, 7, 8, 10]
-        output = input.take(while: {$0 % 2 == 0 })
-        XCTAssertEqual(output, [Int]())
-
-        XCTAssertEqual([].take(while: {$0 % 2 == 0 }), [])
-    }
-
-    func testSkipWhile() {
-        var input = [2, 4, 6, 7, 8, 9, 10]
-        var output = input.skip(while: {$0 % 2 == 0 })
-        XCTAssertEqual(output, [7, 8, 9, 10])
-
-        input = [7, 7, 8, 10]
-        output = input.skip(while: {$0 % 2 == 0 })
-        XCTAssertEqual(output, [7, 7, 8, 10])
-
-        XCTAssertEqual([].skip(while: { $0 % 2 == 0}), [])
-    }
-
     func testDivided() {
         let input = [0, 1, 2, 3, 4, 5]
         let (even, odd) = input.divided { $0 % 2 == 0 }

--- a/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
@@ -69,4 +69,37 @@ final class RangeReplaceableCollectionTests: XCTestCase {
         XCTAssertFalse(array.contains(removedElement))
     }
 
+    func testKeepWhile() {
+        var input = [2, 4, 6, 7, 8, 9, 10]
+        input.keep(while: {$0 % 2 == 0 })
+        XCTAssertEqual(input, [2, 4, 6])
+
+        input = [7, 7, 8, 10]
+        input.keep(while: {$0 % 2 == 0 })
+        XCTAssertEqual(input, [Int]())
+    }
+
+    func testTakeWhile() {
+        var input = [2, 4, 6, 7, 8, 9, 10]
+        var output = input.take(while: {$0 % 2 == 0 })
+        XCTAssertEqual(output, [2, 4, 6])
+
+        input = [7, 7, 8, 10]
+        output = input.take(while: {$0 % 2 == 0 })
+        XCTAssertEqual(output, [Int]())
+
+        XCTAssertEqual([].take(while: {$0 % 2 == 0 }), [])
+    }
+
+    func testSkipWhile() {
+        var input = [2, 4, 6, 7, 8, 9, 10]
+        var output = input.skip(while: {$0 % 2 == 0 })
+        XCTAssertEqual(output, [7, 8, 9, 10])
+
+        input = [7, 7, 8, 10]
+        output = input.skip(while: {$0 % 2 == 0 })
+        XCTAssertEqual(output, [7, 7, 8, 10])
+
+        XCTAssertEqual([].skip(while: { $0 % 2 == 0}), [])
+    }
 }


### PR DESCRIPTION
Making keep(while: ), take(while: ) and skip(while:) array extensions, collection extensions.

Just want to use them with other types 😅 

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.