### PR TITLE
🚀 Added `isValidIndexPath(_:)` UICollectionView method and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `absolute` property to calculate the vector's components as absolute values. [#660](https://github.com/SwifterSwift/SwifterSwift/pull/660) by [vyax](https://github.com/vyax)
   - Added `length` property to calculate the vector's length. [#660](https://github.com/SwifterSwift/SwifterSwift/pull/660) by [vyax](https://github.com/vyax)
 - **UICollectionView**:
-  - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UICollectionView. [#number](https://github.com/SwifterSwift/SwifterSwift/pull/number) by [emilrb](https://github.com/emilrb).
+  - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UICollectionView. [#695](https://github.com/SwifterSwift/SwifterSwift/pull/695) by [emilrb](https://github.com/emilrb).
 
 ### Changed
 - **UIApplication**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **SCNVector3**:
   - Added `absolute` property to calculate the vector's components as absolute values. [#660](https://github.com/SwifterSwift/SwifterSwift/pull/660) by [vyax](https://github.com/vyax)
   - Added `length` property to calculate the vector's length. [#660](https://github.com/SwifterSwift/SwifterSwift/pull/660) by [vyax](https://github.com/vyax)
+- **UICollectionView**:
+  - Added `isValidIndexPath(_:)` method to check whether given IndexPath is valid within UICollectionView. [#number](https://github.com/SwifterSwift/SwifterSwift/pull/number) by [emilrb](https://github.com/emilrb).
 
 ### Changed
 - **UIApplication**:

--- a/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
@@ -146,6 +146,14 @@ public extension UICollectionView {
 
         register(UINib(nibName: identifier, bundle: bundle), forCellWithReuseIdentifier: identifier)
     }
+    
+    /// SwifterSwift: Check whether IndexPath is valid within the CollectionView
+    ///
+    /// - Parameter indexPath: An IndexPath to check
+    /// - Returns: Boolean value for valid or invalid IndexPath
+    func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
+        return indexPath.section < numberOfSections && indexPath.row < numberOfItems(inSection: indexPath.section)
+    }
 
 }
 

--- a/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
@@ -152,11 +152,11 @@ public extension UICollectionView {
     /// - Parameter indexPath: An IndexPath to check
     /// - Returns: Boolean value for valid or invalid IndexPath
     func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section >= 0
-            && indexPath.item >= 0
-            && indexPath.section < numberOfSections
-            && indexPath.item < numberOfItems(inSection: indexPath.section)
-        
+        return indexPath.section >= 0 &&
+            indexPath.item >= 0 &&
+            indexPath.section < numberOfSections &&
+            indexPath.item < numberOfItems(inSection: indexPath.section)
+
     }
 
 }

--- a/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
@@ -156,7 +156,6 @@ public extension UICollectionView {
             indexPath.item >= 0 &&
             indexPath.section < numberOfSections &&
             indexPath.item < numberOfItems(inSection: indexPath.section)
-
     }
 
 }

--- a/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
@@ -146,7 +146,7 @@ public extension UICollectionView {
 
         register(UINib(nibName: identifier, bundle: bundle), forCellWithReuseIdentifier: identifier)
     }
-    
+
     /// SwifterSwift: Check whether IndexPath is valid within the CollectionView
     ///
     /// - Parameter indexPath: An IndexPath to check

--- a/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UICollectionViewExtensions.swift
@@ -152,7 +152,11 @@ public extension UICollectionView {
     /// - Parameter indexPath: An IndexPath to check
     /// - Returns: Boolean value for valid or invalid IndexPath
     func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section < numberOfSections && indexPath.row < numberOfItems(inSection: indexPath.section)
+        return indexPath.section >= 0
+            && indexPath.item >= 0
+            && indexPath.section < numberOfSections
+            && indexPath.item < numberOfItems(inSection: indexPath.section)
+        
     }
 
 }

--- a/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
@@ -75,14 +75,15 @@ final class UICollectionViewExtensionsTests: XCTestCase {
     }
     #endif
 
-    
     func testIsValidIndexPath() {
         let zeroIndexPath = IndexPath(item: 0, section: 0)
         let invalidIndexPath = IndexPath(item: 0, section: 3)
         let validIndexPath = IndexPath(item: 4, section: 0)
+        let negativeIndexPath = IndexPath(item: -1, section: 0)
         
         XCTAssertFalse(emptyCollectionView.isValidIndexPath(zeroIndexPath))
         
+        XCTAssertFalse(collectionView.isValidIndexPath(negativeIndexPath))
         XCTAssertTrue(collectionView.isValidIndexPath(zeroIndexPath))
         XCTAssertTrue(collectionView.isValidIndexPath(validIndexPath))
         XCTAssertFalse(collectionView.isValidIndexPath(invalidIndexPath))

--- a/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
@@ -80,9 +80,9 @@ final class UICollectionViewExtensionsTests: XCTestCase {
         let invalidIndexPath = IndexPath(item: 0, section: 3)
         let validIndexPath = IndexPath(item: 4, section: 0)
         let negativeIndexPath = IndexPath(item: -1, section: 0)
-        
+
         XCTAssertFalse(emptyCollectionView.isValidIndexPath(zeroIndexPath))
-        
+
         XCTAssertFalse(collectionView.isValidIndexPath(negativeIndexPath))
         XCTAssertTrue(collectionView.isValidIndexPath(zeroIndexPath))
         XCTAssertTrue(collectionView.isValidIndexPath(validIndexPath))

--- a/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
@@ -75,6 +75,18 @@ final class UICollectionViewExtensionsTests: XCTestCase {
     }
     #endif
 
+    
+    func testIsValidIndexPath() {
+        let zeroIndexPath = IndexPath(item: 0, section: 0)
+        let invalidIndexPath = IndexPath(item: 0, section: 3)
+        let validIndexPath = IndexPath(item: 4, section: 0)
+        
+        XCTAssertFalse(emptyCollectionView.isValidIndexPath(zeroIndexPath))
+        
+        XCTAssertTrue(collectionView.isValidIndexPath(zeroIndexPath))
+        XCTAssertTrue(collectionView.isValidIndexPath(validIndexPath))
+        XCTAssertFalse(collectionView.isValidIndexPath(invalidIndexPath))
+    }
 }
 
 extension UICollectionViewExtensionsTests: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {


### PR DESCRIPTION
Porting #441 to a UICollectionView equivalent
## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
