### PR TITLE
 Copied UserDefaults code to NSUbiquitousKeyValueStore for iCloud use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 
 - **NSUbiquitousKeyValueStore**:
-    -Added `subscript(key)`, 
-        `float(forKey:)`,
-        `date(forKey:)`,
-        `object(_:with:usingDecoder)`,
-        `set(object:forKey:usingEncoder)` [#686](https://github.com/SwifterSwift/SwifterSwift/pull/686) by [jlcanale](https://github.com/jlcanale)
+    -Added `subscript(key)`,  `float(forKey:)`, `date(forKey:)`, `object(_:with:usingDecoder)`, `set(object:forKey:usingEncoder)` [#686](https://github.com/SwifterSwift/SwifterSwift/pull/686) by [jlcanale](https://github.com/jlcanale)
 
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+
+- **NSUbiquitousKeyValueStore**:
+    -Added `subscript(key)`, 
+        `float(forKey:)`,
+        `date(forKey:)`,
+        `object(:with:usingDecoder)`,
+        `set(object:forKey:usingEncoder)`
+
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
     -Added `subscript(key)`, 
         `float(forKey:)`,
         `date(forKey:)`,
-        `object(:with:usingDecoder)`,
+        `object(_:with:usingDecoder)`,
         `set(object:forKey:usingEncoder)` [#686](https://github.com/SwifterSwift/SwifterSwift/pull/686) by [jlcanale](https://github.com/jlcanale)
 
 - **Sequence**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
         `float(forKey:)`,
         `date(forKey:)`,
         `object(:with:usingDecoder)`,
-        `set(object:forKey:usingEncoder)`
+        `set(object:forKey:usingEncoder)` [#686](https://github.com/SwifterSwift/SwifterSwift/pull/686) by [jlcanale](https://github.com/jlcanale)
 
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)

--- a/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
@@ -1,0 +1,68 @@
+//
+//  NSUbiquitousKeyValueStoreExtensions.swift
+//  SwifterSwift
+//
+//  Created by Joseph Canale on 6/7/19.
+//  Copyright © 2017 SwifterSwift
+//
+
+import Foundation
+#if canImport(Foundation) && !os(Linux)
+
+// MARK: - Methods
+public extension NSUbiquitousKeyValueStore {
+
+    /// SwifterSwift: get object from NSUbiquitousKeyValueStore by using subscript
+    ///
+    /// - Parameter key: key in the current Key-Value Stor database.
+    subscript(key: String) -> Any? {
+        get {
+            return object(forKey: key)
+        }
+        set {
+            set(newValue, forKey: key)
+        }
+    }
+
+    /// SwifterSwift: Float from NSUbiquitousKeyValueStore.
+    ///
+    /// - Parameter forKey: key to find float for.
+    /// - Returns: Float object for key (if exists).
+    func float(forKey key: String) -> Float? {
+        return object(forKey: key) as? Float
+    }
+
+    /// SwifterSwift: Date from NSUbiquitousKeyValueStore.
+    ///
+    /// - Parameter forKey: key to find date for.
+    /// - Returns: Date object for key (if exists).
+    func date(forKey key: String) -> Date? {
+        return object(forKey: key) as? Date
+    }
+
+    /// SwifterSwift: Retrieves a Codable object from NSUbiquitousKeyValueStore.
+    ///
+    /// - Parameters:
+    ///   - type: Class that conforms to the Codable protocol.
+    ///   - key: Identifier of the object.
+    ///   - decoder: Custom JSONDecoder instance. Defaults to `JSONDecoder()`.
+    /// - Returns: Codable object for key (if exists).
+    func object<T: Codable>(_ type: T.Type, with key: String, usingDecoder decoder: JSONDecoder = JSONDecoder()) -> T? {
+        guard let data = object(forKey: key) as? Data else { return nil }
+        return try? decoder.decode(type.self, from: data)
+    }
+
+    /// SwifterSwift: Allows storing of Codable objects to NSUbiquitousKeyValueStore.
+    ///
+    /// - Parameters:
+    ///   - object: Codable object to store.
+    ///   - key: Identifier of the object.
+    ///   - encoder: Custom JSONEncoder instance. Defaults to `JSONEncoder()`.
+    func set<T: Codable>(object: T, forKey key: String, usingEncoder encoder: JSONEncoder = JSONEncoder()) {
+        let data = try? encoder.encode(object)
+        set(data, forKey: key)
+    }
+
+}
+
+#endif

--- a/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
@@ -24,14 +24,6 @@ public extension NSUbiquitousKeyValueStore {
         }
     }
 
-    /// SwifterSwift: Float from NSUbiquitousKeyValueStore.
-    ///
-    /// - Parameter key: key to find float for.
-    /// - Returns: Float object for key (if exists).
-    func float(forKey key: String) -> Float {
-        return Float(double(forKey: key))
-    }
-
     /// SwifterSwift: Date from NSUbiquitousKeyValueStore.
     ///
     /// - Parameter key: key to find date for.

--- a/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(Foundation) && !os(Linux)
+#if canImport(Foundation) && !os(Linux) && !os(watchOS)
 
 // MARK: - Methods
 public extension NSUbiquitousKeyValueStore {

--- a/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
@@ -26,7 +26,7 @@ public extension NSUbiquitousKeyValueStore {
 
     /// SwifterSwift: Float from NSUbiquitousKeyValueStore.
     ///
-    /// - Parameter forKey: key to find float for.
+    /// - Parameter key: key to find float for.
     /// - Returns: Float object for key (if exists).
     func float(forKey key: String) -> Float? {
         return object(forKey: key) as? Float
@@ -34,7 +34,7 @@ public extension NSUbiquitousKeyValueStore {
 
     /// SwifterSwift: Date from NSUbiquitousKeyValueStore.
     ///
-    /// - Parameter forKey: key to find date for.
+    /// - Parameter key: key to find date for.
     /// - Returns: Date object for key (if exists).
     func date(forKey key: String) -> Date? {
         return object(forKey: key) as? Date
@@ -58,7 +58,7 @@ public extension NSUbiquitousKeyValueStore {
     ///   - object: Codable object to store.
     ///   - key: Identifier of the object.
     ///   - encoder: Custom JSONEncoder instance. Defaults to `JSONEncoder()`.
-    func set<T: Codable>(object: T, forKey key: String, usingEncoder encoder: JSONEncoder = JSONEncoder()) {
+    func set<T: Codable>(_ object: T, forKey key: String, usingEncoder encoder: JSONEncoder = JSONEncoder()) {
         let data = try? encoder.encode(object)
         set(data, forKey: key)
     }

--- a/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
@@ -28,8 +28,8 @@ public extension NSUbiquitousKeyValueStore {
     ///
     /// - Parameter key: key to find float for.
     /// - Returns: Float object for key (if exists).
-    func float(forKey key: String) -> Float? {
-        return object(forKey: key) as? Float
+    func float(forKey key: String) -> Float {
+        return Float(double(forKey: key))
     }
 
     /// SwifterSwift: Date from NSUbiquitousKeyValueStore.

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-#if canImport(Foundation)
+#if canImport(Foundation) && !os(Linux) && !os(watchOS)
 import Foundation
 
 final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
@@ -19,7 +19,6 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
     }
 
     func testSubscript() {
-        #if !os(Linux)
         let key = "testKey"
         NSUbiquitousKeyValueStore.default.set(true, forKey: key)
         XCTAssertNotNil(NSUbiquitousKeyValueStore.default[key])
@@ -29,47 +28,38 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
         NSUbiquitousKeyValueStore.default[key] = false
         XCTAssertNotNil(NSUbiquitousKeyValueStore.default[key])
         XCTAssertFalse(NSUbiquitousKeyValueStore.default[key] as? Bool ?? false)
-        #endif
     }
 
     func testFloat() {
-        #if !os(Linux)
         let key = "floatTestKey"
         let number: Float = 10.0
         NSUbiquitousKeyValueStore.default.set(number, forKey: key)
         XCTAssertNotNil(NSUbiquitousKeyValueStore.default.float(forKey: key))
-        XCTAssertEqual(NSUbiquitousKeyValueStore.default.float(forKey: key)!, number)
-        #endif
+        XCTAssertEqual(NSUbiquitousKeyValueStore.default.float(forKey: key), number)
     }
 
     func testDate() {
-        #if !os(Linux)
         let key = "dateTestKey"
         let date = Date()
         NSUbiquitousKeyValueStore.default.set(date, forKey: key)
         XCTAssertNotNil(NSUbiquitousKeyValueStore.default.date(forKey: key))
         XCTAssertEqual(NSUbiquitousKeyValueStore.default.date(forKey: key)!, date)
-        #endif
     }
 
     func testGetCodableObject() {
-        #if !os(Linux)
         let key = "codableTestKey"
         let codable = TestObject(itemId: 1)
-        NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
+        NSUbiquitousKeyValueStore.default.set(codable, forKey: key)
         let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
         XCTAssertNotNil(retrievedCodable)
-        #endif
     }
 
     func testSetCodableObject() {
-        #if !os(Linux)
         let key = "codableTestKey"
         let codable = TestObject(itemId: 1)
-        NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
+        NSUbiquitousKeyValueStore.default.set(codable, forKey: key)
         let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
         XCTAssertEqual(codable, retrievedCodable)
-        #endif
     }
 
 }

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
@@ -68,7 +68,7 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
         let codable = TestObject(itemId: 1)
         NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
         let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
-        XCTAssertNotNil(retrievedCodable)
+        XCTAssertEqual(codable, retrievedCodable)
         #endif
     }
 

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
@@ -1,0 +1,77 @@
+//
+//  UserDefaultsExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Omar Albeik on 9/6/17.
+//  Copyright © 2016 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if canImport(Foundation)
+import Foundation
+
+final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
+
+    private struct TestObject: Codable {
+        var itemId: Int
+    }
+
+    func testSubscript() {
+        #if !os(Linux)
+        let key = "testKey"
+        NSUbiquitousKeyValueStore.default.set(true, forKey: key)
+        XCTAssertNotNil(NSUbiquitousKeyValueStore.default[key])
+        XCTAssert(NSUbiquitousKeyValueStore.default[key] as? Bool ?? false)
+
+        NSUbiquitousKeyValueStore.default.removeObject(forKey: key)
+        NSUbiquitousKeyValueStore.default[key] = false
+        XCTAssertNotNil(NSUbiquitousKeyValueStore.default[key])
+        XCTAssertFalse(NSUbiquitousKeyValueStore.default[key] as? Bool ?? false)
+        #endif
+    }
+
+    func testFloat() {
+        #if !os(Linux)
+        let key = "floatTestKey"
+        let number: Float = 10.0
+        NSUbiquitousKeyValueStore.default.set(number, forKey: key)
+        XCTAssertNotNil(NSUbiquitousKeyValueStore.default.float(forKey: key))
+        XCTAssertEqual(NSUbiquitousKeyValueStore.default.float(forKey: key)!, number)
+        #endif
+    }
+
+    func testDate() {
+        #if !os(Linux)
+        let key = "dateTestKey"
+        let date: Date = Date()
+        NSUbiquitousKeyValueStore.default.set(date, forKey: key)
+        XCTAssertNotNil(NSUbiquitousKeyValueStore.default.date(forKey: key))
+        XCTAssertEqual(NSUbiquitousKeyValueStore.default.date(forKey: key)!, date)
+        #endif
+    }
+
+    func testGetCodableObject() {
+        #if !os(Linux)
+        let key = "codableTestKey"
+        let codable: TestObject = TestObject(itemId: 1)
+        NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
+        let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
+        XCTAssertNotNil(retrievedCodable)
+        #endif
+    }
+
+    func testSetCodableObject() {
+        #if !os(Linux)
+        let key = "codableTestKey"
+        let codable: TestObject = TestObject(itemId: 1)
+        NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
+        let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
+        XCTAssertNotNil(retrievedCodable)
+        #endif
+    }
+
+}
+
+#endif

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
@@ -14,7 +14,7 @@ import Foundation
 
 final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
 
-    private struct TestObject: Codable {
+    private struct TestObject: Codable, Equatable {
         var itemId: Int
     }
 
@@ -45,7 +45,7 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
     func testDate() {
         #if !os(Linux)
         let key = "dateTestKey"
-        let date: Date = Date()
+        let date = Date()
         NSUbiquitousKeyValueStore.default.set(date, forKey: key)
         XCTAssertNotNil(NSUbiquitousKeyValueStore.default.date(forKey: key))
         XCTAssertEqual(NSUbiquitousKeyValueStore.default.date(forKey: key)!, date)
@@ -55,7 +55,7 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
     func testGetCodableObject() {
         #if !os(Linux)
         let key = "codableTestKey"
-        let codable: TestObject = TestObject(itemId: 1)
+        let codable = TestObject(itemId: 1)
         NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
         let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
         XCTAssertNotNil(retrievedCodable)
@@ -65,7 +65,7 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
     func testSetCodableObject() {
         #if !os(Linux)
         let key = "codableTestKey"
-        let codable: TestObject = TestObject(itemId: 1)
+        let codable = TestObject(itemId: 1)
         NSUbiquitousKeyValueStore.default.set(object: codable, forKey: key)
         let retrievedCodable = NSUbiquitousKeyValueStore.default.object(TestObject.self, with: key)
         XCTAssertNotNil(retrievedCodable)

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
@@ -30,14 +30,6 @@ final class NSUbiquitousKeyValueStoreExtensionsTests: XCTestCase {
         XCTAssertFalse(NSUbiquitousKeyValueStore.default[key] as? Bool ?? false)
     }
 
-    func testFloat() {
-        let key = "floatTestKey"
-        let number: Float = 10.0
-        NSUbiquitousKeyValueStore.default.set(number, forKey: key)
-        XCTAssertNotNil(NSUbiquitousKeyValueStore.default.float(forKey: key))
-        XCTAssertEqual(NSUbiquitousKeyValueStore.default.float(forKey: key), number)
-    }
-
     func testDate() {
         let key = "dateTestKey"
         let date = Date()

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreExtensionsTests.swift
@@ -1,9 +1,9 @@
 //
-//  UserDefaultsExtensionsTests.swift
+//  NSUbiquitousKeyValueStoreExtensions.swift
 //  SwifterSwift
 //
-//  Created by Omar Albeik on 9/6/17.
-//  Copyright © 2016 SwifterSwift
+//  Created by Joseph Canale on 6/7/19.
+//  Copyright © 2017 SwifterSwift
 //
 
 import XCTest


### PR DESCRIPTION
This pull request copies the functions from UserDefaults to NSUbiquitousKeyValueStore.

## Checklist :rocket:
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.