### PR TITLE
Added a convenience to UIColor 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **UIColor**:
-    -You can now init UIColor with `UIColor(red: 255, green: 255, blue: 255, alpha: 1)`. That means no dividing!
+    - You can now init UIColor with `UIColor(red: 255, green: 255, blue: 255, alpha: 1)`. That means no dividing!
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
-- **UIColor**
-    -You can now init UIColor with `UIColor(r: 255, g: 255, b: 255, a: 1)`
+- **UIColor**:
+    -You can now init UIColor with `UIColor(red: 255, green: 255, blue: 255, alpha: 1)`. That means no dividing!
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -10,14 +10,15 @@ import Foundation
 import UIKit
 
 extension UIColor {
-    /// SwifterSwift: Simple UIColor init.
+    /// SwifterSwift: Simple  UIColor init.
     ///
     ///    loginButton.color = UIColor(r: 255, g: 0, b: 70, a: 1)
     ///
     /// - Parameters:
-    ///   - r: Red Value.
-    ///   - b: Blue Value.
-    ///   - g: Green Value.
+    ///   - red: Red Value.
+    ///   - blue: Blue Value.
+    ///   - green: Green Value.
+    ///   -alpha: Alpha Value.
     public convenience init?(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
         self.init(red: red/255, green: green/255, blue: blue/255, alpha: alpha)
     }

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -18,8 +18,8 @@ extension UIColor {
     ///   - r: Red Value.
     ///   - b: Blue Value.
     ///   - g: Green Value.
-    public convenience init?(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
-        self.init(red: r/255, green: g/255, blue: b/255, alpha: a)
+    public convenience init?(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        self.init(red: red/255, green: green/255, blue: blue/255, alpha: alpha)
     }
 
 }

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -18,11 +18,8 @@ extension UIColor {
     ///   - r: Red Value.
     ///   - b: Blue Value.
     ///   - g: Green Value.
-    
     public convenience init?(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
         self.init(red: r/255, green: g/255, blue: b/255, alpha: a)
-        
     }
 
 }
-

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -1,0 +1,28 @@
+//
+//  UIColorExtensions.swift
+//  SwifterSwift
+//
+//  Created by freedom on 5/24/19.
+//  Copyright © 2019 SwifterSwift
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    /// SwifterSwift: Simple UIColor init.
+    ///
+    ///    loginButton.color = UIColor(r: 255, g: 0, b: 70, a: 1)
+    ///
+    /// - Parameters:
+    ///   - r: Red Value.
+    ///   - b: Blue Value.
+    ///   - g: Green Value.
+    
+    public convenience init?(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        self.init(red: r/255, green: g/255, blue: b/255, alpha: a)
+        
+    }
+
+}
+

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 		CAC5EBD12125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
 		CF30948A216AAC7A005609BC /* UIActivityExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF309489216AAC7A005609BC /* UIActivityExtensions.swift */; };
 		EE72DFDD2298478200145E80 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72DFDC2298478200145E80 /* UIColorExtensions.swift */; };
+		EE72DFE02298515A00145E80 /* UIColorExtentionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72DFDE22984EA900145E80 /* UIColorExtentionTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -727,6 +728,7 @@
 		CAC5EBC52125270A00AB27EC /* big_buck_bunny_720p_1mb.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = big_buck_bunny_720p_1mb.mp4; sourceTree = "<group>"; };
 		CF309489216AAC7A005609BC /* UIActivityExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityExtensions.swift; sourceTree = "<group>"; };
 		EE72DFDC2298478200145E80 /* UIColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
+		EE72DFDE22984EA900145E80 /* UIColorExtentionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtentionTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -933,6 +935,7 @@
 				07B7F17D1F5EB41600E6F910 /* UIBarButtonItemExtensions.swift */,
 				07B7F17E1F5EB41600E6F910 /* UIButtonExtensions.swift */,
 				07B7F17F1F5EB41600E6F910 /* UICollectionViewExtensions.swift */,
+				EE72DFDC2298478200145E80 /* UIColorExtensions.swift */,
 				074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */,
 				90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */,
 				07B7F1811F5EB41600E6F910 /* UIImageExtensions.swift */,
@@ -960,7 +963,6 @@
 				CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */,
 				8D4B424B212972AE002A5923 /* UILayoutPriorityExtensions.swift */,
 				CF309489216AAC7A005609BC /* UIActivityExtensions.swift */,
