### PR TITLE
add missing 'SwifterSwift/UIKit' to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ SwifterSwift is Swift v5.0 compatible starting from v5
 <h4>- Integrate Foundation extensions only:</h4>
 <pre><code class="ruby language-ruby">pod 'SwifterSwift/Foundation'</code></pre>
 
+<h4>- Integrate UIKit extensions only:</h4>
+<pre><code class="ruby language-ruby">pod 'SwifterSwift/UIKit'</code></pre>
+
 <h4>- Integrate AppKit extensions only:</h4>
 <pre><code class="ruby language-ruby">pod 'SwifterSwift/AppKit'</code></pre>
 


### PR DESCRIPTION
add missing 'SwifterSwift/UIKit'

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
