### PR TITLE
Add a probot stale configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,11 @@ onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
- - help wanted
+  - enhancement
+  - bug
+  - confirmed bug
+  - discussion
+  - help wanted
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -24,7 +28,7 @@ exemptMilestones: false
 exemptAssignees: false
 
 # Label to use when marking as stale
-staleLabel: won't fix
+staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,60 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+ - help wanted
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: won't fix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been automatically closed because it has not had
+  recent activity. Thank you for your contributions.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
See Issue #644 

Also see https://github.com/probot/stale

It's a default configuration with 30 Days until stale (label `won't fix`) and another 7 days until close.  It ignores issues with the label `help wanted`.

Additionally it has the following close comment:

> This issue has been automatically closed because it has not had recent activity. Thank you for your contributions.

When this is merged we have to setup the probot for this repository: https://github.com/apps/stale
(I'll request the add of the app as soon as this is merged. **The Org administrator has to verify this**.)

Since it doesn't add anything to the library itself, I haven't added a changelog entry.