### PR TITLE
Removed isNumber, isLetter, isLowercased, isUppercased and isWhiteSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Removed
 - **Character**:
-  - `isNumber` is replaced by `isNumber` from Swift's Standard Library. [#689](https://github.com/SwifterSwift/SwifterSwift/pull/689) by [RomanPodymov](https://github.com/RomanPodymov).
-  - `isLetter` is replaced by `isLetter` from Swift's Standard Library. [#689](https://github.com/SwifterSwift/SwifterSwift/pull/689) by [RomanPodymov](https://github.com/RomanPodymov).
-  - `isLowercased` is replaced by `isLowercase` from Swift's Standard Library. [#689](https://github.com/SwifterSwift/SwifterSwift/pull/689) by [RomanPodymov](https://github.com/RomanPodymov).
-  - `isUppercased` is replaced by `isUppercase` from Swift's Standard Library. [#689](https://github.com/SwifterSwift/SwifterSwift/pull/689) by [RomanPodymov](https://github.com/RomanPodymov).
-  - `isWhiteSpace` is replaced by `isWhitespace` from Swift's Standard Library. [#689](https://github.com/SwifterSwift/SwifterSwift/pull/689) by [RomanPodymov](https://github.com/RomanPodymov).
+  - Removed `isNumber`, `isLetter`, `isLowercased`, `isUppercased` and `isWhiteSpace` because the same properties are defined in the Swift standard library. [#689](https://github.com/SwifterSwift/SwifterSwift/pull/689) by [RomanPodymov](https://github.com/RomanPodymov).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 
 ### Removed
+- **Character**:
+  - `isNumber` is replaced by `isNumber` from Swift's Standard Library. [#687](https://github.com/SwifterSwift/SwifterSwift/pull/687) by [RomanPodymov](https://github.com/RomanPodymov).
+  - `isLetter` is replaced by `isLetter` from Swift's Standard Library. [#687](https://github.com/SwifterSwift/SwifterSwift/pull/687) by [RomanPodymov](https://github.com/RomanPodymov).
+  - `isLowercased` is replaced by `isLowercase` from Swift's Standard Library. [#687](https://github.com/SwifterSwift/SwifterSwift/pull/687) by [RomanPodymov](https://github.com/RomanPodymov).
+  - `isUppercased` is replaced by `isUppercase` from Swift's Standard Library. [#687](https://github.com/SwifterSwift/SwifterSwift/pull/687) by [RomanPodymov](https://github.com/RomanPodymov).
+  - `isWhiteSpace` is replaced by `isWhitespace` from Swift's Standard Library. [#687](https://github.com/SwifterSwift/SwifterSwift/pull/687) by [RomanPodymov](https://github.com/RomanPodymov).
 
 ### Fixed
 

--- a/Sources/SwifterSwift/SwiftStdlib/CharacterExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CharacterExtensions.swift
@@ -36,51 +36,6 @@ public extension Character {
         }
     }
 
-    /// SwifterSwift: Check if character is number.
-    ///
-    ///        Character("1").isNumber -> true
-    ///        Character("a").isNumber -> false
-    ///
-    var isNumber: Bool {
-        return Int(String(self)) != nil
-    }
-
-    /// SwifterSwift: Check if character is a letter.
-    ///
-    ///        Character("4").isLetter -> false
-    ///        Character("a").isLetter -> true
-    ///
-    var isLetter: Bool {
-        return String(self).rangeOfCharacter(from: .letters, options: .numeric, range: nil) != nil
-    }
-
-    /// SwifterSwift: Check if character is lowercased.
-    ///
-    ///        Character("a").isLowercased -> true
-    ///        Character("A").isLowercased -> false
-    ///
-    var isLowercased: Bool {
-        return String(self) == String(self).lowercased()
-    }
-
-    /// SwifterSwift: Check if character is uppercased.
-    ///
-    ///        Character("a").isUppercased -> false
-    ///        Character("A").isUppercased -> true
-    ///
-    var isUppercased: Bool {
-        return String(self) == String(self).uppercased()
-    }
-
-    /// SwifterSwift: Check if character is white space.
-    ///
-    ///        Character(" ").isWhiteSpace -> true
-    ///        Character("A").isWhiteSpace -> false
-    ///
-    var isWhiteSpace: Bool {
-        return String(self) == " "
-    }
-
     /// SwifterSwift: Integer from character (if applicable).
     ///
     ///        Character("1").int -> 1