-				EE72DFDC2298478200145E80 /* UIColorExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -1035,6 +1037,7 @@
 				B247BDE820D37AFE00842ACC /* UIEdgeInsetsExtensionsTests.swift */,
 				CA1317562106D4F5002F1B0D /* UIRefreshControlExntesionsTests.swift */,
 				8D4B424E212972E7002A5923 /* UILayoutPriorityExtensionsTests.swift */,
+				EE72DFDE22984EA900145E80 /* UIColorExtentionTest.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -2008,6 +2011,7 @@
 				A94AA78A202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */,
 				7832C2B4209BB32500224EED /* ComparableExtensionsTests.swift in Sources */,
 				182698AC1F8AB46E0052F21E /* CGColorExtensionsTests.swift in Sources */,
+				EE72DFE02298515A00145E80 /* UIColorExtentionTest.swift in Sources */,
 				07C50D8F1F5EB06000F46E5A /* CLLocationExtensionsTests.swift in Sources */,
 				9D806A972258FD81008E500A /* SCNCylinderExtensionsTests.swift in Sources */,
 				07C50D8D1F5EB06000F46E5A /* CGPointExtensionsTests.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 		CAC5EBD02125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
 		CAC5EBD12125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
 		CF30948A216AAC7A005609BC /* UIActivityExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF309489216AAC7A005609BC /* UIActivityExtensions.swift */; };
+		EE72DFDD2298478200145E80 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72DFDC2298478200145E80 /* UIColorExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -725,6 +726,7 @@
 		CAC5EBC42125270A00AB27EC /* UITableViewHeaderFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UITableViewHeaderFooterView.xib; sourceTree = "<group>"; };
 		CAC5EBC52125270A00AB27EC /* big_buck_bunny_720p_1mb.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = big_buck_bunny_720p_1mb.mp4; sourceTree = "<group>"; };
 		CF309489216AAC7A005609BC /* UIActivityExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityExtensions.swift; sourceTree = "<group>"; };
+		EE72DFDC2298478200145E80 /* UIColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -958,6 +960,7 @@
 				CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */,
 				8D4B424B212972AE002A5923 /* UILayoutPriorityExtensions.swift */,
 				CF309489216AAC7A005609BC /* UIActivityExtensions.swift */,
+				EE72DFDC2298478200145E80 /* UIColorExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -1651,6 +1654,7 @@
 				07B7F22F1F5EB45100E6F910 /* CGFloatExtensions.swift in Sources */,
 				9D806A602258D503008E500A /* SCNPlaneExtensions.swift in Sources */,
 				CF30948A216AAC7A005609BC /* UIActivityExtensions.swift in Sources */,
+				EE72DFDD2298478200145E80 /* UIColorExtensions.swift in Sources */,
 				07B7F1981F5EB42000E6F910 /* UIImageViewExtensions.swift in Sources */,
 				42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */,
 				7832C2AF209BB19300224EED /* ComparableExtensions.swift in Sources */,

--- a/Tests/UIKitTests/UIColorExtentionTest.swift
+++ b/Tests/UIKitTests/UIColorExtentionTest.swift
@@ -10,8 +10,8 @@ import XCTest
 @testable import SwifterSwift
 final class UIColorExtensionTest: XCTestCase {
     func testRGB() {
-        let color = UIColor(r: 255, g: 255, b: 255, a: 1)
+        let color = UIColor(red: 255, green: 255, blue: 255, alpha: 1)
         let viewController = UIViewController()
-        ViewController.view.backgroundColor = color
+        viewController.view.backgroundColor = color
     }
 }

--- a/Tests/UIKitTests/UIColorExtentionTest.swift
+++ b/Tests/UIKitTests/UIColorExtentionTest.swift
@@ -1,0 +1,17 @@
+//
+//  UIColorExtentionTest.swift
+//  SwifterSwift
+//
+//  Created by freedom on 5/24/19.
+//  Copyright © 2019 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+final class UIColorExtensionTest: XCTestCase {
+    func testRGB() {
+        let color = UIColor(r: 255, g: 255, b: 255, a: 1)
+        let viewController = UIViewController()
+        ViewController.view.backgroundColor = color
+    }
+}


### PR DESCRIPTION
## Checklist 🚀 
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

## Changes

My extension allows you to use UIColor without dividing every number. It uses a convenience init to do this. This is also my first time writing a test, and contributing Swift to a open source Project. Here is the before and after of the color white:

#### Before:

`UIColor(red: 255/255, green: 255/255, blue: 255/255, a: 1)` 

#### After:

`UIColor(red: 255, green: 255, blue: 255, a: 1)` 

I complied to all SwiftLint Guidelines in writing this code.



