### PR TITLE
✨ Added String.isPalindrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **String**
+  - - `isPalindrome` computed property of String to check if it is a palindrome
 
 ### Changed
 - **UIApplication**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **String**
-  - - `isPalindrome` computed property of String to check if it is a palindrome
+  - `isPalindrome` computed property of String to check if it is a palindrome
 
 ### Changed
 - **UIApplication**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **String**
-  - `isPalindrome` computed property of String to check if it is a palindrome
+  - `isPalindrome` computed property of String to check if it is a palindrome. [#671](https://github.com/SwifterSwift/SwifterSwift/pull/671) by [cHaLkdusT](https://github.com/cHaLkdusT).
 
 - **CGSize**:
   - Added `aspectRatio`, `maxDimension`, and `minDimension` properties. [#662](https://github.com/SwifterSwift/SwifterSwift/pull/662) by [vyax](https://github.com/vyax)

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -154,21 +154,22 @@ public extension String {
         return comps.joined(separator: "").count == 0 && hasLetters && hasNumbers
     }
 
-    /// SwifterSwift: Check if string is palindrome
+    /// SwifterSwift: Check if string is palindrome.
     ///
     ///     "abcdcba".isPalindrome -> true
     ///     "Mom".isPalindrome -> true
+    ///     "A man a plan a canal, Panama!".isPalindrome -> true
     ///     "Mama".isPalindrome -> false
     ///
     var isPalindrome: Bool {
-        // https://gist.github.com/alimir1/83b94be5fde4ef8b51ba6bf6044e78cd
-        let word = self.lowercased().filter { $0 != " " }
-        for (i, character) in word.enumerated() {
-            if character != Array(word)[word.count-i-1] {
-                return false
-            }
-        }
-        return true
+        let letters = filter { $0.isLetter }
+        
+        guard !letters.isEmpty else { return false }
+        
+        let midIndex = letters.index(letters.startIndex, offsetBy: letters.count / 2)
+        let firstHalf = letters[letters.startIndex..<midIndex]
+        let secondHalf = letters[midIndex..<letters.endIndex].reversed()
+        return !zip(firstHalf, secondHalf).contains(where: { $0.lowercased() != $1.lowercased() })
     }
 
     #if canImport(Foundation)

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -154,6 +154,22 @@ public extension String {
         return comps.joined(separator: "").count == 0 && hasLetters && hasNumbers
     }
 
+    /// SwifterSwift: Check if string is palindrome
+    ///
+    ///     "abcdcba".isPalindrome -> true
+    ///     "Mom".isPalindrome -> true
+    ///     "Mama".isPalindrome -> false
+    ///
+    var isPalindrome: Bool {
+        let word = self.lowercased().filter { $0 != " " }
+        for (i, character) in word.enumerated() {
+            if character != Array(word)[word.count-i-1] {
+                return false
+            }
+        }
+        return true
+    }
+
     #if canImport(Foundation)
     /// SwifterSwift: Check if string is valid email format.
     ///

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -161,6 +161,7 @@ public extension String {
     ///     "Mama".isPalindrome -> false
     ///
     var isPalindrome: Bool {
+        // https://gist.github.com/alimir1/83b94be5fde4ef8b51ba6bf6044e78cd
         let word = self.lowercased().filter { $0 != " " }
         for (i, character) in word.enumerated() {
             if character != Array(word)[word.count-i-1] {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -77,7 +77,9 @@ final class StringExtensionsTests: XCTestCase {
     func testIsPalindrome() {
         XCTAssert("abcdcba".isPalindrome)
         XCTAssert("Mom".isPalindrome)
+        XCTAssert("A man a plan a canal, Panama!".isPalindrome)
         XCTAssertFalse("Mama".isPalindrome)
+        XCTAssertFalse("".isPalindrome)
     }
 
     func testisValidEmail() {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -74,6 +74,12 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("abc".isAlphaNumeric)
     }
 
+    func testIsPalindrome() {
+        XCTAssert("abcdcba".isPalindrome)
+        XCTAssert("Mom".isPalindrome)
+        XCTAssertFalse("Mama".isPalindrome)
+    }
+
     func testisValidEmail() {
         // https://blogs.msdn.microsoft.com/testing123/2009/02/06/email-address-test-cases/
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Check if string is palindrome

### Sample Usage
`"Mom".isPalindrome // true`

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