--- a/Tests/FoundationTests/XCTestManifests.swift
+++ b/Tests/FoundationTests/XCTestManifests.swift
@@ -113,6 +113,15 @@ extension NSAttributedStringExtensionsTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__NSAttributedStringExtensionsTests = [
+        ("testAppending", testAppending),
+        ("testApplyingToOccurrences", testApplyingToOccurrences),
+        ("testApplyingToRegex", testApplyingToRegex),
+        ("testAttributes", testAttributes),
+        ("testBolded", testBolded),
+        ("testColored", testColored),
+        ("testItalicized", testItalicized),
+        ("testOperators", testOperators),
+        ("testStruckthrough", testStruckthrough),
         ("testUnderlined", testUnderlined),
     ]
 }

--- a/Tests/SwiftStdlibTests/CharacterExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CharacterExtensionsTests.swift
@@ -24,33 +24,6 @@ final class CharacterExtensionsTests: XCTestCase {
         XCTAssertFalse(Character("j").isEmoji)
     }
 
-    func testIsNumber() {
-        XCTAssert(Character("1").isNumber)
-        XCTAssertFalse(Character("s").isNumber)
-    }
-
-    func testIsLetter() {
-        XCTAssertTrue(Character("a").isLetter)
-        XCTAssertTrue(Character("B").isLetter)
-        XCTAssertFalse(Character("3").isLetter)
-        XCTAssertFalse(Character("-").isLetter)
-    }
-
-    func testIsLowercased() {
-        XCTAssert(Character("s").isLowercased)
-        XCTAssertFalse(Character("S").isLowercased)
-    }
-
-    func testIsUpercased() {
-        XCTAssert(Character("S").isUppercased)
-        XCTAssertFalse(Character("s").isUppercased)
-    }
-
-    func testIsWhiteSpace() {
-        XCTAssertTrue(Character(" ").isWhiteSpace)
-        XCTAssertFalse(Character("-").isWhiteSpace)
-    }
-
     func testInt() {
         XCTAssertNotNil(Character("1").int)
         XCTAssertEqual(Character("1").int, 1)

--- a/Tests/SwiftStdlibTests/XCTestManifests.swift
+++ b/Tests/SwiftStdlibTests/XCTestManifests.swift
@@ -52,11 +52,6 @@ extension CharacterExtensionsTests {
     static let __allTests__CharacterExtensionsTests = [
         ("testInt", testInt),
         ("testIsEmoji", testIsEmoji),
-        ("testIsLetter", testIsLetter),
-        ("testIsLowercased", testIsLowercased),
-        ("testIsNumber", testIsNumber),
-        ("testIsUpercased", testIsUpercased),
-        ("testIsWhiteSpace", testIsWhiteSpace),
         ("testLowercased", testLowercased),
         ("testOperators", testOperators),
         ("testRandom", testRandom),
@@ -233,6 +228,7 @@ extension SequenceExtensionsTests {
         ("testRejectWhere", testRejectWhere),
         ("testSingle", testSingle),
         ("testSum", testSum),
+        ("testWithoutDuplicates", testWithoutDuplicates),
     ]
 }
 
@@ -303,6 +299,8 @@ extension StringExtensionsTests {
         ("testIsAlphaNumeric", testIsAlphaNumeric),
         ("testIsDigits", testIsDigits),
         ("testIsNumeric", testIsNumeric),
+        ("testIsPalindrome", testIsPalindrome),
+        ("testIsSpelledCorrectly", testIsSpelledCorrectly),
         ("testisValidEmail", testisValidEmail),
         ("testIsValidFileURL", testIsValidFileURL),
         ("testIsValidHttpsUrl", testIsValidHttpsUrl),
@@ -310,6 +308,7 @@ extension StringExtensionsTests {
         ("testIsValidSchemedUrl", testIsValidSchemedUrl),
         ("testIsValidUrl", testIsValidUrl),
         ("testIsWhiteSpaces", testIsWhiteSpaces),
+        ("testItalic", testItalic),
         ("testLastCharacter", testLastCharacter),
         ("testLastDeletingLastPathComponent", testLastDeletingLastPathComponent),
         ("testLastDeletingPathExtension", testLastDeletingPathExtension),


### PR DESCRIPTION
Hello.
This pull request fixes #673.

## 🚀Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.