### PR TITLE
Add conformance for Optional to Comparable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Optional**
+  - Conformance to `Comparable`. [#647](https://github.com/SwifterSwift/SwifterSwift/pull/647) by [guykogus](https://github.com/guykogus)
 
 ### Changed
 
@@ -43,7 +45,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Sequence**:
   - Added `duplicates()` for getting the duplicated elements in a sequence. [#605](https://github.com/SwifterSwift/SwifterSwift/pull/605) by [dylancfe15](https://github.com/dylancfe15)
 - **Date**:
-- Added `tomorrow` computed property to get tomorrow's date avoiding calling `adding(_:value:)` function. (Completes PR #578) [#587](https://github.com/SwifterSwift/SwifterSwift/pull/587) by [AlexeiGitH](https://github.com/AlexeiGitH)
+  - Added `tomorrow` computed property to get tomorrow's date avoiding calling `adding(_:value:)` function. (Completes PR #578) [#587](https://github.com/SwifterSwift/SwifterSwift/pull/587) by [AlexeiGitH](https://github.com/AlexeiGitH)
   - Added `random(in:)` and `random(in:using:)` to generate random dates using the built-in random functions added to Swift 4.2. [#576](https://github.com/SwifterSwift/SwifterSwift/pull/576/files) by [guykogus](https://github.com/guykogus)
 - **Dictionary**:
   - Added `Dictionary[path:]` subscript for deep fetching/setting nested values. [#574](https://github.com/SwifterSwift/SwifterSwift/pull/573) by [@calebkleveter](https://github.com/calebkleveter)
@@ -59,7 +61,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIActivity**:
   - Added `ActivityType` constants for iCloud Drive, WhatsApp, LinkedIn and XING. [#580](https://github.com/SwifterSwift/SwifterSwift/pull/580) by [staffler-xyz](https://github.com/staffler-xyz)
 - **MKMapView**
-  - Added 'register(annotationViewWithClass:)`, `dequeueReusableAnnotationView(withClass:)` and `dequeueReusableAnnotationView(withClass:annotation)` methods. [#629](https://github.com/SwifterSwift/SwifterSwift/pull/629) by [staffler-xyz](https://github.com/staffler-xyz)
+  - Added `register(annotationViewWithClass:)`, `dequeueReusableAnnotationView(withClass:)` and `dequeueReusableAnnotationView(withClass:annotation)` methods. [#629](https://github.com/SwifterSwift/SwifterSwift/pull/629) by [staffler-xyz](https://github.com/staffler-xyz)
 
 ### Changed
 

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -50,18 +50,6 @@ public extension Array {
         return (matching, nonMatching)
     }
 
-    /// SwifterSwift: Returns a sorted array based on an optional keypath.
-    ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
-    /// - Parameter ascending: If order must be ascending.
-    /// - Returns: Sorted array based on keyPath.
-    func sorted<T: Comparable>(by path: KeyPath<Element, T?>, ascending: Bool = true) -> [Element] {
-        return sorted(by: { (lhs, rhs) -> Bool in
-            guard let lhsValue = lhs[keyPath: path], let rhsValue = rhs[keyPath: path] else { return false }
-            return ascending ? (lhsValue < rhsValue) : (lhsValue > rhsValue)
-        })
-    }
-
     /// SwifterSwift: Returns a sorted array based on a keypath.
     ///
     /// - Parameter path: Key path to sort. The key path type must be Comparable.
@@ -71,18 +59,6 @@ public extension Array {
         return sorted(by: { (lhs, rhs) -> Bool in
             return ascending ? (lhs[keyPath: path] < rhs[keyPath: path]) : (lhs[keyPath: path] > rhs[keyPath: path])
         })
-    }
-
-    /// SwifterSwift: Sort the array based on an optional keypath.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to sort, must be Comparable.
-    ///   - ascending: whether order is ascending or not.
-    /// - Returns: self after sorting.
-    @discardableResult
-    mutating func sort<T: Comparable>(by path: KeyPath<Element, T?>, ascending: Bool = true) -> [Element] {
-        self = sorted(by: path, ascending: ascending)
-        return self
     }
 
     /// SwifterSwift: Sort the array based on a keypath.

--- a/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
@@ -111,6 +111,21 @@ public extension Optional where Wrapped: Collection {
 
 }
 
+// MARK: - Methods (Comparable)
+
+extension Optional: Comparable where Wrapped: Comparable {
+    public static func < (lhs: Optional, rhs: Optional) -> Bool {
+        switch (lhs, rhs) {
+        case (.some(let lhsValue), .some(let rhsValue)):
+            return lhsValue < rhsValue
+        case (_, .none):
+            return false
+        case (.none, _):
+            return true
+        }
+    }
+}
+
 // MARK: - Operators
 infix operator ??= : AssignmentPrecedence
 infix operator ?= : AssignmentPrecedence

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -61,27 +61,31 @@ final class ArrayExtensionsTests: XCTestCase {
     }
 
     func testKeyPathSorted() {
-        let array = [Person(name: "James", age: 32), Person(name: "Wade", age: 36), Person(name: "Rose", age: 29)]
+        let james = Person(name: "James", age: 32)
+        let wade = Person(name: "Wade", age: 36)
+        let rose = Person(name: "Rose", age: nil)
 
-        XCTAssertEqual(array.sorted(by: \Person.name), [Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "Wade", age: 36)])
-        XCTAssertEqual(array.sorted(by: \Person.name, ascending: false), [Person(name: "Wade", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 32)])
+        let array = [james, wade, rose]
+
+        XCTAssertEqual(array.sorted(by: \.name), [james, rose, wade])
+        XCTAssertEqual(array.sorted(by: \.name, ascending: false), [wade, rose, james])
         // Testing Optional keyPath
-        XCTAssertEqual(array.sorted(by: \Person.age), [Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Wade", age: 36)])
-        XCTAssertEqual(array.sorted(by: \Person.age, ascending: false), [Person(name: "Wade", age: 36), Person(name: "James", age: 32), Person(name: "Rose", age: 29)])
+        XCTAssertEqual(array.sorted(by: \.age), [rose, james, wade])
+        XCTAssertEqual(array.sorted(by: \.age, ascending: false), [wade, james, rose])
 
         // Testing Mutating
-        var mutableArray = [Person(name: "James", age: 32), Person(name: "Wade", age: 36), Person(name: "Rose", age: 29)]
+        var mutableArray = [james, wade, rose]
 
-        mutableArray.sort(by: \Person.name)
-        XCTAssertEqual(mutableArray, [Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "Wade", age: 36)])
+        mutableArray.sort(by: \.name)
+        XCTAssertEqual(mutableArray, [james, rose, wade])
 
         // Testing Mutating Optional keyPath
-        mutableArray.sort(by: \Person.age)
-        XCTAssertEqual(mutableArray, [Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Wade", age: 36)])
+        mutableArray.sort(by: \.age)
+        XCTAssertEqual(mutableArray, [rose, james, wade])
 
         // Testing nil path
         let nilArray = [Person(name: "James", age: nil), Person(name: "Wade", age: nil)]
-        XCTAssertEqual(nilArray.sorted(by: \Person.age), [Person(name: "James", age: nil), Person(name: "Wade", age: nil)])
+        XCTAssertEqual(nilArray.sorted(by: \.age), [Person(name: "James", age: nil), Person(name: "Wade", age: nil)])
     }
 
     func testRemoveAll() {

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -116,4 +116,39 @@ final class OptionalExtensionsTests: XCTestCase {
         XCTAssertEqual(collection.nonEmpty!, [1, 2, 3])
     }
 
+    func testComparable() {
+        let minusOne: Int? = -1
+        let zero: Int? = 0
+        let one: Int? = 1
+
+        // Int?.some vs Int
+        XCTAssert(minusOne < 0)
+        XCTAssert(zero < 1)
+        XCTAssert(one < 2)
+        XCTAssert(-2 < minusOne)
+        XCTAssert(-1 < zero)
+        XCTAssert(0 < one)
+
+        // Int?.none vs Int
+        XCTAssert(nil < -1)
+        XCTAssert(nil < 0)
+        XCTAssert(nil < 1)
+        XCTAssertFalse(-1 < nil)
+        XCTAssertFalse(0 < nil)
+        XCTAssertFalse(1 < nil)
+
+        // Int?.some vs Int?.some
+        XCTAssert(minusOne < zero)
+        XCTAssert(minusOne < one)
+        XCTAssert(zero < one)
+
+        // Int?.some vs Int?.none
+        XCTAssertFalse(minusOne < nil)
+        XCTAssertFalse(zero < nil)
+        XCTAssertFalse(one < nil)
+        XCTAssert(nil < minusOne)
+        XCTAssert(nil < zero)
+        XCTAssert(nil < one)
+    }
+
 }


### PR DESCRIPTION
It would be nice if we were able to compare `Optional` values, like so:
```Swift
struct Player {
    let name: String
    let score: Int?
}

let players = [Player(name: "Omar", score: 10),
               Player(name: "Steven", score: 20),
               Player(name: "Guy", score: nil)]
players.sorted(by: { $0.score < $1.score }) // Guy, Omar, Steven
```

Does this make sense to do? Is there a situation where this doesn't make sense?
Also, I can't mark the extension as `public`, because I get the following error:
> 'public' modifier cannot be used with extensions that declare protocol conformances

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 4.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.