### PR TITLE
Added Sequence.casted<T>()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
+    - Added `casted<T>()` to get an array where all items are casted to T. [#687](https://github.com/SwifterSwift/SwifterSwift/pull/687) by [RomanPodymov](https://github.com/RomanPodymov)
 - **String**
   - `isPalindrome` computed property of String to check if it is a palindrome. [#671](https://github.com/SwifterSwift/SwifterSwift/pull/671) by [cHaLkdusT](https://github.com/cHaLkdusT).
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -133,6 +133,15 @@ public extension Sequence {
         })
     }
 
+    /// SwifterSwift: Removes items that are not castable to the required type. You can also use this function to remove nils.
+    ///
+    ///     [1, nil, 3, nil, 5].casted as [Int] -> [1, 3, 5]
+    ///
+    /// - Returns: A filtered array with all elements casted to T
+    func casted<T>() -> [T] {
+        return compactMap { $0 as? T }
+    }
+
     /// SwifterSwift: Get the only element based on a condition.
     ///
     ///     [].single(where: {_ in true}) -> nil

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -133,7 +133,7 @@ public extension Sequence {
         })
     }
 
-    /// SwifterSwift: Removes items that are not castable to the required type. You can also use this function to remove nils.
+    /// SwifterSwift: Removes items that are not convertible to the required type. You can also use this function to remove nils.
     ///
     ///     [1, nil, 3, nil, 5].casted as [Int] -> [1, 3, 5]
     ///

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -76,6 +76,13 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(["2", "4"], result)
     }
 
+    func testCasted() {
+        let input = [1, nil, 3, nil, 5]
+        let result: [Int] = input.casted()
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual([1, 3, 5], result)
+    }
+
     func testSingle() {
         XCTAssertNil([].single(where: { _ in true }))
         XCTAssertEqual([4].single(where: { _ in true }), 4)


### PR DESCRIPTION
🚀
Added a function to remove all items that are not convertible to the required type. You can also use it to remove `nil`s since it is not possible to create an extension like `extension Sequence<T> where Element == Optional<T>`.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.