### PR TITLE
fix #693 [UITableViewExtensions] : Crash in iOS 13.0 (XCode 11.0) due…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UITableView**:
   - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UITableView. [#441](https://github.com/SwifterSwift/SwifterSwift/pull/441) by [setoelkahfi](https://github.com/setoelkahfi).
   - Added `safeScrollToRow(at:at:animated:)` method to safely scroll UITableView to the given IndexPath. [#445](https://github.com/SwifterSwift/SwifterSwift/pull/445) by [setoelkahfi](https://github.com/setoelkahfi).
+  - Fixed  `lastSection`,  and `indexPathForLastRow`  and  `indexPathForLastRow(inSection: 0)`  methods to get last section, get the lastIndexPath for section 0 if exists and get the lastIndexPath for a given section respectively . 
+        [#694](https://github.com/SwifterSwift/SwifterSwift/pull/694) by [mohshin-shah](https://github.com/mohshin-shah).
 - **Optional**:
   - Added `isNilOrEmpty` property to check whether an optional is nil or empty collection.
 - **UIWindow**:

--- a/Sources/SwifterSwift/UIKit/UITableViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UITableViewExtensions.swift
@@ -14,12 +14,13 @@ public extension UITableView {
 
     /// SwifterSwift: Index path of last row in tableView.
     var indexPathForLastRow: IndexPath? {
+        guard let lastSection = lastSection else { return nil }
         return indexPathForLastRow(inSection: lastSection)
     }
 
     /// SwifterSwift: Index of last section in tableView.
-    var lastSection: Int {
-        return numberOfSections > 0 ? numberOfSections - 1 : 0
+    var lastSection: Int? {
+        return numberOfSections > 0 ? numberOfSections - 1 : nil
     }
 
 }
@@ -45,7 +46,7 @@ public extension UITableView {
     /// - Parameter section: section to get last row in.
     /// - Returns: optional last indexPath for last row in section (if applicable).
     func indexPathForLastRow(inSection section: Int) -> IndexPath? {
-        guard section >= 0 else { return nil }
+        guard numberOfSections > 0, section >= 0 else { return nil }
         guard numberOfRows(inSection: section) > 0  else {
             return IndexPath(row: 0, section: section)
         }

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -26,12 +26,15 @@ final class UITableViewExtensionsTests: XCTestCase {
     }
 
     func testIndexPathForLastRow() {
+        XCTAssertNotNil(tableView.indexPathForLastRow)
         XCTAssertEqual(tableView.indexPathForLastRow, IndexPath(row: 7, section: 1))
+        XCTAssertNil(emptyTableView.indexPathForLastRow)
+        XCTAssertNil(emptyTableView.indexPathForLastRow(inSection: 0))
     }
 
     func testLastSection() {
         XCTAssertEqual(tableView.lastSection, 1)
-        XCTAssertEqual(emptyTableView.lastSection, 0)
+        XCTAssertNil(emptyTableView.lastSection)
     }
 
     func testNumberOfRows() {
@@ -41,6 +44,7 @@ final class UITableViewExtensionsTests: XCTestCase {
 
     func testIndexPathForLastRowInSection() {
         XCTAssertNil(tableView.indexPathForLastRow(inSection: -1))
+        XCTAssertNil(emptyTableView.indexPathForLastRow(inSection: -1))
         XCTAssertEqual(tableView.indexPathForLastRow(inSection: 0), IndexPath(row: 4, section: 0))
         XCTAssertEqual(UITableView().indexPathForLastRow(inSection: 0), IndexPath(row: 0, section: 0))
     }


### PR DESCRIPTION
… to returning wrong last section (0) even for the empty tableView

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
