### PR TITLE
Mutating versions of removeDuplicates(keyPath:) and removeDuplicates() refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - - `queryValue(for:)` extension for URL is refactored. [#668](https://github.com/SwifterSwift/SwifterSwift/pull/668) by [LucianoPAlmeida](https://github.com/ratulSharker).
 - **Sequence**:
   - `sum()` extension for Sequence is refactored. [#707](https://github.com/SwifterSwift/SwifterSwift/pull/707) by [cHaLkdusT](https://github.com/cHaLkdusT).
-- **Array**:
-  - `removeDuplicates()` is refactored using `withoutDuplicates()` [#711](https://github.com/SwifterSwift/SwifterSwift/pull/711) by [RomanPodymov](https://github.com/RomanPodymov).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Array**:
+    - Added `removeDuplicates(keyPath:)` for filtering duplicate elements based on key path. [#711](https://github.com/SwifterSwift/SwifterSwift/pull/711) by [RomanPodymov](https://github.com/RomanPodymov).
     - Added `withoutDuplicates(keyPath:)` for filtering duplicate elements based on key path. [#704](https://github.com/SwifterSwift/SwifterSwift/pull/704) by [RomanPodymov](https://github.com/RomanPodymov).
 - **Sequence**:
     - Added `withoutDuplicates(transform:)` for remove duplicate elements based on condition in a sequence. [#666](https://github.com/SwifterSwift/SwifterSwift/pull/666) by [saucym](https://github.com/saucym)
@@ -49,6 +50,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - - `queryValue(for:)` extension for URL is refactored. [#668](https://github.com/SwifterSwift/SwifterSwift/pull/668) by [LucianoPAlmeida](https://github.com/ratulSharker).
 - **Sequence**:
   - `sum()` extension for Sequence is refactored. [#707](https://github.com/SwifterSwift/SwifterSwift/pull/707) by [cHaLkdusT](https://github.com/cHaLkdusT).
+- **Array**:
+  - `removeDuplicates()` is refactored using `withoutDuplicates()` [#711](https://github.com/SwifterSwift/SwifterSwift/pull/711) by [RomanPodymov](https://github.com/RomanPodymov).
 
 ### Deprecated
 

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -122,7 +122,11 @@ public extension Array where Element: Equatable {
     @discardableResult
     mutating func removeDuplicates() -> [Element] {
         // Thanks to https://github.com/sairamkotha for improving the method
-        self = withoutDuplicates()
+        self = reduce(into: [Element]()) {
+            if !$0.contains($1) {
+                $0.append($1)
+            }
+        }
         return self
     }
 

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -122,11 +122,7 @@ public extension Array where Element: Equatable {
     @discardableResult
     mutating func removeDuplicates() -> [Element] {
         // Thanks to https://github.com/sairamkotha for improving the method
-        self = reduce(into: [Element]()) {
-            if !$0.contains($1) {
-                $0.append($1)
-            }
-        }
+        self = withoutDuplicates()
         return self
     }
 
@@ -146,6 +142,16 @@ public extension Array where Element: Equatable {
         }
     }
 
+    /// SwifterSwift: Remove all duplicate elements from Array using KeyPath to compare.
+    ///
+    /// - Parameter path: Key path to compare, the value must be Equatable.
+    /// - Returns: an array of unique elements.
+    @discardableResult
+    mutating func removeDuplicates<E: Equatable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        self = withoutDuplicates(keyPath: path)
+        return self
+    }
+    
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Equatable.
@@ -158,6 +164,16 @@ public extension Array where Element: Equatable {
         }
     }
 
+    /// SwifterSwift: Remove all duplicate elements from Array using KeyPath to compare.
+    ///
+    /// - Parameter path: Key path to compare, the value must be Hashable.
+    /// - Returns: an array of unique elements.
+    @discardableResult
+    mutating func removeDuplicates<E: Hashable>(keyPath path: KeyPath<Element, E>) -> [Element] {
+        self = withoutDuplicates(keyPath: path)
+        return self
+    }
+    
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -151,7 +151,7 @@ public extension Array where Element: Equatable {
         self = withoutDuplicates(keyPath: path)
         return self
     }
-    
+
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Equatable.
@@ -173,7 +173,7 @@ public extension Array where Element: Equatable {
         self = withoutDuplicates(keyPath: path)
         return self
     }
-    
+
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -107,6 +107,19 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
     }
 
+    func testRemoveDuplicatesUsingKeyPath() {
+        var array = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
+        let arrayWithoutDuplicatesHashable = array.removeDuplicates(keyPath: \.name)
+        let arrayWithoutDuplicatesHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "Rose", age: 29)]
+        XCTAssertEqual(array, arrayWithoutDuplicatesHashablePrepared)
+        XCTAssertEqual(arrayWithoutDuplicatesHashable, arrayWithoutDuplicatesHashablePrepared)
+        var arrayCopy = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
+        let arrayWithoutDuplicatesNHashable = arrayCopy.removeDuplicates(keyPath: \.location)
+        let arrayWithoutDuplicatesNHashablePrepared = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
+        XCTAssertEqual(arrayCopy, arrayWithoutDuplicatesNHashablePrepared)
+        XCTAssertEqual(arrayWithoutDuplicatesNHashable, arrayWithoutDuplicatesNHashablePrepared)
+    }
+
     func testWithoutDuplicatesUsingKeyPath() {
         let array = [Person(name: "Wade", age: 20, location: Location(city: "London")), Person(name: "James", age: 32), Person(name: "James", age: 36), Person(name: "Rose", age: 29), Person(name: "James", age: 72, location: Location(city: "Moscow")), Person(name: "Rose", age: 56), Person(name: "Wade", age: 22, location: Location(city: "Prague"))]
         let arrayWithoutDuplicatesHashable = array.withoutDuplicates(keyPath: \.name)


### PR DESCRIPTION
🚀 Fixed #710. Refactored `Array.removeDuplicates()`.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
