### PR TITLE
removing extensions not needed anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `random(from:upTo:)` in favor of `random(in:)` and `random(in:using:)`. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576) by [guykogus](https://github.com/guykogus)
   - `timeZone` should never have been added because `Date`s are timezone-agnostic. This came to my attention during unit testing over daylight savings changes. [#594](https://github.com/SwifterSwift/SwifterSwift/pull/594) by [guykogus](https://github.com/guykogus)
 ### Removed
-  - removed `firstIndex(where: )`, `firstIndex(of:)`, `lastIndex(where: )`, `lastIndex(of:)` which are no longer needed by [marcocapano](https://github.com/marcocapano)
+  - removed `firstIndex(where: )`, `firstIndex(of:)`, `lastIndex(where: )`, `lastIndex(of:)` which are no longer needed. [#637](https://github.com/SwifterSwift/SwifterSwift/pull/637) by [marcocapano](https://github.com/marcocapano)
 ### Security
 
 ---

--- a/Sources/Extensions/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/CollectionExtensions.swift
@@ -45,32 +45,6 @@ public extension Collection {
 // MARK: - Methods (Int)
 public extension Collection where Index == Int {
 
-    /// SwifterSwift: Get the first index where condition is met.
-    ///
-    ///        [1, 7, 1, 2, 4, 1, 6].firstIndex { $0 % 2 == 0 } -> 3
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: first index where the specified condition evaluates to true. (optional)
-    public func firstIndex(where condition: (Element) throws -> Bool) rethrows -> Index? {
-        for (index, value) in lazy.enumerated() where try condition(value) {
-            return index
-        }
-        return nil
-    }
-
-    /// SwifterSwift: Get the last index where condition is met.
-    ///
-    ///     [1, 7, 1, 2, 4, 1, 8].lastIndex { $0 % 2 == 0 } -> 6
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: last index where the specified condition evaluates to true. (optional)
-    public func lastIndex(where condition: (Element) throws -> Bool) rethrows -> Index? {
-        for (index, value) in lazy.enumerated().reversed() where try condition(value) {
-            return index
-        }
-        return nil
-    }
-
     /// SwifterSwift: Get all indices where condition is met.
     ///
     ///     [1, 7, 1, 2, 4, 1, 8].indices(where: { $0 == 1 }) -> [0, 2, 5]
@@ -120,40 +94,6 @@ public extension Collection where Index == Int {
             value += size
         }
         return slices
-    }
-
-}
-
-public extension Collection where Element: Equatable, Index == Int {
-
-    /// SwifterSwift: First index of a given item in an array.
-    ///
-    ///        [1, 2, 2, 3, 4, 2, 5].firstIndex(of: 2) -> 1
-    ///        [1.2, 2.3, 4.5, 3.4, 4.5].firstIndex(of: 6.5) -> nil
-    ///        ["h", "e", "l", "l", "o"].firstIndex(of: "l") -> 2
-    ///
-    /// - Parameter item: item to check.
-    /// - Returns: first index of item in array (if exists).
-    public func firstIndex(of item: Element) -> Index? {
-        for (index, value) in lazy.enumerated() where value == item {
-            return index
-        }
-        return nil
-    }
-
-    /// SwifterSwift: Last index of element in array.
-    ///
-    ///        [1, 2, 2, 3, 4, 2, 5].lastIndex(of: 2) -> 5
-    ///        [1.2, 2.3, 4.5, 3.4, 4.5].lastIndex(of: 6.5) -> nil
-    ///        ["h", "e", "l", "l", "o"].lastIndex(of: "l") -> 3
-    ///
-    /// - Parameter item: item to check.
-    /// - Returns: last index of item in array (if exists).
-    public func lastIndex(of item: Element) -> Index? {
-        for (index, value) in lazy.enumerated().reversed() where value == item {
-            return index
-        }
-        return nil
     }
 
 }

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -25,21 +25,6 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertNil(collection[safe: 10])
     }
 
-    func testFirstIndexWhere() {
-        let array = [1, 7, 1, 2, 4, 1, 6]
-        let index = array.firstIndex { $0 % 2 == 0 }
-        XCTAssertEqual(index, 3)
-        XCTAssertNil([Int]().firstIndex { $0 % 2 == 0 })
-    }
-
-    func testLastIndexWhere() {
-        let array = [1, 1, 1, 2, 2, 1, 1, 2, 1]
-        let index = array.lastIndex { $0 % 2 == 0 }
-        XCTAssertEqual(index, 7)
-        XCTAssertNil(array.lastIndex { $0 == 3 })
-        XCTAssertNil([Int]().lastIndex { $0 % 2 == 0 })
-    }
-
     func testIndicesWhere() {
         let array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         let indices = array.indices { $0 % 2 == 0 }
@@ -126,18 +111,6 @@ final class CollectionExtensionsTests: XCTestCase {
         slices = array.group(by: 6)
         XCTAssertNotNil(slices)
         XCTAssertEqual(slices?.count, 1)
-    }
-
-    func testFirstIndex() {
-        XCTAssertNotNil([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 2))
-        XCTAssertEqual([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 2), 2)
-        XCTAssertNil([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 7))
-    }
-
-    func testLastIndex() {
-        XCTAssertNotNil([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 2))
-        XCTAssertEqual([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 2), 6)
-        XCTAssertNil([1, 1, 2, 3, 4, 1, 2, 1].lastIndex(of: 7))
     }
 
     func testAverage() {


### PR DESCRIPTION
This PR addresses issue #636 by removing 

* `firstIndex(where: )`
* `firstIndex(of:)`
* `lastIndex(where: )`
* `lastIndex(of:)`

and their related tests.
They should be removed since they are now (since swift 4.2) part of the Swift Standard Library.
See: [SE-0204](https://github.com/apple/swift-evolution/blob/master/proposals/0204-add-last-methods.md)

## Checklist
- [ x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.