### PR TITLE
Added element(:) extension to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Array**:
+    - Added `element(at:)` for safely accessing elements without using subscript syntax. [#717](https://github.com/SwifterSwift/SwifterSwift/pull/717) by [Zach Frew](https://github.com/zmfrew).
+
+Added element(at:) for safely accessing elements without using subscript syntax. #717 by Zach Frew.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Array**:
     - Added `element(at:)` for safely accessing elements without using subscript syntax. [#717](https://github.com/SwifterSwift/SwifterSwift/pull/717) by [Zach Frew](https://github.com/zmfrew).
 
-Added element(at:) for safely accessing elements without using subscript syntax. #717 by Zach Frew.
-
 ### Changed
 
 ### Deprecated

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -9,6 +9,19 @@
 // MARK: - Methods
 public extension Array {
 
+    /// SwifterSwift: Safely accesses elements in the array and protects from out of bounds exceptions.
+    ///
+    ///        let arr = [1, 2, 3, 4, 5]
+    ///        arr.element(at: 2) -> 3
+    ///        arr.element(at: 6) -> nil
+    ///
+    /// - Parameter index: index of element to access.
+    /// - Returns: element at the given index or nil if the index out of bounds.
+    func element(at index: Int) -> Element? {
+        guard index >= 0 && index < self.count else { return nil }
+        return self[index]
+    }
+
     /// SwifterSwift: Insert an element at the beginning of array.
     ///
     ///        [2, 3, 4, 5].prepend(1) -> [1, 2, 3, 4, 5]

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -26,6 +26,15 @@ private struct Location: Equatable {
 
 final class ArrayExtensionsTests: XCTestCase {
 
+    func testElement() {
+        let arr = [1, 2, 3, 4, 5]
+        XCTAssertEqual(arr.element(at: 0), 1)
+        XCTAssertEqual(arr.element(at: -0), 1)
+        XCTAssertEqual(arr.element(at: 4), 5)
+        XCTAssertNil(arr.element(at: 5))
+        XCTAssertNil(arr.element(at: -1))
+    }
+
     func testPrepend() {
         var arr = [2, 3, 4, 5]
         arr.prepend(1)


### PR DESCRIPTION
:rocket: I added an extension on `Array`, which allows for safe accessing of elements in the array. It provides a clean, swifty way of accessing elements in the array without subscript syntax.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
