### PR TITLE
🚀`isValidIndexPath(_:)` will now return `false` for IndexPaths with a negative row or section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIImage**:
   - The size of rect can equal to the size of UIImage when using `cropped(to:)` to crop UIImage. [#679](https://github.com/SwifterSwift/SwifterSwift/pull/679) by [dirtmelon](https://github.com/dirtmelon).
 - **UITableView**:
-  - `isValidIndexPath(_:)` will now return `false` for IndexPaths with a negative row or section. [#number](https://github.com/SwifterSwift/SwifterSwift/pull/number) by [emilrb](https://github.com/emilrb).
+  - `isValidIndexPath(_:)` will now return `false` for IndexPaths with a negative row or section. [#696](https://github.com/SwifterSwift/SwifterSwift/pull/696) by [emilrb](https://github.com/emilrb).
   
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Resolved an issue where `version` and `displayName` would return nil if localized.
 - **UIImage**:
   - The size of rect can equal to the size of UIImage when using `cropped(to:)` to crop UIImage. [#679](https://github.com/SwifterSwift/SwifterSwift/pull/679) by [dirtmelon](https://github.com/dirtmelon).
+- **UITableView**:
+  - `isValidIndexPath(_:)` will now return `false` for IndexPaths with a negative row or section. [#number](https://github.com/SwifterSwift/SwifterSwift/pull/number) by [emilrb](https://github.com/emilrb).
   
 ### Security
 

--- a/Sources/SwifterSwift/UIKit/UITableViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UITableViewExtensions.swift
@@ -178,7 +178,10 @@ public extension UITableView {
     /// - Parameter indexPath: An IndexPath to check
     /// - Returns: Boolean value for valid or invalid IndexPath
     func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section < numberOfSections && indexPath.row < numberOfRows(inSection: indexPath.section)
+        return indexPath.section >= 0
+            && indexPath.row >= 0
+            && indexPath.section < numberOfSections
+            && indexPath.row < numberOfRows(inSection: indexPath.section)
     }
 
     /// SwifterSwift: Safely scroll to possibly invalid IndexPath

--- a/Sources/SwifterSwift/UIKit/UITableViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UITableViewExtensions.swift
@@ -178,10 +178,10 @@ public extension UITableView {
     /// - Parameter indexPath: An IndexPath to check
     /// - Returns: Boolean value for valid or invalid IndexPath
     func isValidIndexPath(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section >= 0
-            && indexPath.row >= 0
-            && indexPath.section < numberOfSections
-            && indexPath.row < numberOfRows(inSection: indexPath.section)
+        return indexPath.section >= 0 &&
+            indexPath.row >= 0 &&
+            indexPath.section < numberOfSections &&
+            indexPath.row < numberOfRows(inSection: indexPath.section)
     }
 
     /// SwifterSwift: Safely scroll to possibly invalid IndexPath

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -106,8 +106,12 @@ final class UITableViewExtensionsTests: XCTestCase {
     func testIsValidIndexPath() {
         let validIndexPath = IndexPath(row: 0, section: 0)
         XCTAssertTrue(tableView.isValidIndexPath(validIndexPath))
+
         let invalidIndexPath = IndexPath(row: 10, section: 0)
         XCTAssertFalse(tableView.isValidIndexPath(invalidIndexPath))
+
+        let negativeIndexPath = IndexPath(row: -1, section: 0)
+        XCTAssertFalse(tableView.isValidIndexPath(negativeIndexPath))
     }
 
     func testSafeScrollToIndexPath() {


### PR DESCRIPTION
On #695, @LucianoPAlmeida raised a point about `isValidIndexPath(_:)` checking for IndexPaths with negative rows/sections on CollectionViews. This PR updates the TableView's behavior to keep them consistent.
## Checklist

- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 5.0.
- [X] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
