### PR TITLE
String with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **String**:
-    - Added `withPrefix(_ prefix)`, which provides a method to add a prefix to a string. If the string already has that prefix, it simply returns the original string. [#720](https://github.com/SwifterSwift/SwifterSwift/pull/720) by [Zach Frew](https://github.com/zmfrew).
+    - Added `withPrefix(_:)`, which provides a method to add a prefix to a string. If the string already has that prefix, it simply returns the original string. [#720](https://github.com/SwifterSwift/SwifterSwift/pull/720) by [Zach Frew](https://github.com/zmfrew).
 
 ### Changed
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -586,36 +586,6 @@ public extension String {
     }
     #endif
 
-    #if canImport(Foundation)
-    // https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions
-    /// SwifterSwift: Replaces a set number of occurrences of a string with replacement text.
-    ///
-    ///        "I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1) -> "I love swift."
-    /// - Parameters:
-    ///     - search: the string to be replaced
-    ///     - replacement: the replacement string
-    ///     - maxReplacements: the maximum number of times to replace the string, which must be greater than 0
-    /// - Returns: The new string with the replacement text swapped the specified amount of times.
-    func replacingOccurrences(of search: String, with replacement: String, count maxReplacements: Int) -> String {
-        guard maxReplacements > 0 else { return self }
-
-        var count = 0
-        var returnValue = self
-
-        while let range = returnValue.range(of: search) {
-            returnValue = returnValue.replacingCharacters(in: range, with: replacement)
-            count += 1
-
-            // exit as soon as we've made all replacements
-            if count == maxReplacements {
-                return returnValue
-            }
-        }
-
-        return returnValue
-    }
-    #endif
-
     /// SwifterSwift: Safely subscript string with index.
     ///
     ///		"Hello World!"[safe: 3] -> "l"

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1082,6 +1082,17 @@ public extension String {
         return String(dropLast(suffix.count))
     }
 
+    // https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions
+    /// SwifterSwift: Adds prefix to the string.
+    ///
+    ///     "www.apple.com".withPrefix("https://") -> "https://www.apple.com"
+    ///
+    /// - Parameter prefix: Prefix to add to the string.
+    /// - Returns: The string with the prefix prepended.
+    func withPrefix(_ prefix: String) -> String {
+        if self.hasPrefix(prefix) { return self }
+        return "\(prefix)\(self)"
+    }
 }
 
 // MARK: - Initializers

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1052,7 +1052,6 @@ public extension String {
         return String(dropLast(suffix.count))
     }
 
-    // https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions
     /// SwifterSwift: Adds prefix to the string.
     ///
     ///     "www.apple.com".withPrefix("https://") -> "https://www.apple.com"
@@ -1060,6 +1059,7 @@ public extension String {
     /// - Parameter prefix: Prefix to add to the string.
     /// - Returns: The string with the prefix prepended.
     func withPrefix(_ prefix: String) -> String {
+        // https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions
         guard !hasPrefix(prefix) else { return self }
         return prefix + self
     }

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1090,8 +1090,8 @@ public extension String {
     /// - Parameter prefix: Prefix to add to the string.
     /// - Returns: The string with the prefix prepended.
     func withPrefix(_ prefix: String) -> String {
-        if self.hasPrefix(prefix) { return self }
-        return "\(prefix)\(self)"
+        if hasPrefix(prefix) { return self }
+        return prefix + self
     }
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -586,6 +586,36 @@ public extension String {
     }
     #endif
 
+    #if canImport(Foundation)
+    // https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions
+    /// SwifterSwift: Replaces a set number of occurrences of a string with replacement text.
+    ///
+    ///        "I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1) -> "I love swift."
+    /// - Parameters:
+    ///     - search: the string to be replaced
+    ///     - replacement: the replacement string
+    ///     - maxReplacements: the maximum number of times to replace the string, which must be greater than 0
+    /// - Returns: The new string with the replacement text swapped the specified amount of times.
+    func replacingOccurrences(of search: String, with replacement: String, count maxReplacements: Int) -> String {
+        guard maxReplacements > 0 else { return self }
+
+        var count = 0
+        var returnValue = self
+
+        while let range = returnValue.range(of: search) {
+            returnValue = returnValue.replacingCharacters(in: range, with: replacement)
+            count += 1
+
+            // exit as soon as we've made all replacements
+            if count == maxReplacements {
+                return returnValue
+            }
+        }
+
+        return returnValue
+    }
+    #endif
+
     /// SwifterSwift: Safely subscript string with index.
     ///
     ///		"Hello World!"[safe: 3] -> "l"

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1060,7 +1060,7 @@ public extension String {
     /// - Parameter prefix: Prefix to add to the string.
     /// - Returns: The string with the prefix prepended.
     func withPrefix(_ prefix: String) -> String {
-        if hasPrefix(prefix) { return self }
+        guard !hasPrefix(prefix) else { return self }
         return prefix + self
     }
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -635,6 +635,11 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(inputStr.removingSuffix(", World!"), "Hello")
     }
 
+    func testWithPrefix() {
+        XCTAssertEqual("www.apple.com".withPrefix("https://"), "https://www.apple.com")
+        XCTAssertEqual("https://www.apple.com".withPrefix("https://"), "https://www.apple.com")
+    }
+
     func testInitFromBase64() {
         XCTAssertNotNil(String(base64: "SGVsbG8gV29ybGQh"))
         XCTAssertEqual(String(base64: "SGVsbG8gV29ybGQh"), "Hello World!")

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -335,6 +335,14 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Swift is amazing".toSlug(), "swift-is-amazing")
     }
 
+    func testReplacingOccurrences() {
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift")
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 5), "I love love")
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: -1), "I swift swift")
+        XCTAssertEqual("I swift swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift swift")
+        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 2), "I love love")
+    }
+
     func testSubscript() {
         let str = "Hello world!"
         XCTAssertEqual(str[safe: 1], "e")

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -335,14 +335,6 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Swift is amazing".toSlug(), "swift-is-amazing")
     }
 
-    func testReplacingOccurrences() {
-        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift")
-        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 5), "I love love")
-        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: -1), "I swift swift")
-        XCTAssertEqual("I swift swift swift".replacingOccurrences(of: "swift", with: "love", count: 1), "I love swift swift")
-        XCTAssertEqual("I swift swift".replacingOccurrences(of: "swift", with: "love", count: 2), "I love love")
-    }
-
     func testSubscript() {
         let str = "Hello world!"
         XCTAssertEqual(str[safe: 1], "e")


### PR DESCRIPTION
🚀 This extension also comes from Paul Hudson at Hacking with Swift. It provides a clean method to add a prefix to a string. If the string already has that prefix, it simply returns the original string.

https://www.hackingwithswift.com/articles/141/8-useful-swift-extensions

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
