### PR TITLE
Fixed all SwiftLint(0.31.0)-related warnings

### DIFF
--- a/Sources/Extensions/CoreGraphics/CGPointExtensions.swift
+++ b/Sources/Extensions/CoreGraphics/CGPointExtensions.swift
@@ -80,7 +80,7 @@ public extension CGPoint {
     ///   - lhs: self
     ///   - rhs: CGPoint to add.
     public static func += (lhs: inout CGPoint, rhs: CGPoint) {
-        // swiftlint:disable next shorthand_operator
+        // swiftlint:disable:next shorthand_operator
         lhs = lhs + rhs
     }
 
@@ -110,7 +110,7 @@ public extension CGPoint {
     ///   - lhs: self
     ///   - rhs: CGPoint to subtract.
     public static func -= (lhs: inout CGPoint, rhs: CGPoint) {
-        // swiftlint:disable next shorthand_operator
+        // swiftlint:disable:next shorthand_operator
         lhs = lhs - rhs
     }
 
@@ -139,7 +139,7 @@ public extension CGPoint {
     ///   - scalar: scalar value.
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     public static func *= (point: inout CGPoint, scalar: CGFloat) {
-        // swiftlint:disable next shorthand_operator
+        // swiftlint:disable:next shorthand_operator
         point = point * scalar
     }
 

--- a/Sources/Extensions/CoreGraphics/CGVectorExtensions.swift
+++ b/Sources/Extensions/CoreGraphics/CGVectorExtensions.swift
@@ -86,7 +86,7 @@ public extension CGVector {
     ///   - vector: The vector to be multiplied
     ///   - scalar: The scale by which the vector will be multiplied
     public static func *= (vector: inout CGVector, scalar: CGFloat) {
-        // swiftlint:disable next shorthand_operator
+        // swiftlint:disable:next shorthand_operator
         vector = vector * scalar
     }
 

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -513,20 +513,19 @@ public extension Date {
         }
     }
 
-    // swiftlint:disable function_body_length, function_body_length
-    // swiftlint:disable cyclomatic_complexity
     /// SwifterSwift: Date by changing value of calendar component.
     ///
-    /// 	let date = Date() // "Jan 12, 2017, 7:07 PM"
-    /// 	let date2 = date.changing(.minute, value: 10) // "Jan 12, 2017, 6:10 PM"
-    /// 	let date3 = date.changing(.day, value: 4) // "Jan 4, 2017, 7:07 PM"
-    /// 	let date4 = date.changing(.month, value: 2) // "Feb 12, 2017, 7:07 PM"
-    /// 	let date5 = date.changing(.year, value: 2000) // "Jan 12, 2000, 7:07 PM"
+    ///     let date = Date() // "Jan 12, 2017, 7:07 PM"
+    ///     let date2 = date.changing(.minute, value: 10) // "Jan 12, 2017, 6:10 PM"
+    ///     let date3 = date.changing(.day, value: 4) // "Jan 4, 2017, 7:07 PM"
+    ///     let date4 = date.changing(.month, value: 2) // "Feb 12, 2017, 7:07 PM"
+    ///     let date5 = date.changing(.year, value: 2000) // "Jan 12, 2000, 7:07 PM"
     ///
     /// - Parameters:
     ///   - component: component type.
     ///   - value: new value of compnenet to change.
     /// - Returns: original date after changing given component to given value.
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     public func changing(_ component: Calendar.Component, value: Int) -> Date? {
         switch component {
         case .nanosecond:
@@ -626,16 +625,16 @@ public extension Date {
         return Calendar.current.date(from: Calendar.current.dateComponents(components, from: self))
     }
 
-    // swiftlint:disable function_body_length
     /// SwifterSwift: Date at the end of calendar component.
     ///
-    /// 	let date = Date() // "Jan 12, 2017, 7:27 PM"
-    /// 	let date2 = date.end(of: .day) // "Jan 12, 2017, 11:59 PM"
-    /// 	let date3 = date.end(of: .month) // "Jan 31, 2017, 11:59 PM"
-    /// 	let date4 = date.end(of: .year) // "Dec 31, 2017, 11:59 PM"
+    ///     let date = Date() // "Jan 12, 2017, 7:27 PM"
+    ///     let date2 = date.end(of: .day) // "Jan 12, 2017, 11:59 PM"
+    ///     let date3 = date.end(of: .month) // "Jan 31, 2017, 11:59 PM"
+    ///     let date4 = date.end(of: .year) // "Dec 31, 2017, 11:59 PM"
     ///
     /// - Parameter component: calendar component to get date at the end of.
     /// - Returns: date at the end of calendar component (if applicable).
+    // swiftlint:disable:next function_body_length
     public func end(of component: Calendar.Component) -> Date? {
         switch component {
         case .second:

--- a/Sources/Extensions/Foundation/DateExtensions.swift
+++ b/Sources/Extensions/Foundation/DateExtensions.swift
@@ -515,11 +515,11 @@ public extension Date {
 
     /// SwifterSwift: Date by changing value of calendar component.
     ///
-    ///     let date = Date() // "Jan 12, 2017, 7:07 PM"
-    ///     let date2 = date.changing(.minute, value: 10) // "Jan 12, 2017, 6:10 PM"
-    ///     let date3 = date.changing(.day, value: 4) // "Jan 4, 2017, 7:07 PM"
-    ///     let date4 = date.changing(.month, value: 2) // "Feb 12, 2017, 7:07 PM"
-    ///     let date5 = date.changing(.year, value: 2000) // "Jan 12, 2000, 7:07 PM"
+    /// 	let date = Date() // "Jan 12, 2017, 7:07 PM"
+    /// 	let date2 = date.changing(.minute, value: 10) // "Jan 12, 2017, 6:10 PM"
+    /// 	let date3 = date.changing(.day, value: 4) // "Jan 4, 2017, 7:07 PM"
+    /// 	let date4 = date.changing(.month, value: 2) // "Feb 12, 2017, 7:07 PM"
+    /// 	let date5 = date.changing(.year, value: 2000) // "Jan 12, 2000, 7:07 PM"
     ///
     /// - Parameters:
     ///   - component: component type.
@@ -627,10 +627,10 @@ public extension Date {
 
     /// SwifterSwift: Date at the end of calendar component.
     ///
-    ///     let date = Date() // "Jan 12, 2017, 7:27 PM"
-    ///     let date2 = date.end(of: .day) // "Jan 12, 2017, 11:59 PM"
-    ///     let date3 = date.end(of: .month) // "Jan 31, 2017, 11:59 PM"
-    ///     let date4 = date.end(of: .year) // "Dec 31, 2017, 11:59 PM"
+    /// 	let date = Date() // "Jan 12, 2017, 7:27 PM"
+    /// 	let date2 = date.end(of: .day) // "Jan 12, 2017, 11:59 PM"
+    /// 	let date3 = date.end(of: .month) // "Jan 31, 2017, 11:59 PM"
+    /// 	let date4 = date.end(of: .year) // "Dec 31, 2017, 11:59 PM"
     ///
     /// - Parameter component: calendar component to get date at the end of.
     /// - Returns: date at the end of calendar component (if applicable).

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -36,9 +36,9 @@ public extension Color {
 
     /// SwifterSwift: RGB components for a Color (between 0 and 255).
     ///
-    ///        UIColor.red.rgbComponents.red -> 255
-    ///        NSColor.green.rgbComponents.green -> 255
-    ///        UIColor.blue.rgbComponents.blue -> 255
+    ///     UIColor.red.rgbComponents.red -> 255
+    ///     NSColor.green.rgbComponents.green -> 255
+    ///     UIColor.blue.rgbComponents.blue -> 255
     ///
     // swiftlint:disable:next large_tuple
     public var rgbComponents: (red: Int, green: Int, blue: Int) {
@@ -55,9 +55,9 @@ public extension Color {
 
     /// SwifterSwift: RGB components for a Color represented as CGFloat numbers (between 0 and 1)
     ///
-    ///        UIColor.red.rgbComponents.red -> 1.0
-    ///        NSColor.green.rgbComponents.green -> 1.0
-    ///        UIColor.blue.rgbComponents.blue -> 1.0
+    ///     UIColor.red.rgbComponents.red -> 1.0
+    ///     NSColor.green.rgbComponents.green -> 1.0
+    ///     UIColor.blue.rgbComponents.blue -> 1.0
     ///
     // swiftlint:disable:next large_tuple
     public var cgFloatComponents: (red: CGFloat, green: CGFloat, blue: CGFloat) {

--- a/Sources/Extensions/Shared/ColorExtensions.swift
+++ b/Sources/Extensions/Shared/ColorExtensions.swift
@@ -34,13 +34,13 @@ public extension Color {
         return Color(red: red, green: green, blue: blue)!
     }
 
-    // swiftlint:disable next large_tuple
     /// SwifterSwift: RGB components for a Color (between 0 and 255).
     ///
-    ///		UIColor.red.rgbComponents.red -> 255
-    ///		NSColor.green.rgbComponents.green -> 255
-    ///		UIColor.blue.rgbComponents.blue -> 255
+    ///        UIColor.red.rgbComponents.red -> 255
+    ///        NSColor.green.rgbComponents.green -> 255
+    ///        UIColor.blue.rgbComponents.blue -> 255
     ///
+    // swiftlint:disable:next large_tuple
     public var rgbComponents: (red: Int, green: Int, blue: Int) {
         var components: [CGFloat] {
             let comps = cgColor.components!
@@ -53,13 +53,13 @@ public extension Color {
         return (red: Int(red * 255.0), green: Int(green * 255.0), blue: Int(blue * 255.0))
     }
 
-    // swiftlint:disable next large_tuple
     /// SwifterSwift: RGB components for a Color represented as CGFloat numbers (between 0 and 1)
     ///
-    ///		UIColor.red.rgbComponents.red -> 1.0
-    ///		NSColor.green.rgbComponents.green -> 1.0
-    ///		UIColor.blue.rgbComponents.blue -> 1.0
+    ///        UIColor.red.rgbComponents.red -> 1.0
+    ///        NSColor.green.rgbComponents.green -> 1.0
+    ///        UIColor.blue.rgbComponents.blue -> 1.0
     ///
+    // swiftlint:disable:next large_tuple
     public var cgFloatComponents: (red: CGFloat, green: CGFloat, blue: CGFloat) {
         var components: [CGFloat] {
             let comps = cgColor.components!
@@ -72,8 +72,8 @@ public extension Color {
         return (red: red, green: green, blue: blue)
     }
 
-    // swiftlint:disable next large_tuple
     /// SwifterSwift: Get components of hue, saturation, and brightness, and alpha (read-only).
+    // swiftlint:disable:next large_tuple
     public var hsbaComponents: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
         var hue: CGFloat = 0.0
         var saturation: CGFloat = 0.0
@@ -356,7 +356,6 @@ public extension Color {
 
 }
 
-// swiftlint:disable next type_body_length
 // MARK: - Social
 public extension Color {
 
@@ -452,6 +451,7 @@ public extension Color {
 public extension Color {
 
     /// SwifterSwift: Google Material design colors palette.
+    // swiftlint:disable:next type_body_length
     public struct Material {
         // https://material.google.com/style/color.html
 

--- a/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/DoubleExtensions.swift
@@ -47,12 +47,12 @@ public func ** (lhs: Double, rhs: Double) -> Double {
     return pow(lhs, rhs)
 }
 
-// swiftlint:disable next identifier_name
 prefix operator √
 /// SwifterSwift: Square root of double.
 ///
 /// - Parameter double: double value to find square root for.
 /// - Returns: square root of given double.
+// swiftlint:disable:next identifier_name
 public prefix func √ (double: Double) -> Double {
     // http://nshipster.com/swift-operators/
     return sqrt(double)

--- a/Sources/Extensions/SwiftStdlib/FloatExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/FloatExtensions.swift
@@ -47,12 +47,12 @@ public func ** (lhs: Float, rhs: Float) -> Float {
     return pow(lhs, rhs)
 }
 
-// swiftlint:disable next identifier_name
 prefix operator √
 /// SwifterSwift: Square root of float.
 ///
 /// - Parameter float: float value to find square root for
 /// - Returns: square root of given float.
+// swiftlint:disable:next identifier_name
 public prefix func √ (float: Float) -> Float {
     // http://nshipster.com/swift-operators/
     return sqrt(float)

--- a/Sources/Extensions/SwiftStdlib/FloatingPointExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/FloatingPointExtensions.swift
@@ -56,7 +56,6 @@ public extension FloatingPoint {
 
 // MARK: - Operators
 
-// swiftlint:disable next identifier_name
 infix operator ±
 /// SwifterSwift: Tuple of plus-minus operation.
 ///
@@ -64,17 +63,18 @@ infix operator ±
 ///   - lhs: number
 ///   - rhs: number
 /// - Returns: tuple of plus-minus operation ( 2.5 ± 1.5 -> (4, 1)).
+// swiftlint:disable:next identifier_name
 public func ±<T: FloatingPoint> (lhs: T, rhs: T) -> (T, T) {
     // http://nshipster.com/swift-operators/
     return (lhs + rhs, lhs - rhs)
 }
 
-// swiftlint:disable next identifier_name
 prefix operator ±
 /// SwifterSwift: Tuple of plus-minus operation.
 ///
 /// - Parameter int: number
 /// - Returns: tuple of plus-minus operation (± 2.5 -> (2.5, -2.5)).
+// swiftlint:disable:next identifier_name
 public prefix func ±<T: FloatingPoint> (number: T) -> (T, T) {
     // http://nshipster.com/swift-operators/
     return 0 ± number

--- a/Sources/Extensions/SwiftStdlib/IntExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/IntExtensions.swift
@@ -146,8 +146,8 @@ public extension Int {
         return romanValue
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Rounds to the closest multiple of n
+    // swiftlint:disable:next identifier_name
     public func roundToNearest(_ n: Int) -> Int {
         return n == 0 ? self : Int(round(Double(self) / Double(n))) * n
     }
@@ -169,18 +169,17 @@ public func ** (lhs: Int, rhs: Int) -> Double {
     return pow(Double(lhs), Double(rhs))
 }
 
-// swiftlint:disable next identifier_name
 prefix operator √
 /// SwifterSwift: Square root of integer.
 ///
 /// - Parameter int: integer value to find square root for
 /// - Returns: square root of given integer.
+// swiftlint:disable:next identifier_name
 public prefix func √ (int: Int) -> Double {
     // http://nshipster.com/swift-operators/
     return sqrt(Double(int))
 }
 
-// swiftlint:disable next identifier_name
 infix operator ±
 /// SwifterSwift: Tuple of plus-minus operation.
 ///
@@ -188,17 +187,18 @@ infix operator ±
 ///   - lhs: integer number.
 ///   - rhs: integer number.
 /// - Returns: tuple of plus-minus operation (example: 2 ± 3 -> (5, -1)).
+// swiftlint:disable:next identifier_name
 public func ± (lhs: Int, rhs: Int) -> (Int, Int) {
     // http://nshipster.com/swift-operators/
     return (lhs + rhs, lhs - rhs)
 }
 
-// swiftlint:disable next identifier_name
 prefix operator ±
 /// SwifterSwift: Tuple of plus-minus operation.
 ///
 /// - Parameter int: integer number
 /// - Returns: tuple of plus-minus operation (example: ± 2 -> (2, -2)).
+// swiftlint:disable:next identifier_name
 public prefix func ± (int: Int) -> (Int, Int) {
     // http://nshipster.com/swift-operators/
     return 0 ± int

--- a/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedIntegerExtensions.swift
@@ -62,20 +62,20 @@ public extension SignedInteger {
 // MARK: - Methods
 public extension SignedInteger {
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Greatest common divisor of integer value and n.
     ///
     /// - Parameter n: integer value to find gcd with.
     /// - Returns: greatest common divisor of self and n.
+    // swiftlint:disable:next identifier_name
     public func gcd(of n: Self) -> Self {
         return n == 0 ? self : n.gcd(of: self % n)
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Least common multiple of integer and n.
     ///
     /// - Parameter n: integer value to find lcm with.
     /// - Returns: least common multiple of self and n.
+    // swiftlint:disable:next identifier_name
     public func lcm(of n: Self) -> Self {
         return (self * n).abs / gcd(of: n)
     }

--- a/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/SignedNumericExtensions.swift
@@ -24,7 +24,7 @@ public extension SignedNumeric {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.locale = Locale.current
-        // swiftlint:disable next force_cast
+        // swiftlint:disable:next force_cast
         return formatter.string(from: self as! NSNumber)
     }
     #endif

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -566,13 +566,13 @@ public extension String {
     }
     #endif
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Safely subscript string with index.
     ///
-    ///		"Hello World!"[safe: 3] -> "l"
-    ///		"Hello World!"[safe: 20] -> nil
+    ///        "Hello World!"[safe: 3] -> "l"
+    ///        "Hello World!"[safe: 20] -> nil
     ///
     /// - Parameter i: index.
+    // swiftlint:disable:next identifier_name
     public subscript(safe i: Int) -> Character? {
         guard i >= 0 && i < count else { return nil }
         return self[index(startIndex, offsetBy: i)]
@@ -746,7 +746,6 @@ public extension String {
         self = String(chars)
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Sliced string from a start index with length.
     ///
     ///        "Hello World".slicing(from: 6, length: 5) -> "World"
@@ -755,6 +754,7 @@ public extension String {
     ///   - i: string index the slicing should start from.
     ///   - length: amount of characters to be sliced after given index.
     /// - Returns: sliced substring of length number of characters (if applicable) (example: "Hello World".slicing(from: 6, length: 5) -> "World")
+    // swiftlint:disable:next identifier_name
     public func slicing(from i: Int, length: Int) -> String? {
         guard length >= 0, i >= 0, i < count  else { return nil }
         guard i.advanced(by: length) <= count else {
@@ -764,16 +764,16 @@ public extension String {
         return self[safe: i..<i.advanced(by: length)]
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Slice given string from a start index with length (if applicable).
     ///
-    ///		var str = "Hello World"
-    ///		str.slice(from: 6, length: 5)
-    ///		print(str) // prints "World"
+    ///        var str = "Hello World"
+    ///        str.slice(from: 6, length: 5)
+    ///        print(str) // prints "World"
     ///
     /// - Parameters:
     ///   - i: string index the slicing should start from.
     ///   - length: amount of characters to be sliced after given index.
+    // swiftlint:disable:next identifier_name
     public mutating func slice(from i: Int, length: Int) {
         if let str = slicing(from: i, length: length) {
             self = String(str)
@@ -796,14 +796,14 @@ public extension String {
         }
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: Slice given string from a start index (if applicable).
     ///
-    ///		var str = "Hello World"
-    ///		str.slice(at: 6)
-    ///		print(str) // prints "World"
+    ///        var str = "Hello World"
+    ///        str.slice(at: 6)
+    ///        print(str) // prints "World"
     ///
     /// - Parameter i: string index the slicing should start from.
+    // swiftlint:disable:next identifier_name
     public mutating func slice(at i: Int) {
         guard i < count else { return }
         if let str = self[safe: i..<count] {

--- a/Sources/Extensions/SwiftStdlib/StringExtensions.swift
+++ b/Sources/Extensions/SwiftStdlib/StringExtensions.swift
@@ -568,8 +568,8 @@ public extension String {
 
     /// SwifterSwift: Safely subscript string with index.
     ///
-    ///        "Hello World!"[safe: 3] -> "l"
-    ///        "Hello World!"[safe: 20] -> nil
+    ///		"Hello World!"[safe: 3] -> "l"
+    ///		"Hello World!"[safe: 20] -> nil
     ///
     /// - Parameter i: index.
     // swiftlint:disable:next identifier_name
@@ -766,9 +766,9 @@ public extension String {
 
     /// SwifterSwift: Slice given string from a start index with length (if applicable).
     ///
-    ///        var str = "Hello World"
-    ///        str.slice(from: 6, length: 5)
-    ///        print(str) // prints "World"
+    ///		var str = "Hello World"
+    ///		str.slice(from: 6, length: 5)
+    ///		print(str) // prints "World"
     ///
     /// - Parameters:
     ///   - i: string index the slicing should start from.
@@ -798,9 +798,9 @@ public extension String {
 
     /// SwifterSwift: Slice given string from a start index (if applicable).
     ///
-    ///        var str = "Hello World"
-    ///        str.slice(at: 6)
-    ///        print(str) // prints "World"
+    ///		var str = "Hello World"
+    ///		str.slice(at: 6)
+    ///		print(str) // prints "World"
     ///
     /// - Parameter i: string index the slicing should start from.
     // swiftlint:disable:next identifier_name

--- a/Sources/Extensions/UIKit/UITextViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UITextViewExtensions.swift
@@ -20,14 +20,14 @@ public extension UITextView {
 
     /// SwifterSwift: Scroll to the bottom of text view
     public func scrollToBottom() {
-        // swiftlint:disable next legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let range = NSMakeRange((text as NSString).length - 1, 1)
         scrollRangeToVisible(range)
     }
 
     /// SwifterSwift: Scroll to the top of text view
     public func scrollToTop() {
-        // swiftlint:disable next legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let range = NSMakeRange(0, 1)
         scrollRangeToVisible(range)
     }

--- a/Sources/Extensions/UIKit/UIViewExtensions.swift
+++ b/Sources/Extensions/UIKit/UIViewExtensions.swift
@@ -203,8 +203,8 @@ public extension UIView {
         }
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: x origin of view.
+    // swiftlint:disable:next identifier_name
     public var x: CGFloat {
         get {
             return frame.origin.x
@@ -214,8 +214,8 @@ public extension UIView {
         }
     }
 
-    // swiftlint:disable next identifier_name
     /// SwifterSwift: y origin of view.
+    // swiftlint:disable:next identifier_name
     public var y: CGFloat {
         get {
             return frame.origin.y
@@ -233,6 +233,7 @@ public extension UIView {
     /// SwifterSwift: Recursively find the first responder.
     public func firstResponder() -> UIView? {
         var views = [UIView](arrayLiteral: self)
+        // swiftlint:disable:next identifier_name
         var i = 0
         repeat {
             let view = views[i]

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -12,7 +12,7 @@ import XCTest
 #if canImport(Foundation)
 import Foundation
 
-// swiftlint:disable next type_body_length
+// swiftlint:disable:next type_body_length
 final class DateExtensionsTests: XCTestCase {
 
     override func setUp() {
@@ -20,7 +20,7 @@ final class DateExtensionsTests: XCTestCase {
         NSTimeZone.default = TimeZone(abbreviation: "UTC")!
     }
 
-    // swiftlint:disable next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     func testCalendar() {
         switch Calendar.current.identifier {
         case .buddhist:
@@ -510,7 +510,7 @@ final class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(date8.adding(.year, value: -4), date)
     }
 
-    // swiftlint:disable next function_body_length
+    // swiftlint:disable:next function_body_length
     func testAdd() {
         var date = Date(timeIntervalSince1970: 0)
 

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -23,7 +23,7 @@ public typealias Color = UIColor
 import CoreImage
 #endif
 
-// swiftlint:disable next type_body_length
+// swiftlint:disable:next type_body_length
 final class ColorExtensionsTests: XCTestCase {
 
     // MARK: - Test properties

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-// swiftlint:disable next type_body_length
+// swiftlint:disable:next type_body_length
 final class StringExtensionsTests: XCTestCase {
 
     var helloWorld = "Hello World!"
@@ -628,7 +628,7 @@ final class StringExtensionsTests: XCTestCase {
     #if !os(tvOS) && !os(watchOS)
     func testBold() {
         let boldString = "hello".bold
-        // swiftlint:disable next legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let attrs = boldString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, boldString.length))
         XCTAssertNotNil(attrs[NSAttributedString.Key.font])
 
@@ -650,9 +650,8 @@ final class StringExtensionsTests: XCTestCase {
 
     func testUnderline() {
         let underlinedString = "hello".underline
-        // swiftlint:disable legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let attrs = underlinedString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, underlinedString.length))
-        // swiftlint:enable legacy_constructor
         XCTAssertNotNil(attrs[NSAttributedString.Key.underlineStyle])
         guard let style = attrs[NSAttributedString.Key.underlineStyle] as? Int else {
             XCTFail("Unable to find style in testUnderline")
@@ -663,7 +662,7 @@ final class StringExtensionsTests: XCTestCase {
 
     func testStrikethrough() {
         let strikedthroughString = "hello".strikethrough
-        // swiftlint:disable next legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let attrs = strikedthroughString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, strikedthroughString.length))
         XCTAssertNotNil(attrs[NSAttributedString.Key.strikethroughStyle])
         guard let style = attrs[NSAttributedString.Key.strikethroughStyle] as? NSNumber else {
@@ -676,7 +675,7 @@ final class StringExtensionsTests: XCTestCase {
     #if os(iOS)
     func testItalic() {
         let italicString = "hello".italic
-        // swiftlint:disable next legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let attrs = italicString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, italicString.length))
         XCTAssertNotNil(attrs[NSAttributedString.Key.font])
         guard let font = attrs[NSAttributedString.Key.font] as? UIFont else {
@@ -689,7 +688,7 @@ final class StringExtensionsTests: XCTestCase {
 
     func testColored() {
         let coloredString = "hello".colored(with: .orange)
-        // swiftlint:disable next legacy_constructor
+        // swiftlint:disable:next legacy_constructor
         let attrs = coloredString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, coloredString.length))
         XCTAssertNotNil(attrs[NSAttributedString.Key.foregroundColor])
 

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -12,7 +12,7 @@ import XCTest
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
 
-// swiftlint:disable type_body_length, type_body_length
+// swiftlint:disable:next type_body_length
 final class UIViewExtensionsTests: XCTestCase {
 
     func testBorderColor() {


### PR DESCRIPTION
:rocket: It seems like SwifterSwift was using some outdated SwiftLint syntax for `disable next` and they were added in wrong places (not just above the line they were intended to apply to).

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 4.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.