### PR TITLE
Fix UIImageView download

### DIFF
--- a/Sources/SwifterSwift/UIKit/UIImageViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageViewExtensions.swift
@@ -37,8 +37,8 @@ public extension UIImageView {
                     completionHandler?(nil)
                     return
             }
-            DispatchQueue.main.async { [unowned self] in
-                self.image = image
+            DispatchQueue.main.async { [weak self] in
+                self?.image = image
                 completionHandler?(image)
             }
             }.resume()


### PR DESCRIPTION
### Fixed
- Fix UIImageView download method. If it's deallocated, this causes a crash when call **self**.