### PR TITLE
Refactored the query value extension in URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 
 ### Changed
+- **UIApplication**:
+  - - `queryValue(for:)` extension for URL is refactored. [#668](https://github.com/SwifterSwift/SwifterSwift/pull/668) by [LucianoPAlmeida](https://github.com/ratulSharker).
+
 
 ### Deprecated
 

--- a/Sources/SwifterSwift/Foundation/URLExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLExtensions.swift
@@ -70,12 +70,10 @@ public extension URL {
     ///
     /// - Parameter key: The key of a query value.
     func queryValue(for key: String) -> String? {
-        let stringURL = absoluteString
-        guard let items = URLComponents(string: stringURL)?.queryItems else { return nil }
-        for item in items where item.name == key {
-            return item.value
-        }
-        return nil
+        return URLComponents(string: absoluteString)?
+            .queryItems?
+            .first(where: { $0.name == key })?
+            .value
     }
 
     /// SwifterSwift: Returns a new URL by removing all the path components.


### PR DESCRIPTION
`queryValue` extension refactored. Issue discussed in [#661.](https://github.com/SwifterSwift/SwifterSwift/issues/661)

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
