### PR TITLE
Array.withoutDuplicates(keyPath:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Array**:
-    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. [#703](https://github.com/SwifterSwift/SwifterSwift/pull/703) by [RomanPodymov](https://github.com/RomanPodymov)
+    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**
@@ -44,6 +44,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(from:to:)`, `init(points:)`, `init(polygonWithPoints:)`, `init(ovalOf:centered:)` and `init(rectOf:centered:)` convenience initializers. [#659](https://github.com/SwifterSwift/SwifterSwift/pull/659) by [vyax](https://github.com/vyax)
 
 ### Changed
+- **Array**:
+  - - `removeDuplicates` and `withoutDuplicates` are implemented based on `removeDuplicates(by:)` and `withoutDuplicates(by:)`. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **UIApplication**:
   - - `queryValue(for:)` extension for URL is refactored. [#668](https://github.com/SwifterSwift/SwifterSwift/pull/668) by [LucianoPAlmeida](https://github.com/ratulSharker).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Array**:
-    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
+    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. Different implementations for `Element: Equatable` and `Element: Hashable`. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
-- **Array**:
-    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
-    - Added `removeDuplicates()`, `withoutDuplicates()` where `Element: Hashable` for remove duplicate elements. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**
@@ -46,8 +43,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(from:to:)`, `init(points:)`, `init(polygonWithPoints:)`, `init(ovalOf:centered:)` and `init(rectOf:centered:)` convenience initializers. [#659](https://github.com/SwifterSwift/SwifterSwift/pull/659) by [vyax](https://github.com/vyax)
 
 ### Changed
-- **Array**:
-  - - `removeDuplicates` and `withoutDuplicates` where `Element: Equatable` are implemented based on `removeDuplicates(by:)` and `withoutDuplicates(by:)`. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **UIApplication**:
   - - `queryValue(for:)` extension for URL is refactored. [#668](https://github.com/SwifterSwift/SwifterSwift/pull/668) by [LucianoPAlmeida](https://github.com/ratulSharker).
 - **Sequence**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Array**:
-    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. Different implementations for `Element: Equatable` and `Element: Hashable`. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
+    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
+    - Added `removeDuplicates()`, `withoutDuplicates()` where `Element: Hashable` for remove duplicate elements. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**
@@ -45,7 +46,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Changed
 - **Array**:
-  - - `removeDuplicates` and `withoutDuplicates` are implemented based on `removeDuplicates(by:)` and `withoutDuplicates(by:)`. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
+  - - `removeDuplicates` and `withoutDuplicates` where `Element: Equatable` are implemented based on `removeDuplicates(by:)` and `withoutDuplicates(by:)`. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **UIApplication**:
   - - `queryValue(for:)` extension for URL is refactored. [#668](https://github.com/SwifterSwift/SwifterSwift/pull/668) by [LucianoPAlmeida](https://github.com/ratulSharker).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Array**:
+    - Added `removeDuplicates(by:)`, `removeDuplicates(keyPath:)`, `withoutDuplicates(by:)`, `withoutDuplicates(keyPath:)` for remove duplicate elements based on comparator or key path. [#703](https://github.com/SwifterSwift/SwifterSwift/pull/703) by [RomanPodymov](https://github.com/RomanPodymov)
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Array**:
-    - Added `withoutDuplicates(keyPath:)` for remove duplicate elements based on key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
+    - Added `withoutDuplicates(keyPath:)` for filtering duplicate elements based on key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Array**:
+    - Added `withoutDuplicates(keyPath:)` for remove duplicate elements based on key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
 - **String**

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -1,105 +1,158 @@
 //
-//  ArrayExtensionsTests.swift
+//  ArrayExtensions.swift
 //  SwifterSwift
 //
-//  Created by Omar Albeik on 8/26/16.
+//  Created by Omar Albeik on 8/5/16.
 //  Copyright © 2016 SwifterSwift
 //
-import XCTest
-@testable import SwifterSwift
 
-private struct Person: Equatable, Hashable {
-    var name: String
-    var age: Int?
+// MARK: - Methods
+public extension Array {
+
+    /// SwifterSwift: Insert an element at the beginning of array.
+    ///
+    ///        [2, 3, 4, 5].prepend(1) -> [1, 2, 3, 4, 5]
+    ///        ["e", "l", "l", "o"].prepend("h") -> ["h", "e", "l", "l", "o"]
+    ///
+    /// - Parameter newElement: element to insert.
+    mutating func prepend(_ newElement: Element) {
+        insert(newElement, at: 0)
+    }
+
+    /// SwifterSwift: Safely swap values at given index positions.
+    ///
+    ///        [1, 2, 3, 4, 5].safeSwap(from: 3, to: 0) -> [4, 2, 3, 1, 5]
+    ///        ["h", "e", "l", "l", "o"].safeSwap(from: 1, to: 0) -> ["e", "h", "l", "l", "o"]
+    ///
+    /// - Parameters:
+    ///   - index: index of first element.
+    ///   - otherIndex: index of other element.
+    mutating func safeSwap(from index: Index, to otherIndex: Index) {
+        guard index != otherIndex else { return }
+        guard startIndex..<endIndex ~= index else { return }
+        guard startIndex..<endIndex ~= otherIndex else { return }
+        swapAt(index, otherIndex)
+    }
+
+    /// SwifterSwift: Returns a sorted array based on an optional keypath.
+    ///
+    /// - Parameter path: Key path to sort. The key path type must be Comparable.
+    /// - Parameter ascending: If order must be ascending.
+    /// - Returns: Sorted array based on keyPath.
+    func sorted<T: Comparable>(by path: KeyPath<Element, T?>, ascending: Bool = true) -> [Element] {
+        return sorted(by: { (lhs, rhs) -> Bool in
+            guard let lhsValue = lhs[keyPath: path], let rhsValue = rhs[keyPath: path] else { return false }
+            return ascending ? (lhsValue < rhsValue) : (lhsValue > rhsValue)
+        })
+    }
+
+    /// SwifterSwift: Returns a sorted array based on a keypath.
+    ///
+    /// - Parameter path: Key path to sort. The key path type must be Comparable.
+    /// - Parameter ascending: If order must be ascending.
+    /// - Returns: Sorted array based on keyPath.
+    func sorted<T: Comparable>(by path: KeyPath<Element, T>, ascending: Bool = true) -> [Element] {
+        return sorted(by: { (lhs, rhs) -> Bool in
+            return ascending ? (lhs[keyPath: path] < rhs[keyPath: path]) : (lhs[keyPath: path] > rhs[keyPath: path])
+        })
+    }
+
+    /// SwifterSwift: Sort the array based on an optional keypath.
+    ///
+    /// - Parameters:
+    ///   - path: Key path to sort, must be Comparable.
+    ///   - ascending: whether order is ascending or not.
+    /// - Returns: self after sorting.
+    @discardableResult
+    mutating func sort<T: Comparable>(by path: KeyPath<Element, T?>, ascending: Bool = true) -> [Element] {
+        self = sorted(by: path, ascending: ascending)
+        return self
+    }
+
+    /// SwifterSwift: Sort the array based on a keypath.
+    ///
+    /// - Parameters:
+    ///   - path: Key path to sort, must be Comparable.
+    ///   - ascending: whether order is ascending or not.
+    /// - Returns: self after sorting.
+    @discardableResult
+    mutating func sort<T: Comparable>(by path: KeyPath<Element, T>, ascending: Bool = true) -> [Element] {
+        self = sorted(by: path, ascending: ascending)
+        return self
+    }
+
 }
 
-final class ArrayExtensionsTests: XCTestCase {
+// MARK: - Methods (Equatable)
+public extension Array where Element: Equatable {
 
-    func testPrepend() {
-        var arr = [2, 3, 4, 5]
-        arr.prepend(1)
-        XCTAssertEqual(arr, [1, 2, 3, 4, 5])
+    /// SwifterSwift: Remove all instances of an item from array.
+    ///
+    ///        [1, 2, 2, 3, 4, 5].removeAll(2) -> [1, 3, 4, 5]
+    ///        ["h", "e", "l", "l", "o"].removeAll("l") -> ["h", "e", "o"]
+    ///
+    /// - Parameter item: item to remove.
+    /// - Returns: self after removing all instances of item.
+    @discardableResult
+    mutating func removeAll(_ item: Element) -> [Element] {
+        removeAll(where: { $0 == item })
+        return self
     }
 
-    func testSafeSwap() {
-        var array: [Int] = [1, 2, 3, 4, 5]
-        array.safeSwap(from: 3, to: 0)
-        XCTAssertEqual(array[3], 1)
-        XCTAssertEqual(array[0], 4)
-
-        var newArray = array
-        newArray.safeSwap(from: 1, to: 1)
-        XCTAssertEqual(newArray, array)
-
-        newArray = array
-        newArray.safeSwap(from: 1, to: 12)
-        XCTAssertEqual(newArray, array)
-
-        let emptyArray: [Int] = []
-        var swappedEmptyArray = emptyArray
-        swappedEmptyArray.safeSwap(from: 1, to: 3)
-        XCTAssertEqual(swappedEmptyArray, emptyArray)
+    /// SwifterSwift: Remove all instances contained in items parameter from array.
+    ///
+    ///        [1, 2, 2, 3, 4, 5].removeAll([2,5]) -> [1, 3, 4]
+    ///        ["h", "e", "l", "l", "o"].removeAll(["l", "h"]) -> ["e", "o"]
+    ///
+    /// - Parameter items: items to remove.
+    /// - Returns: self after removing all instances of all items in given array.
+    @discardableResult
+    mutating func removeAll(_ items: [Element]) -> [Element] {
+        guard !items.isEmpty else { return self }
+        removeAll(where: { items.contains($0) })
+        return self
     }
 
-    func testKeyPathSorted() {
-        let array = [Person(name: "James", age: 32), Person(name: "Wade", age: 36), Person(name: "Rose", age: 29)]
-
-        XCTAssertEqual(array.sorted(by: \Person.name), [Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "Wade", age: 36)])
-        XCTAssertEqual(array.sorted(by: \Person.name, ascending: false), [Person(name: "Wade", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 32)])
-        // Testing Optional keyPath
-        XCTAssertEqual(array.sorted(by: \Person.age), [Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Wade", age: 36)])
-        XCTAssertEqual(array.sorted(by: \Person.age, ascending: false), [Person(name: "Wade", age: 36), Person(name: "James", age: 32), Person(name: "Rose", age: 29)])
-
-        // Testing Mutating
-        var mutableArray = [Person(name: "James", age: 32), Person(name: "Wade", age: 36), Person(name: "Rose", age: 29)]
-
-        mutableArray.sort(by: \Person.name)
-        XCTAssertEqual(mutableArray, [Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "Wade", age: 36)])
-
-        // Testing Mutating Optional keyPath
-        mutableArray.sort(by: \Person.age)
-        XCTAssertEqual(mutableArray, [Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Wade", age: 36)])
-
-        // Testing nil path
-        let nilArray = [Person(name: "James", age: nil), Person(name: "Wade", age: nil)]
-        XCTAssertEqual(nilArray.sorted(by: \Person.age), [Person(name: "James", age: nil), Person(name: "Wade", age: nil)])
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    ///
+    ///        [1, 2, 2, 3, 4, 5].removeDuplicates() -> [1, 2, 3, 4, 5]
+    ///        ["h", "e", "l", "l", "o"]. removeDuplicates() -> ["h", "e", "l", "o"]
+    ///
+    /// - Returns: Return array with all duplicate elements removed.
+    @discardableResult
+    mutating func removeDuplicates() -> [Element] {
+        // Thanks to https://github.com/sairamkotha for improving the method
+        self = reduce(into: [Element]()) {
+            if !$0.contains($1) {
+                $0.append($1)
+            }
+        }
+        return self
     }
 
-    func testRemoveAll() {
-        var arr = [0, 1, 2, 0, 3, 4, 5, 0, 0]
-        arr.removeAll(0)
-        XCTAssertEqual(arr, [1, 2, 3, 4, 5])
-        arr = []
-        arr.removeAll(0)
-        XCTAssertEqual(arr, [])
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    ///
+    ///     [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates() -> [1, 2, 3, 4, 5])
+    ///     ["h", "e", "l", "l", "o"].withoutDuplicates() -> ["h", "e", "l", "o"])
+    ///
+    /// - Returns: an array of unique elements.
+    ///
+    func withoutDuplicates() -> [Element] {
+        // Thanks to https://github.com/sairamkotha for improving the method
+        return reduce(into: [Element]()) {
+            if !$0.contains($1) {
+                $0.append($1)
+            }
+        }
     }
 
-    func testRemoveAllItems() {
-        var arr = [0, 1, 2, 2, 0, 3, 4, 5, 0, 0]
-        arr.removeAll([0, 2])
-        XCTAssertEqual(arr, [1, 3, 4, 5])
-        arr.removeAll([])
-        XCTAssertEqual(arr, [1, 3, 4, 5])
-        arr = []
-        arr.removeAll([])
-        XCTAssertEqual(arr, [])
-    }
-
-    func testRemoveDuplicates() {
-        var array = [1, 1, 2, 2, 3, 3, 3, 4, 5]
-        array.removeDuplicates()
-        XCTAssertEqual(array, [1, 2, 3, 4, 5])
-    }
-
-    func testWithoutDuplicates() {
-        XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates(), [1, 2, 3, 4, 5])
-        XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
-    }
-
-    func testWithoutDuplicatesUsingKeyPath() {
-        let array = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22)]
-        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
-        let arrayWithoutDuplicatesPrepared = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared)
+    /// SwifterSwift: Returns a set with all duplicate elements removed using KeyPath to compare.
+    ///
+    /// - Parameter path: Key path to compare, the value must be Hashable.
+    /// - Returns: a set of unique elements.
+    func withoutDuplicates<E: Hashable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        var set: Set<E> = []
+        // since set don't allow duplications it never adds two equal key path values, and filter by that and maintaining the check O(1)
+        return filter { set.insert($0[keyPath: path]).inserted }
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -151,7 +151,7 @@ public extension Array where Element: Equatable {
     /// - Parameter path: Key path to compare, the value must be Hashable.
     /// - Returns: a set of unique elements.
     func withoutDuplicates<E: Hashable>(keyPath path: KeyPath<Element, E>) -> [Element] {
-        var set: Set<E> = []
+        var set = Set<E>()
         // since set don't allow duplications it never adds two equal key path values, and filter by that and maintaining the check O(1)
         return filter { set.insert($0[keyPath: path]).inserted }
     }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -164,7 +164,7 @@ public extension Array where Element: Hashable {
     ///
     /// - Parameter path: Key path to compare, must be Equatable.
     /// - Returns: a set of unique elements.
-    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> Set<Element> {
+    func withoutDuplicatesUnordered<E: Equatable>(keyPath path: KeyPath<Element, E>) -> Set<Element> {
         return reduce(into: Set<Element>()) { (result, element) in
             if !result.contains { $0[keyPath: path] == element[keyPath: path] } {
                 result.insert(element)

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -99,7 +99,7 @@ public extension Array {
 
     /// SwifterSwift: Remove all duplicate elements from Array.
     ///
-    ///        [4, 2, -2, 3, -4, 5].removeDuplicates { abs($0) == abs($1) } -> [1, 2, 3, 4, 5]
+    ///        [1, -1, 2, -4, 3, 3, 3, 4, -5].removeDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
     ///
     /// - Parameters:
     ///   - comparator: Returns true if 2 elements of array are equal.
@@ -123,7 +123,7 @@ public extension Array {
 
     /// SwifterSwift: Return array with all duplicate elements removed.
     ///
-    ///     [4, 2, -2, 3, -4, 5].withoutDuplicates { abs($0) == abs($1) } -> [1, 2, 3, 4, 5]
+    ///     [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
     ///
     /// - Parameters:
     ///   - comparator: Returns true if 2 elements of array are equal.

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -202,3 +202,79 @@ public extension Array where Element: Equatable {
     }
 
 }
+
+// MARK: - Methods (Hashable)
+public extension Array where Element: Hashable {
+
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    ///
+    ///        [1, -1, 2, -4, 3, 3, 3, 4, -5].removeDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
+    ///
+    /// - Parameters:
+    ///   - comparator: Returns true if 2 elements of array are equal.
+    /// - Returns: Return array with all duplicate elements removed.
+    @discardableResult
+    mutating func removeDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
+        self = withoutDuplicates(by: comparator)
+        return self
+    }
+
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    ///
+    /// - Parameters:
+    ///   - path: Key path to compare, must be Equatable
+    /// - Returns: Return array with all duplicate elements removed.
+    @discardableResult
+    mutating func removeDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        self = withoutDuplicates(keyPath: path)
+        return self
+    }
+
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    ///
+    ///        [1, 2, 2, 3, 4, 5].removeDuplicates() -> [1, 2, 3, 4, 5]
+    ///        ["h", "e", "l", "l", "o"]. removeDuplicates() -> ["h", "e", "l", "o"]
+    ///
+    /// - Returns: Return array with all duplicate elements removed.
+    @discardableResult
+    mutating func removeDuplicates() -> [Element] {
+        return removeDuplicates(by: ==)
+    }
+
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    ///
+    ///     [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
+    ///
+    /// - Parameters:
+    ///   - comparator: Returns true if 2 elements of array are equal.
+    /// - Returns: an array of unique elements.
+    ///
+    func withoutDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
+        return Array(reduce(into: Set<Element>()) { result, element in
+            if !result.contains { comparator($0, element) } {
+                result.insert(element)
+            }
+        })
+    }
+
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    ///
+    /// - Parameters:
+    ///   - path: Key path to compare, must be Equatable
+    /// - Returns: an array of unique elements.
+    ///
+    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        return withoutDuplicates { $0[keyPath: path] == $1[keyPath: path] }
+    }
+
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    ///
+    ///     [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates() -> [1, 2, 3, 4, 5])
+    ///     ["h", "e", "l", "l", "o"].withoutDuplicates() -> ["h", "e", "l", "o"])
+    ///
+    /// - Returns: an array of unique elements.
+    ///
+    func withoutDuplicates() -> [Element] {
+        return withoutDuplicates(by: ==)
+    }
+}

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -146,7 +146,7 @@ public extension Array where Element: Equatable {
         }
     }
 
-    /// SwifterSwift: Returns a set with all duplicate elements removed using KeyPath to compare.
+    /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.
     /// - Returns: an array of unique elements.

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -152,7 +152,7 @@ public extension Array where Element: Hashable {
     /// SwifterSwift: Returns a set with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, must be Equatable.
-    /// - Returns: an array of unique elements.
+    /// - Returns: a set of unique elements.
     func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> Set<Element> {
         return reduce(into: Set<Element>()) { (result, element) in
             if !result.contains { $0[keyPath: path] == element[keyPath: path] } {

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -157,7 +157,7 @@ public extension Array where Element: Equatable {
             }
         }
     }
-    
+
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -1,174 +1,105 @@
 //
-//  ArrayExtensions.swift
+//  ArrayExtensionsTests.swift
 //  SwifterSwift
 //
-//  Created by Omar Albeik on 8/5/16.
+//  Created by Omar Albeik on 8/26/16.
 //  Copyright © 2016 SwifterSwift
 //
+import XCTest
+@testable import SwifterSwift
 
-// MARK: - Methods
-public extension Array {
-
-    /// SwifterSwift: Insert an element at the beginning of array.
-    ///
-    ///        [2, 3, 4, 5].prepend(1) -> [1, 2, 3, 4, 5]
-    ///        ["e", "l", "l", "o"].prepend("h") -> ["h", "e", "l", "l", "o"]
-    ///
-    /// - Parameter newElement: element to insert.
-    mutating func prepend(_ newElement: Element) {
-        insert(newElement, at: 0)
-    }
-
-    /// SwifterSwift: Safely swap values at given index positions.
-    ///
-    ///        [1, 2, 3, 4, 5].safeSwap(from: 3, to: 0) -> [4, 2, 3, 1, 5]
-    ///        ["h", "e", "l", "l", "o"].safeSwap(from: 1, to: 0) -> ["e", "h", "l", "l", "o"]
-    ///
-    /// - Parameters:
-    ///   - index: index of first element.
-    ///   - otherIndex: index of other element.
-    mutating func safeSwap(from index: Index, to otherIndex: Index) {
-        guard index != otherIndex else { return }
-        guard startIndex..<endIndex ~= index else { return }
-        guard startIndex..<endIndex ~= otherIndex else { return }
-        swapAt(index, otherIndex)
-    }
-
-    /// SwifterSwift: Returns a sorted array based on an optional keypath.
-    ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
-    /// - Parameter ascending: If order must be ascending.
-    /// - Returns: Sorted array based on keyPath.
-    func sorted<T: Comparable>(by path: KeyPath<Element, T?>, ascending: Bool = true) -> [Element] {
-        return sorted(by: { (lhs, rhs) -> Bool in
-            guard let lhsValue = lhs[keyPath: path], let rhsValue = rhs[keyPath: path] else { return false }
-            return ascending ? (lhsValue < rhsValue) : (lhsValue > rhsValue)
-        })
-    }
-
-    /// SwifterSwift: Returns a sorted array based on a keypath.
-    ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
-    /// - Parameter ascending: If order must be ascending.
-    /// - Returns: Sorted array based on keyPath.
-    func sorted<T: Comparable>(by path: KeyPath<Element, T>, ascending: Bool = true) -> [Element] {
-        return sorted(by: { (lhs, rhs) -> Bool in
-            return ascending ? (lhs[keyPath: path] < rhs[keyPath: path]) : (lhs[keyPath: path] > rhs[keyPath: path])
-        })
-    }
-
-    /// SwifterSwift: Sort the array based on an optional keypath.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to sort, must be Comparable.
-    ///   - ascending: whether order is ascending or not.
-    /// - Returns: self after sorting.
-    @discardableResult
-    mutating func sort<T: Comparable>(by path: KeyPath<Element, T?>, ascending: Bool = true) -> [Element] {
-        self = sorted(by: path, ascending: ascending)
-        return self
-    }
-
-    /// SwifterSwift: Sort the array based on a keypath.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to sort, must be Comparable.
-    ///   - ascending: whether order is ascending or not.
-    /// - Returns: self after sorting.
-    @discardableResult
-    mutating func sort<T: Comparable>(by path: KeyPath<Element, T>, ascending: Bool = true) -> [Element] {
-        self = sorted(by: path, ascending: ascending)
-        return self
-    }
-
+private struct Person: Equatable, Hashable {
+    var name: String
+    var age: Int?
 }
 
-// MARK: - Methods (Equatable)
-public extension Array where Element: Equatable {
+final class ArrayExtensionsTests: XCTestCase {
 
-    /// SwifterSwift: Remove all instances of an item from array.
-    ///
-    ///        [1, 2, 2, 3, 4, 5].removeAll(2) -> [1, 3, 4, 5]
-    ///        ["h", "e", "l", "l", "o"].removeAll("l") -> ["h", "e", "o"]
-    ///
-    /// - Parameter item: item to remove.
-    /// - Returns: self after removing all instances of item.
-    @discardableResult
-    mutating func removeAll(_ item: Element) -> [Element] {
-        removeAll(where: { $0 == item })
-        return self
+    func testPrepend() {
+        var arr = [2, 3, 4, 5]
+        arr.prepend(1)
+        XCTAssertEqual(arr, [1, 2, 3, 4, 5])
     }
 
-    /// SwifterSwift: Remove all instances contained in items parameter from array.
-    ///
-    ///        [1, 2, 2, 3, 4, 5].removeAll([2,5]) -> [1, 3, 4]
-    ///        ["h", "e", "l", "l", "o"].removeAll(["l", "h"]) -> ["e", "o"]
-    ///
-    /// - Parameter items: items to remove.
-    /// - Returns: self after removing all instances of all items in given array.
-    @discardableResult
-    mutating func removeAll(_ items: [Element]) -> [Element] {
-        guard !items.isEmpty else { return self }
-        removeAll(where: { items.contains($0) })
-        return self
+    func testSafeSwap() {
+        var array: [Int] = [1, 2, 3, 4, 5]
+        array.safeSwap(from: 3, to: 0)
+        XCTAssertEqual(array[3], 1)
+        XCTAssertEqual(array[0], 4)
+
+        var newArray = array
+        newArray.safeSwap(from: 1, to: 1)
+        XCTAssertEqual(newArray, array)
+
+        newArray = array
+        newArray.safeSwap(from: 1, to: 12)
+        XCTAssertEqual(newArray, array)
+
+        let emptyArray: [Int] = []
+        var swappedEmptyArray = emptyArray
+        swappedEmptyArray.safeSwap(from: 1, to: 3)
+        XCTAssertEqual(swappedEmptyArray, emptyArray)
     }
 
-    /// SwifterSwift: Remove all duplicate elements from Array.
-    ///
-    ///        [1, 2, 2, 3, 4, 5].removeDuplicates() -> [1, 2, 3, 4, 5]
-    ///        ["h", "e", "l", "l", "o"]. removeDuplicates() -> ["h", "e", "l", "o"]
-    ///
-    /// - Returns: Return array with all duplicate elements removed.
-    @discardableResult
-    mutating func removeDuplicates() -> [Element] {
-        // Thanks to https://github.com/sairamkotha for improving the method
-        self = reduce(into: [Element]()) {
-            if !$0.contains($1) {
-                $0.append($1)
-            }
-        }
-        return self
+    func testKeyPathSorted() {
+        let array = [Person(name: "James", age: 32), Person(name: "Wade", age: 36), Person(name: "Rose", age: 29)]
+
+        XCTAssertEqual(array.sorted(by: \Person.name), [Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "Wade", age: 36)])
+        XCTAssertEqual(array.sorted(by: \Person.name, ascending: false), [Person(name: "Wade", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 32)])
+        // Testing Optional keyPath
+        XCTAssertEqual(array.sorted(by: \Person.age), [Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Wade", age: 36)])
+        XCTAssertEqual(array.sorted(by: \Person.age, ascending: false), [Person(name: "Wade", age: 36), Person(name: "James", age: 32), Person(name: "Rose", age: 29)])
+
+        // Testing Mutating
+        var mutableArray = [Person(name: "James", age: 32), Person(name: "Wade", age: 36), Person(name: "Rose", age: 29)]
+
+        mutableArray.sort(by: \Person.name)
+        XCTAssertEqual(mutableArray, [Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "Wade", age: 36)])
+
+        // Testing Mutating Optional keyPath
+        mutableArray.sort(by: \Person.age)
+        XCTAssertEqual(mutableArray, [Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Wade", age: 36)])
+
+        // Testing nil path
+        let nilArray = [Person(name: "James", age: nil), Person(name: "Wade", age: nil)]
+        XCTAssertEqual(nilArray.sorted(by: \Person.age), [Person(name: "James", age: nil), Person(name: "Wade", age: nil)])
     }
 
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    ///     [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates() -> [1, 2, 3, 4, 5])
-    ///     ["h", "e", "l", "l", "o"].withoutDuplicates() -> ["h", "e", "l", "o"])
-    ///
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates() -> [Element] {
-        // Thanks to https://github.com/sairamkotha for improving the method
-        return reduce(into: [Element]()) {
-            if !$0.contains($1) {
-                $0.append($1)
-            }
-        }
+    func testRemoveAll() {
+        var arr = [0, 1, 2, 0, 3, 4, 5, 0, 0]
+        arr.removeAll(0)
+        XCTAssertEqual(arr, [1, 2, 3, 4, 5])
+        arr = []
+        arr.removeAll(0)
+        XCTAssertEqual(arr, [])
     }
 
-    /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
-    ///
-    /// - Parameter path: Key path to compare, must be Equatable.
-    /// - Returns: an array of unique elements.
-    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
-        return reduce(into: [Element]()) { (result, element) in
-            if !result.contains { $0[keyPath: path] == element[keyPath: path] } {
-                result.append(element)
-            }
-        }
+    func testRemoveAllItems() {
+        var arr = [0, 1, 2, 2, 0, 3, 4, 5, 0, 0]
+        arr.removeAll([0, 2])
+        XCTAssertEqual(arr, [1, 3, 4, 5])
+        arr.removeAll([])
+        XCTAssertEqual(arr, [1, 3, 4, 5])
+        arr = []
+        arr.removeAll([])
+        XCTAssertEqual(arr, [])
     }
-}
 
-public extension Array where Element: Hashable {
-    /// SwifterSwift: Returns a set with all duplicate elements removed using KeyPath to compare.
-    ///
-    /// - Parameter path: Key path to compare, must be Equatable.
-    /// - Returns: a set of unique elements.
-    func withoutDuplicatesUnordered<E: Equatable>(keyPath path: KeyPath<Element, E>) -> Set<Element> {
-        return reduce(into: Set<Element>()) { (result, element) in
-            if !result.contains { $0[keyPath: path] == element[keyPath: path] } {
-                result.insert(element)
-            }
-        }
+    func testRemoveDuplicates() {
+        var array = [1, 1, 2, 2, 3, 3, 3, 4, 5]
+        array.removeDuplicates()
+        XCTAssertEqual(array, [1, 2, 3, 4, 5])
+    }
+
+    func testWithoutDuplicates() {
+        XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates(), [1, 2, 3, 4, 5])
+        XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
+    }
+
+    func testWithoutDuplicatesUsingKeyPath() {
+        let array = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22)]
+        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicatesPrepared = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared)
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -152,7 +152,6 @@ public extension Array where Element: Equatable {
     /// - Returns: a set of unique elements.
     func withoutDuplicates<E: Hashable>(keyPath path: KeyPath<Element, E>) -> [Element] {
         var set = Set<E>()
-        // since set don't allow duplications it never adds two equal key path values, and filter by that and maintaining the check O(1)
         return filter { set.insert($0[keyPath: path]).inserted }
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -148,6 +148,18 @@ public extension Array where Element: Equatable {
 
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
+    /// - Parameter path: Key path to compare, the value must be Equatable.
+    /// - Returns: an array of unique elements.
+    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        return reduce(into: [Element]()) { (result, element) in
+            if !result.contains { $0[keyPath: path] == element[keyPath: path] } {
+                result.append(element)
+            }
+        }
+    }
+    
+    /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
+    ///
     /// - Parameter path: Key path to compare, the value must be Hashable.
     /// - Returns: an array of unique elements.
     func withoutDuplicates<E: Hashable>(keyPath path: KeyPath<Element, E>) -> [Element] {

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -81,56 +81,6 @@ public extension Array {
         return self
     }
 
-    /// SwifterSwift: Remove all duplicate elements from Array.
-    ///
-    ///        [1, -1, 2, -4, 3, 3, 3, 4, -5].removeDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
-    ///
-    /// - Parameters:
-    ///   - comparator: Returns true if 2 elements of array are equal.
-    /// - Returns: Return array with all duplicate elements removed.
-    @discardableResult
-    mutating func removeDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
-        self = withoutDuplicates(by: comparator)
-        return self
-    }
-
-    /// SwifterSwift: Remove all duplicate elements from Array.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to compare, must be Equatable
-    /// - Returns: Return array with all duplicate elements removed.
-    @discardableResult
-    mutating func removeDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
-        self = withoutDuplicates(keyPath: path)
-        return self
-    }
-
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    ///     [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
-    ///
-    /// - Parameters:
-    ///   - comparator: Returns true if 2 elements of array are equal.
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
-        // Thanks to https://github.com/sairamkotha for improving the method
-        return reduce(into: [Element]()) { result, element in
-            if !result.contains { comparator($0, element) } {
-                result.append(element)
-            }
-        }
-    }
-
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to compare, must be Equatable
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
-        return withoutDuplicates { $0[keyPath: path] == $1[keyPath: path] }
-    }
 }
 
 // MARK: - Methods (Equatable)
@@ -171,7 +121,13 @@ public extension Array where Element: Equatable {
     /// - Returns: Return array with all duplicate elements removed.
     @discardableResult
     mutating func removeDuplicates() -> [Element] {
-        return removeDuplicates(by: ==)
+        // Thanks to https://github.com/sairamkotha for improving the method
+        self = reduce(into: [Element]()) {
+            if !$0.contains($1) {
+                $0.append($1)
+            }
+        }
+        return self
     }
 
     /// SwifterSwift: Return array with all duplicate elements removed.
@@ -182,7 +138,12 @@ public extension Array where Element: Equatable {
     /// - Returns: an array of unique elements.
     ///
     func withoutDuplicates() -> [Element] {
-        return withoutDuplicates(by: ==)
+        // Thanks to https://github.com/sairamkotha for improving the method
+        return reduce(into: [Element]()) {
+            if !$0.contains($1) {
+                $0.append($1)
+            }
+        }
     }
 
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -97,6 +97,56 @@ public extension Array {
         return self
     }
 
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    ///
+    ///        [4, 2, -2, 3, -4, 5].removeDuplicates { abs($0) == abs($1) } -> [1, 2, 3, 4, 5]
+    ///
+    /// - Parameters:
+    ///   - comparator: Returns true if 2 elements of array are equal.
+    /// - Returns: Return array with all duplicate elements removed.
+    @discardableResult
+    mutating func removeDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
+        self = withoutDuplicates(by: comparator)
+        return self
+    }
+
+    /// SwifterSwift: Remove all duplicate elements from Array.
+    ///
+    /// - Parameters:
+    ///   - path: Key path to compare, must be Equatable
+    /// - Returns: Return array with all duplicate elements removed.
+    @discardableResult
+    mutating func removeDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        self = withoutDuplicates(keyPath: path)
+        return self
+    }
+
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    ///
+    ///     [4, 2, -2, 3, -4, 5].withoutDuplicates { abs($0) == abs($1) } -> [1, 2, 3, 4, 5]
+    ///
+    /// - Parameters:
+    ///   - comparator: Returns true if 2 elements of array are equal.
+    /// - Returns: an array of unique elements.
+    ///
+    func withoutDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
+        // Thanks to https://github.com/sairamkotha for improving the method
+        return reduce(into: [Element]()) { result, element in
+            if !result.contains { comparator($0, element) } {
+                result.append(element)
+            }
+        }
+    }
+
+    /// SwifterSwift: Return array with all duplicate elements removed.
+    ///
+    /// - Parameters:
+    ///   - path: Key path to compare, must be Equatable
+    /// - Returns: an array of unique elements.
+    ///
+    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        return withoutDuplicates { $0[keyPath: path] == $1[keyPath: path] }
+    }
 }
 
 // MARK: - Methods (Equatable)
@@ -137,13 +187,7 @@ public extension Array where Element: Equatable {
     /// - Returns: Return array with all duplicate elements removed.
     @discardableResult
     mutating func removeDuplicates() -> [Element] {
-        // Thanks to https://github.com/sairamkotha for improving the method
-        self = reduce(into: [Element]()) {
-            if !$0.contains($1) {
-                $0.append($1)
-            }
-        }
-        return self
+        return removeDuplicates(by: ==)
     }
 
     /// SwifterSwift: Return array with all duplicate elements removed.
@@ -154,12 +198,7 @@ public extension Array where Element: Equatable {
     /// - Returns: an array of unique elements.
     ///
     func withoutDuplicates() -> [Element] {
-        // Thanks to https://github.com/sairamkotha for improving the method
-        return reduce(into: [Element]()) {
-            if !$0.contains($1) {
-                $0.append($1)
-            }
-        }
+        return withoutDuplicates(by: ==)
     }
 
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -146,6 +146,17 @@ public extension Array where Element: Equatable {
         }
     }
 
+    /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
+    ///
+    /// - Parameter path: Key path to compare, must be Equatable.
+    /// - Returns: an array of unique elements.
+    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        return reduce(into: [Element]()) { (result, element) in
+            if !result.contains { $0[keyPath: path] == element[keyPath: path] } {
+                result.append(element)
+            }
+        }
+    }
 }
 
 public extension Array where Element: Hashable {

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -149,7 +149,7 @@ public extension Array where Element: Equatable {
     /// SwifterSwift: Returns a set with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.
-    /// - Returns: a set of unique elements.
+    /// - Returns: an array of unique elements.
     func withoutDuplicates<E: Hashable>(keyPath path: KeyPath<Element, E>) -> [Element] {
         var set = Set<E>()
         return filter { set.insert($0[keyPath: path]).inserted }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -208,63 +208,16 @@ public extension Array where Element: Hashable {
 
     /// SwifterSwift: Remove all duplicate elements from Array.
     ///
-    ///        [1, -1, 2, -4, 3, 3, 3, 4, -5].removeDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
-    ///
-    /// - Parameters:
-    ///   - comparator: Returns true if 2 elements of array are equal.
-    /// - Returns: Return array with all duplicate elements removed.
-    @discardableResult
-    mutating func removeDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
-        self = withoutDuplicates(by: comparator)
-        return self
-    }
-
-    /// SwifterSwift: Remove all duplicate elements from Array.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to compare, must be Equatable
-    /// - Returns: Return array with all duplicate elements removed.
-    @discardableResult
-    mutating func removeDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
-        self = withoutDuplicates(keyPath: path)
-        return self
-    }
-
-    /// SwifterSwift: Remove all duplicate elements from Array.
-    ///
     ///        [1, 2, 2, 3, 4, 5].removeDuplicates() -> [1, 2, 3, 4, 5]
     ///        ["h", "e", "l", "l", "o"]. removeDuplicates() -> ["h", "e", "l", "o"]
     ///
     /// - Returns: Return array with all duplicate elements removed.
     @discardableResult
     mutating func removeDuplicates() -> [Element] {
-        return removeDuplicates(by: ==)
-    }
-
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    ///     [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) } -> [1, 2, -4, 3, -5]
-    ///
-    /// - Parameters:
-    ///   - comparator: Returns true if 2 elements of array are equal.
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates(by comparator: (Element, Element) -> Bool) -> [Element] {
-        return Array(reduce(into: Set<Element>()) { result, element in
-            if !result.contains { comparator($0, element) } {
-                result.insert(element)
-            }
-        })
-    }
-
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    /// - Parameters:
-    ///   - path: Key path to compare, must be Equatable
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
-        return withoutDuplicates { $0[keyPath: path] == $1[keyPath: path] }
+        // Thanks to https://github.com/LucianoPAlmeida for improving the method
+        var set: Set<Element> = []
+        removeAll(where: { !set.insert($0).inserted }) // Since it makes a partition based removal is more optimized.
+        return self
     }
 
     /// SwifterSwift: Return array with all duplicate elements removed.
@@ -275,6 +228,8 @@ public extension Array where Element: Hashable {
     /// - Returns: an array of unique elements.
     ///
     func withoutDuplicates() -> [Element] {
-        return withoutDuplicates(by: ==)
+        // Thanks to https://github.com/LucianoPAlmeida for improving the method
+        var set: Set<Element> = []
+        return filter { set.insert($0).inserted }
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -202,34 +202,3 @@ public extension Array where Element: Equatable {
     }
 
 }
-
-// MARK: - Methods (Hashable)
-public extension Array where Element: Hashable {
-
-    /// SwifterSwift: Remove all duplicate elements from Array.
-    ///
-    ///        [1, 2, 2, 3, 4, 5].removeDuplicates() -> [1, 2, 3, 4, 5]
-    ///        ["h", "e", "l", "l", "o"]. removeDuplicates() -> ["h", "e", "l", "o"]
-    ///
-    /// - Returns: Return array with all duplicate elements removed.
-    @discardableResult
-    mutating func removeDuplicates() -> [Element] {
-        // Thanks to https://github.com/LucianoPAlmeida for improving the method
-        var set: Set<Element> = []
-        removeAll(where: { !set.insert($0).inserted }) // Since it makes a partition based removal is more optimized.
-        return self
-    }
-
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    ///     [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates() -> [1, 2, 3, 4, 5])
-    ///     ["h", "e", "l", "l", "o"].withoutDuplicates() -> ["h", "e", "l", "o"])
-    ///
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates() -> [Element] {
-        // Thanks to https://github.com/LucianoPAlmeida for improving the method
-        var set: Set<Element> = []
-        return filter { set.insert($0).inserted }
-    }
-}

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -147,3 +147,17 @@ public extension Array where Element: Equatable {
     }
 
 }
+
+public extension Array where Element: Hashable {
+    /// SwifterSwift: Returns a set with all duplicate elements removed using KeyPath to compare.
+    ///
+    /// - Parameter path: Key path to compare, must be Equatable.
+    /// - Returns: an array of unique elements.
+    func withoutDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> Set<Element> {
+        return reduce(into: Set<Element>()) { (result, element) in
+            if !result.contains { $0[keyPath: path] == element[keyPath: path] } {
+                result.insert(element)
+            }
+        }
+    }
+}

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -117,8 +117,8 @@ final class ArrayExtensionsTests: XCTestCase {
         let arrayWithoutDuplicatesHashable = array.withoutDuplicates(keyPath: \.name)
         let arrayWithoutDuplicatesHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
         XCTAssertEqual(arrayWithoutDuplicatesHashable, arrayWithoutDuplicatesHashablePrepared)
-        let arrayWithoutDuplicatesNotHashable = array.withoutDuplicates(keyPath: \.location)
-        let arrayWithoutDuplicatesNotHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
-        XCTAssertEqual(arrayWithoutDuplicatesNotHashable, arrayWithoutDuplicatesNotHashablePrepared)
+        let arrayWithoutDuplicatesNHashable = array.withoutDuplicates(keyPath: \.location)
+        let arrayWithoutDuplicatesNHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
+        XCTAssertEqual(arrayWithoutDuplicatesNHashable, arrayWithoutDuplicatesNHashablePrepared)
     }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -105,28 +105,44 @@ final class ArrayExtensionsTests: XCTestCase {
     }
 
     func testRemoveDuplicatesUsingComparator() {
-        var array = [1, -1, 2, -4, 3, 3, 3, 4, -5]
-        array.removeDuplicates { abs($0) == abs($1) }
-        XCTAssertEqual(array, [1, 2, -4, 3, -5])
+        var arrayHashable = [1, -1, 2, -4, 3, 3, 3, 4, -5]
+        arrayHashable.removeDuplicates { abs($0) == abs($1) }
+        XCTAssertEqual(Set(arrayHashable), Set([1, 2, -4, 3, -5]))
+        var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
+        arrayEquatable.removeDuplicates { $0.name == $1.name }
+        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayEquatable.count, arrayEquatableWithoutDuplicates.count)
+        XCTAssertTrue(zip(arrayEquatable, arrayEquatableWithoutDuplicates).any { $0 == $1})
     }
 
     func testRemoveDuplicatesUsingKeyPath() {
-        var array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        array.removeDuplicates(keyPath: \.name)
-        let arrayWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(array.count, arrayWithoutDuplicates.count)
-        XCTAssertTrue(zip(array, arrayWithoutDuplicates).any { $0 == $1})
+        var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
+        arrayEquatable.removeDuplicates(keyPath: \.name)
+        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayEquatable.count, arrayEquatableWithoutDuplicates.count)
+        XCTAssertTrue(zip(arrayEquatable, arrayEquatableWithoutDuplicates).any { $0 == $1})
     }
 
     func testRemoveDuplicates() {
-        var array = [1, 1, 2, 2, 3, 3, 3, 4, 5]
-        array.removeDuplicates()
-        XCTAssertEqual(array, [1, 2, 3, 4, 5])
+        var arrayHashable = [1, 1, 2, 2, 3, 3, 3, 4, 5]
+        arrayHashable.removeDuplicates()
+        XCTAssertEqual(Set(arrayHashable), Set([1, 2, 3, 4, 5]))
+        var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        arrayEquatable.removeDuplicates()
+        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayEquatable.count, arrayEquatableWithoutDuplicates.count)
+        XCTAssertTrue(zip(arrayEquatable, arrayEquatableWithoutDuplicates).any { $0 == $1})
     }
 
     func testWithoutDuplicatesUsingComparator() {
-        XCTAssertEqual([1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) }, [1, 2, -4, 3, -5])
-        XCTAssertEqual(["H", "e", "l", "L", "o"].withoutDuplicates { $0.capitalized == $1.capitalized }, ["H", "e", "l", "o"])
+        let arrayHashableWithoutDuplicates = [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) }
+        XCTAssertEqual(Set(arrayHashableWithoutDuplicates), Set([1, 2, -4, 3, -5]))
+        let stringArrayHashableWithoutDuplicates = ["H", "e", "l", "L", "o"].withoutDuplicates { $0.capitalized == $1.capitalized }
+        XCTAssertEqual(Set(stringArrayHashableWithoutDuplicates), Set(["H", "e", "l", "o"]))
+        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)].withoutDuplicates { $0.name == $1.name }
+        let arrayEquatableWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayEquatableWithoutDuplicates.count, arrayEquatableWithoutDuplicatesPrepared.count)
+        XCTAssertTrue(zip(arrayEquatableWithoutDuplicates, arrayEquatableWithoutDuplicatesPrepared).any { $0 == $1})
     }
 
     func testWithoutDuplicatesUsingKeyPath() {
@@ -138,8 +154,14 @@ final class ArrayExtensionsTests: XCTestCase {
     }
 
     func testWithoutDuplicates() {
-        XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates(), [1, 2, 3, 4, 5])
-        XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
+        let arrayHashableWithoutDuplicates = [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates()
+        XCTAssertEqual(Set(arrayHashableWithoutDuplicates), Set([1, 2, 3, 4, 5]))
+        let stringArrayHashableWithoutDuplicates = ["h", "e", "l", "l", "o"].withoutDuplicates()
+        XCTAssertEqual(Set(stringArrayHashableWithoutDuplicates), Set(["h", "e", "l", "o"]))
+        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)].withoutDuplicates()
+        let arrayEquatableWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayEquatableWithoutDuplicates.count, arrayEquatableWithoutDuplicatesPrepared.count)
+        XCTAssertTrue(zip(arrayEquatableWithoutDuplicates, arrayEquatableWithoutDuplicatesPrepared).any { $0 == $1})
     }
 
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwifterSwift
 
-private struct Person: Equatable, Hashable {
+private struct Person: Equatable {
     var name: String
     var age: Int?
     var location: Location?
@@ -17,11 +17,6 @@ private struct Person: Equatable, Hashable {
         self.name = name
         self.age = age
         self.location = location
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-        hasher.combine(age)
     }
 }
 

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -90,64 +90,15 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(arr, [])
     }
 
-    func testRemoveDuplicatesUsingComparator() {
-        var arrayHashable = [1, -1, 2, -4, 3, 3, 3, 4, -5]
-        arrayHashable.removeDuplicates { abs($0) == abs($1) }
-        XCTAssertEqual(arrayHashable, [1, 2, -4, 3, -5])
-        var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        arrayEquatable.removeDuplicates { $0.name == $1.name }
-        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayEquatable.count, arrayEquatableWithoutDuplicates.count)
-        XCTAssertTrue(zip(arrayEquatable, arrayEquatableWithoutDuplicates).any { $0 == $1})
-    }
-
-    func testRemoveDuplicatesUsingKeyPath() {
-        var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        arrayEquatable.removeDuplicates(keyPath: \.name)
-        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayEquatable.count, arrayEquatableWithoutDuplicates.count)
-        XCTAssertTrue(zip(arrayEquatable, arrayEquatableWithoutDuplicates).any { $0 == $1})
-    }
-
     func testRemoveDuplicates() {
-        var arrayHashable = [1, 1, 2, 2, 3, 3, 3, 4, 5]
-        arrayHashable.removeDuplicates()
-        XCTAssertEqual(arrayHashable, [1, 2, 3, 4, 5])
-        var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        arrayEquatable.removeDuplicates()
-        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayEquatable.count, arrayEquatableWithoutDuplicates.count)
-        XCTAssertTrue(zip(arrayEquatable, arrayEquatableWithoutDuplicates).any { $0 == $1})
-    }
-
-    func testWithoutDuplicatesUsingComparator() {
-        let arrayHashableWithoutDuplicates = [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) }
-        XCTAssertEqual(arrayHashableWithoutDuplicates, [1, 2, -4, 3, -5])
-        let stringArrayHashableWithoutDuplicates = ["H", "e", "l", "L", "o"].withoutDuplicates { $0.capitalized == $1.capitalized }
-        XCTAssertEqual(stringArrayHashableWithoutDuplicates, ["H", "e", "l", "o"])
-        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)].withoutDuplicates { $0.name == $1.name }
-        let arrayEquatableWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayEquatableWithoutDuplicates.count, arrayEquatableWithoutDuplicatesPrepared.count)
-        XCTAssertTrue(zip(arrayEquatableWithoutDuplicates, arrayEquatableWithoutDuplicatesPrepared).any { $0 == $1})
-    }
-
-    func testWithoutDuplicatesUsingKeyPath() {
-        let array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
-        let arrayWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayWithoutDuplicates.count, arrayWithoutDuplicatesPrepared.count)
-        XCTAssertTrue(zip(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared).any { $0 == $1})
+        var array = [1, 1, 2, 2, 3, 3, 3, 4, 5]
+        array.removeDuplicates()
+        XCTAssertEqual(array, [1, 2, 3, 4, 5])
     }
 
     func testWithoutDuplicates() {
-        let arrayHashableWithoutDuplicates = [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates()
-        XCTAssertEqual(arrayHashableWithoutDuplicates, [1, 2, 3, 4, 5])
-        let stringArrayHashableWithoutDuplicates = ["h", "e", "l", "l", "o"].withoutDuplicates()
-        XCTAssertEqual(stringArrayHashableWithoutDuplicates, ["h", "e", "l", "o"])
-        let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)].withoutDuplicates()
-        let arrayEquatableWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayEquatableWithoutDuplicates.count, arrayEquatableWithoutDuplicatesPrepared.count)
-        XCTAssertTrue(zip(arrayEquatableWithoutDuplicates, arrayEquatableWithoutDuplicatesPrepared).any { $0 == $1})
+        XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates(), [1, 2, 3, 4, 5])
+        XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
     }
 
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -8,15 +8,18 @@
 import XCTest
 @testable import SwifterSwift
 
