### PR TITLE
Added replacingOccurrences extension to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **String**:
+    - Added `replacingOccurrences(of search:, with replacement:, count maxReplacements:)`, which allows for replacing a string within a string with specific text a specified amount of times. [#719](https://github.com/SwifterSwift/SwifterSwift/pull/719) by [Zach Frew](https://github.com/zmfrew).
 
 ### Changed
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -604,7 +604,7 @@ public extension String {
 
         while let range = returnValue.range(of: search), count < maxReplacements {
             returnValue.replaceSubrange(range, with: replacement)
-             count += 1
+            count += 1
         }
 
         return returnValue

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -602,14 +602,9 @@ public extension String {
         var count = 0
         var returnValue = self
 
-        while let range = returnValue.range(of: search) {
-            returnValue = returnValue.replacingCharacters(in: range, with: replacement)
-            count += 1
-
-            // exit as soon as we've made all replacements
-            if count == maxReplacements {
-                return returnValue
-            }
+        while let range = returnValue.range(of: search), count < maxReplacements {
+             returnValue = returnValue.replacingCharacters(in: range, with: replacement)
+             count += 1
         }
 
         return returnValue

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -586,6 +586,36 @@ public extension String {
     }
     #endif
 
+    #if canImport(Foundation)
+    // https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions
+    /// SwifterSwift: Replaces a set number of occurrences of a string with replacement text.
+    ///
+    ///        "I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1) -> "I love swift."
+    /// - Parameters:
+    ///     - search: the string to be replaced
+    ///     - replacement: the replacement string
+    ///     - maxReplacements: the maximum number of times to replace the string, which must be greater than 0
+    /// - Returns: The new string with the replacement text swapped the specified amount of times.
+    func replacingOccurrences(of search: String, with replacement: String, count maxReplacements: Int) -> String {
+        guard maxReplacements > 0 else { return self }
+
+        var count = 0
+        var returnValue = self
+
+        while let range = returnValue.range(of: search) {
+            returnValue = returnValue.replacingCharacters(in: range, with: replacement)
+            count += 1
+
+            // exit as soon as we've made all replacements
+            if count == maxReplacements {
+                return returnValue
+            }
+        }
+
+        return returnValue
+    }
+    #endif
+
     /// SwifterSwift: Safely subscript string with index.
     ///
     ///		"Hello World!"[safe: 3] -> "l"

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -603,7 +603,7 @@ public extension String {
         var returnValue = self
 
         while let range = returnValue.range(of: search), count < maxReplacements {
-             returnValue = returnValue.replacingCharacters(in: range, with: replacement)
+            returnValue.replaceSubrange(range, with: replacement)
              count += 1
         }
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -336,6 +336,7 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testReplacingOccurrences() {
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 0), "I swift swift")
         XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift")
         XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 5), "I love love")
         XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: -1), "I swift swift")

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -335,6 +335,14 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Swift is amazing".toSlug(), "swift-is-amazing")
     }
 
+    func testReplacingOccurrences() {
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift")
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 5), "I love love")
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: -1), "I swift swift")
+        XCTAssertEqual("I swift swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift swift")
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 2), "I love love")
+    }
+
     func testSubscript() {
         let str = "Hello world!"
         XCTAssertEqual(str[safe: 1], "e")


### PR DESCRIPTION
🚀 This extension comes from Paul Hudson at Hacking with Swift. It allows for replacing a string within a string with specific text a specified amount of times.

https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