-private struct Person: Equatable {
+private struct Person {
     var name: String
     var age: Int?
+}
 
+extension Person: Equatable {
     static func == (lhs: Person, rhs: Person) -> Bool {
         return lhs.name == rhs.name && lhs.age == rhs.age
     }
-
 }
+
+extension Person: Hashable { }
 
 final class ArrayExtensionsTests: XCTestCase {
 
@@ -101,4 +104,11 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
     }
 
+    func testWithoutDuplicatesUsingKeyPath() {
+        let array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
+        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
+        let setWithoutDuplicatesPrepared = Set([Person(name: "James", age: 32), Person(name: "Rose", age: 29)])
+        XCTAssertEqual(arrayWithoutDuplicates.count, setWithoutDuplicatesPrepared.count)
+        XCTAssertEqual(arrayWithoutDuplicates, setWithoutDuplicatesPrepared)
+    }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -98,9 +98,13 @@ final class ArrayExtensionsTests: XCTestCase {
 
     func testWithoutDuplicatesUsingKeyPath() {
         let array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
-        let setWithoutDuplicatesPrepared = Set([Person(name: "James", age: 32), Person(name: "Rose", age: 29)])
-        XCTAssertEqual(arrayWithoutDuplicates.count, setWithoutDuplicatesPrepared.count)
-        XCTAssertEqual(arrayWithoutDuplicates, setWithoutDuplicatesPrepared)
+        let setWithoutDuplicates: Set<Person> = array.withoutDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicates: [Person] = array.withoutDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        let setWithoutDuplicatesPrepared = Set(arrayWithoutDuplicatesPrepared)
+        XCTAssertEqual(setWithoutDuplicates.count, setWithoutDuplicatesPrepared.count)
+        XCTAssertEqual(arrayWithoutDuplicates.count, arrayWithoutDuplicatesPrepared.count)
+        XCTAssertEqual(setWithoutDuplicates, setWithoutDuplicatesPrepared)
+        XCTAssertTrue(zip(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared).any { $0 == $1})
     }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -107,7 +107,7 @@ final class ArrayExtensionsTests: XCTestCase {
     func testRemoveDuplicatesUsingComparator() {
         var arrayHashable = [1, -1, 2, -4, 3, 3, 3, 4, -5]
         arrayHashable.removeDuplicates { abs($0) == abs($1) }
-        XCTAssertEqual(Set(arrayHashable), Set([1, 2, -4, 3, -5]))
+        XCTAssertEqual(arrayHashable, [1, 2, -4, 3, -5])
         var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
         arrayEquatable.removeDuplicates { $0.name == $1.name }
         let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
@@ -126,7 +126,7 @@ final class ArrayExtensionsTests: XCTestCase {
     func testRemoveDuplicates() {
         var arrayHashable = [1, 1, 2, 2, 3, 3, 3, 4, 5]
         arrayHashable.removeDuplicates()
-        XCTAssertEqual(Set(arrayHashable), Set([1, 2, 3, 4, 5]))
+        XCTAssertEqual(arrayHashable, [1, 2, 3, 4, 5])
         var arrayEquatable = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
         arrayEquatable.removeDuplicates()
         let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
@@ -136,9 +136,9 @@ final class ArrayExtensionsTests: XCTestCase {
 
     func testWithoutDuplicatesUsingComparator() {
         let arrayHashableWithoutDuplicates = [1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) }
-        XCTAssertEqual(Set(arrayHashableWithoutDuplicates), Set([1, 2, -4, 3, -5]))
+        XCTAssertEqual(arrayHashableWithoutDuplicates, [1, 2, -4, 3, -5])
         let stringArrayHashableWithoutDuplicates = ["H", "e", "l", "L", "o"].withoutDuplicates { $0.capitalized == $1.capitalized }
-        XCTAssertEqual(Set(stringArrayHashableWithoutDuplicates), Set(["H", "e", "l", "o"]))
+        XCTAssertEqual(stringArrayHashableWithoutDuplicates, ["H", "e", "l", "o"])
         let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)].withoutDuplicates { $0.name == $1.name }
         let arrayEquatableWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
         XCTAssertEqual(arrayEquatableWithoutDuplicates.count, arrayEquatableWithoutDuplicatesPrepared.count)
@@ -155,9 +155,9 @@ final class ArrayExtensionsTests: XCTestCase {
 
     func testWithoutDuplicates() {
         let arrayHashableWithoutDuplicates = [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates()
-        XCTAssertEqual(Set(arrayHashableWithoutDuplicates), Set([1, 2, 3, 4, 5]))
+        XCTAssertEqual(arrayHashableWithoutDuplicates, [1, 2, 3, 4, 5])
         let stringArrayHashableWithoutDuplicates = ["h", "e", "l", "l", "o"].withoutDuplicates()
-        XCTAssertEqual(Set(stringArrayHashableWithoutDuplicates), Set(["h", "e", "l", "o"]))
+        XCTAssertEqual(stringArrayHashableWithoutDuplicates, ["h", "e", "l", "o"])
         let arrayEquatableWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "James", age: 32), Person(name: "Rose", age: 29), Person(name: "James", age: 32), Person(name: "Rose", age: 29)].withoutDuplicates()
         let arrayEquatableWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
         XCTAssertEqual(arrayEquatableWithoutDuplicates.count, arrayEquatableWithoutDuplicatesPrepared.count)

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -97,14 +97,9 @@ final class ArrayExtensionsTests: XCTestCase {
     }
 
     func testWithoutDuplicatesUsingKeyPath() {
-        let array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        let setWithoutDuplicates = array.withoutDuplicatesUnordered(keyPath: \.name)
+        let array = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22)]
         let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
-        let arrayWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        let setWithoutDuplicatesPrepared = Set(arrayWithoutDuplicatesPrepared)
-        XCTAssertEqual(setWithoutDuplicates.count, setWithoutDuplicatesPrepared.count)
-        XCTAssertEqual(arrayWithoutDuplicates.count, arrayWithoutDuplicatesPrepared.count)
-        XCTAssertEqual(setWithoutDuplicates, setWithoutDuplicatesPrepared)
-        XCTAssertTrue(zip(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared).any { $0 == $1})
+        let arrayWithoutDuplicatesPrepared = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared)
     }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -11,9 +11,9 @@ import XCTest
 private struct Person: Equatable, Hashable {
     var name: String
     var age: Int?
-    var location: Location
+    var location: Location?
 
-    init(name: String, age: Int?, location: Location = Location(city: "New York")) {
+    init(name: String, age: Int?, location: Location? = nil) {
         self.name = name
         self.age = age
         self.location = location

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -8,18 +8,10 @@
 import XCTest
 @testable import SwifterSwift
 
-private struct Person {
+private struct Person: Equatable, Hashable {
     var name: String
     var age: Int?
 }
-
-extension Person: Equatable {
-    static func == (lhs: Person, rhs: Person) -> Bool {
-        return lhs.name == rhs.name && lhs.age == rhs.age
-    }
-}
-
-extension Person: Hashable { }
 
 final class ArrayExtensionsTests: XCTestCase {
 

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -11,6 +11,22 @@ import XCTest
 private struct Person: Equatable, Hashable {
     var name: String
     var age: Int?
+    var location: Location
+
+    init(name: String, age: Int?, location: Location = Location(city: "New York")) {
+        self.name = name
+        self.age = age
+        self.location = location
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(age)
+    }
+}
+
+private struct Location: Equatable {
+    var city: String
 }
 
 final class ArrayExtensionsTests: XCTestCase {
@@ -97,9 +113,12 @@ final class ArrayExtensionsTests: XCTestCase {
     }
 
     func testWithoutDuplicatesUsingKeyPath() {
-        let array = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22)]
-        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
-        let arrayWithoutDuplicatesPrepared = [Person(name: "Wade", age: 20), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
-        XCTAssertEqual(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared)
+        let array = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
+        let arrayWithoutDuplicatesHashable = array.withoutDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicatesHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayWithoutDuplicatesHashable, arrayWithoutDuplicatesHashablePrepared)
+        let arrayWithoutDuplicatesNotHashable = array.withoutDuplicates(keyPath: \.location)
+        let arrayWithoutDuplicatesNotHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
+        XCTAssertEqual(arrayWithoutDuplicatesNotHashable, arrayWithoutDuplicatesNotHashablePrepared)
     }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -26,7 +26,7 @@ private struct Person: Equatable, Hashable {
 }
 
 private struct Location: Equatable {
-    var city: String
+    let city: String
 }
 
 final class ArrayExtensionsTests: XCTestCase {

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -98,8 +98,8 @@ final class ArrayExtensionsTests: XCTestCase {
 
     func testWithoutDuplicatesUsingKeyPath() {
         let array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
-        let setWithoutDuplicates: Set<Person> = array.withoutDuplicates(keyPath: \.name)
-        let arrayWithoutDuplicates: [Person] = array.withoutDuplicates(keyPath: \.name)
+        let setWithoutDuplicates = array.withoutDuplicatesUnordered(keyPath: \.name)
+        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
         let arrayWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
         let setWithoutDuplicatesPrepared = Set(arrayWithoutDuplicatesPrepared)
         XCTAssertEqual(setWithoutDuplicates.count, setWithoutDuplicatesPrepared.count)

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -104,10 +104,37 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(arr, [])
     }
 
+    func testRemoveDuplicatesUsingComparator() {
+        var array = [1, -1, 2, -4, 3, 3, 3, 4, -5]
+        array.removeDuplicates { abs($0) == abs($1) }
+        XCTAssertEqual(array, [1, 2, -4, 3, -5])
+    }
+
+    func testRemoveDuplicatesUsingKeyPath() {
+        var array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
+        array.removeDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicates = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(array.count, arrayWithoutDuplicates.count)
+        XCTAssertTrue(zip(array, arrayWithoutDuplicates).any { $0 == $1})
+    }
+
     func testRemoveDuplicates() {
         var array = [1, 1, 2, 2, 3, 3, 3, 4, 5]
         array.removeDuplicates()
         XCTAssertEqual(array, [1, 2, 3, 4, 5])
+    }
+
+    func testWithoutDuplicatesUsingComparator() {
+        XCTAssertEqual([1, -1, 2, -4, 3, 3, 3, 4, -5].withoutDuplicates { abs($0) == abs($1) }, [1, 2, -4, 3, -5])
+        XCTAssertEqual(["H", "e", "l", "L", "o"].withoutDuplicates { $0.capitalized == $1.capitalized }, ["H", "e", "l", "o"])
+    }
+
+    func testWithoutDuplicatesUsingKeyPath() {
+        let array = [Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72), Person(name: "Rose", age: 56)]
+        let arrayWithoutDuplicates = array.withoutDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicatesPrepared = [Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(arrayWithoutDuplicates.count, arrayWithoutDuplicatesPrepared.count)
+        XCTAssertTrue(zip(arrayWithoutDuplicates, arrayWithoutDuplicatesPrepared).any { $0 == $1})
     }
 
     func testWithoutDuplicates() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
🚀 Fixed #653. Added **withoutDuplicates(keyPath:)** to **Array**.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
