### PR TITLE
Add init(light:dark:) to NSColor and UIColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Color**:
+    - Added `init(light:dark:)` to create an NSColor/UIColor with different variations for light and dark mode. Only available in iOS/tvOS 13.0, macOS 10.15. [#722](https://github.com/SwifterSwift/SwifterSwift/pull/722) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **String**:
     - Added `withPrefix(_:)`, which provides a method to add a prefix to a string. If the string already has that prefix, it simply returns the original string. [#720](https://github.com/SwifterSwift/SwifterSwift/pull/720) by [Zach Frew](https://github.com/zmfrew).
 

--- a/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
@@ -1,0 +1,23 @@
+//
+//  NSColorExtensions.swift
+//  SwifterSwift
+//
+//  Created by Max Haertwig on 10/06/19.
+//  Copyright © 2019 SwifterSwift
+//
+
+import Cocoa
+
+public extension NSColor {
+
+    /// SwifterSwift: Create an NSColor with different colors for light and dark mode.
+    ///
+    /// - Parameters:
+    ///     - light: Color to use in light/unspecified mode.
+    ///     - dark: Color to use in dark mode.
+    @available(OSX 10.15, *)
+    convenience init(light: NSColor, dark: NSColor) {
+        self.init(name: nil, dynamicProvider: { $0.name == .darkAqua ? dark : light })
+    }
+
+}

--- a/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 SwifterSwift
 //
 
+#if canImport(Cocoa)
 import Cocoa
 
 public extension NSColor {
@@ -21,3 +22,5 @@ public extension NSColor {
     }
 
 }
+
+#endif

--- a/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
@@ -9,7 +9,7 @@
 #if canImport(Cocoa)
 import Cocoa
 
-@objc public extension NSColor {
+public extension NSColor {
 
     /// SwifterSwift: Create an NSColor with different colors for light and dark mode.
     ///

--- a/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
@@ -9,7 +9,7 @@
 #if canImport(Cocoa)
 import Cocoa
 
-public extension NSColor {
+@objc public extension NSColor {
 
     /// SwifterSwift: Create an NSColor with different colors for light and dark mode.
     ///

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 SwifterSwift
 //
 
+#if canImport(UIKit)
 import UIKit
 
 public extension UIColor {
@@ -21,3 +22,5 @@ public extension UIColor {
     }
 
 }
+
+#endif

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -1,0 +1,23 @@
+//
+//  UIColorExtensions.swift
+//  SwifterSwift
+//
+//  Created by Max Haertwig on 10/06/19.
+//  Copyright © 2019 SwifterSwift
+//
+
+import UIKit
+
+public extension UIColor {
+
+    /// SwifterSwift: Create a UIColor with different colors for light and dark mode.
+    ///
+    /// - Parameters:
+    ///     - light: Color to use in light/unspecified mode.
+    ///     - dark: Color to use in dark mode.
+    @available(iOS 13.0, tvOS 13.0, *)
+    convenience init(light: UIColor, dark: UIColor) {
+        self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
+    }
+
+}

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -478,6 +478,11 @@
 		9D9784E41FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9784DF1FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift */; };
 		9D9784E51FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9784DF1FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift */; };
 		9D9784E61FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9784DF1FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift */; };
+		9DC29CF42349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC29CF32349E7E200F5CAAD /* UIColorExtensionsTests.swift */; };
+		9DC29CF52349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC29CF32349E7E200F5CAAD /* UIColorExtensionsTests.swift */; };
+		9DC844A32349E1EE00E1571A /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */; };
+		9DC844A62349E27600E1571A /* NSColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC844A42349E24600E1571A /* NSColorExtensions.swift */; };
+		9DC844A82349E28100E1571A /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */; };
 		A94AA78720280F9100E229A5 /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */; };
 		A94AA78A202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */; };
 		A94AA78B202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */; };
@@ -725,6 +730,9 @@
 		9D806AA22258FF98008E500A /* SCNPlaneExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SCNPlaneExtensionsTests.swift; sourceTree = "<group>"; };
 		9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocolExtensions.swift; sourceTree = "<group>"; };
 		9D9784DF1FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringProtocolExtensionsTests.swift; sourceTree = "<group>"; };
+		9DC29CF32349E7E200F5CAAD /* UIColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensionsTests.swift; sourceTree = "<group>"; };
+		9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
+		9DC844A42349E24600E1571A /* NSColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSColorExtensions.swift; sourceTree = "<group>"; };
 		A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
 		A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensionsTests.swift; sourceTree = "<group>"; };
 		B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionExtensions.swift; sourceTree = "<group>"; };
@@ -924,6 +932,7 @@
 		07B7F15C1F5EB41600E6F910 /* AppKit */ = {
 			isa = PBXGroup;
 			children = (
+				9DC844A42349E24600E1571A /* NSColorExtensions.swift */,
 				07B7F1641F5EB41600E6F910 /* NSViewExtensions.swift */,
 				278CA08C1F9A9232004918BD /* NSImageExtensions.swift */,
 			);
@@ -956,6 +965,7 @@
 				9D806A352258AC0D008E500A /* UIBezierPathExtensions.swift */,
 				07B7F17E1F5EB41600E6F910 /* UIButtonExtensions.swift */,
 				07B7F17F1F5EB41600E6F910 /* UICollectionViewExtensions.swift */,
+				9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */,
 				074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */,
 				90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */,
 				07B7F1811F5EB41600E6F910 /* UIImageExtensions.swift */,
@@ -1033,6 +1043,7 @@
 				9D806A392258AE1D008E500A /* UIBezierPathExtensionsTests.swift */,
 				07C50D101F5EB03200F46E5A /* UIButtonExtensionsTests.swift */,
 				07C50D111F5EB03200F46E5A /* UICollectionViewExtensionsTests.swift */,
+				9DC29CF32349E7E200F5CAAD /* UIColorExtensionsTests.swift */,
 				074EAF1E1F7BA74600C74636 /* UIFontExtensionsTests.swift */,
 				07C50D131F5EB03200F46E5A /* UIImageExtensionsTests.swift */,
 				07C50D141F5EB03200F46E5A /* UIImageViewExtensionsTests.swift */,
@@ -1748,6 +1759,7 @@
 				07B7F2101F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
 				86B3F7AC208D3D5C00BC297B /* UIScrollViewExtensions.swift in Sources */,
 				9D806A412258B931008E500A /* SCNVector3Extensions.swift in Sources */,
+				9DC844A32349E1EE00E1571A /* UIColorExtensions.swift in Sources */,
 				07B7F2141F5EB43C00E6F910 /* FloatingPointExtensions.swift in Sources */,
 				07B7F19E1F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
 				B247BDE620D376EC00842ACC /* UIEdgeInsetsExtensions.swift in Sources */,
@@ -1778,6 +1790,7 @@
 				B2A0DAB72336D5A6002B0BC5 /* StdlibDeprecated.swift in Sources */,
 				A9AEB78620283ACC0021AACF /* FileManagerExtensions.swift in Sources */,
 				784C75312051BD4B001C48DD /* MKPolylineExtensions.swift in Sources */,
+				9DC844A82349E28100E1571A /* UIColorExtensions.swift in Sources */,
 				07B7F2351F5EB45200E6F910 /* CGFloatExtensions.swift in Sources */,
 				07B7F1AE1F5EB42000E6F910 /* UIImageViewExtensions.swift in Sources */,
 				9D806A6B2258DC3E008E500A /* SCNShape.swift in Sources */,
@@ -1944,6 +1957,7 @@
 				A9AEB78820283ACD0021AACF /* FileManagerExtensions.swift in Sources */,
 				07B7F1DC1F5EB43B00E6F910 /* DoubleExtensions.swift in Sources */,
 				07B7F1D71F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
+				9DC844A62349E27600E1571A /* NSColorExtensions.swift in Sources */,
 				07B7F2231F5EB44600E6F910 /* CGSizeExtensions.swift in Sources */,
 				664CB9792171899800FC87B4 /* BinaryFloatingPointExtensions.swift in Sources */,
 				9D806A632258D503008E500A /* SCNPlaneExtensions.swift in Sources */,
@@ -2059,6 +2073,7 @@
 				07C50D3D1F5EB04700F46E5A /* UITextFieldExtensionsTests.swift in Sources */,
 				07C50D641F5EB05000F46E5A /* URLExtensionsTests.swift in Sources */,
 				734307FB2108C85B0029CD16 /* CGVectorExtensionsTests.swift in Sources */,
+				9DC29CF42349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */,
 				07C50D2B1F5EB04600F46E5A /* UIAlertControllerExtensionsTests.swift in Sources */,
 				9D806A7E2258F41B008E500A /* SCNMaterialExtensionsTests.swift in Sources */,
 				9D806A8F2258FAA0008E500A /* SCNCapsuleExtensionsTests.swift in Sources */,
@@ -2112,6 +2127,7 @@
 				07C50D4D1F5EB04700F46E5A /* UISegmentedControlExtensionsTests.swift in Sources */,
 				07C50D891F5EB06000F46E5A /* CGSizeExtensionsTests.swift in Sources */,
 				9D806A982258FD81008E500A /* SCNCylinderExtensionsTests.swift in Sources */,
+				9DC29CF52349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */,
 				07C50D661F5EB05100F46E5A /* BoolExtensionsTests.swift in Sources */,
 				07FE50461F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */,
 				07C50D4F1F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */; };
 		42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */; };
 		42F53FF02039C7140070DC11 /* UIStackViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTests.swift */; };
+		5C88FBEC234CC1280065A942 /* NSColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C88FBEB234CC1280065A942 /* NSColorExtensionsTests.swift */; };
 		664CB96D2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */; };
 		664CB96E2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */; };
 		664CB96F2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */; };
@@ -681,6 +682,7 @@
 		278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImageExtensionsTests.swift; sourceTree = "<group>"; };
 		42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensions.swift; sourceTree = "<group>"; };
 		42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTests.swift; sourceTree = "<group>"; };
+		5C88FBEB234CC1280065A942 /* NSColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSColorExtensionsTests.swift; sourceTree = "<group>"; };
 		664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BidirectionalCollectionExtensions.swift; sourceTree = "<group>"; };
 		664CB971217186E900FC87B4 /* BidirectionalCollectionExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BidirectionalCollectionExtensionsTests.swift; sourceTree = "<group>"; };
 		664CB9752171899800FC87B4 /* BinaryFloatingPointExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryFloatingPointExtensions.swift; sourceTree = "<group>"; };
@@ -1076,8 +1078,9 @@
 		07C50D241F5EB03200F46E5A /* AppKitTests */ = {
 			isa = PBXGroup;
 			children = (
-				07C50D2A1F5EB03200F46E5A /* NSViewExtensionsTests.swift */,
+				5C88FBEB234CC1280065A942 /* NSColorExtensionsTests.swift */,
 				278CA0901F9A9679004918BD /* NSImageExtensionsTests.swift */,
+				07C50D2A1F5EB03200F46E5A /* NSViewExtensionsTests.swift */,
 			);
 			path = AppKitTests;
 			sourceTree = "<group>";
@@ -2185,6 +2188,7 @@
 				07C50D731F5EB05100F46E5A /* ArrayExtensionsTests.swift in Sources */,
 				664CB97D21718B1D00FC87B4 /* BinaryFloatingPointExtensionsTests.swift in Sources */,
 				07C50D7E1F5EB05100F46E5A /* OptionalExtensionsTests.swift in Sources */,
+				5C88FBEC234CC1280065A942 /* NSColorExtensionsTests.swift in Sources */,
 				9D9784E61FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
 				07C50D761F5EB05100F46E5A /* CollectionExtensionsTests.swift in Sources */,
 				07C50D841F5EB05800F46E5A /* CLLocationExtensionsTests.swift in Sources */,

--- a/Tests/AppKitTests/NSColorExtensionsTests.swift
+++ b/Tests/AppKitTests/NSColorExtensionsTests.swift
@@ -1,0 +1,33 @@
+//
+//  UIColorExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Max Haertwig on 10/08/19.
+//  Copyright © 2019 SwifterSwift
+//
+
+import Foundation
+
+import XCTest
+@testable import SwifterSwift
+
+final class NSColorExtensionsTests: XCTestCase {
+    
+    @available(OSX 10.15, *)
+    func testInitLightDark() {
+        let lightModeColor = NSColor.red
+        let darkModeColor = NSColor.blue
+        let color = NSColor(light: lightModeColor, dark: darkModeColor)
+        
+        let view = NSView()
+        
+        NSAppearance.current = NSAppearance(named: .aqua)
+        view.backgroundColor = color
+        XCTAssertEqual(view.backgroundColor, lightModeColor)
+
+        NSAppearance.current = NSAppearance(named: .darkAqua)
+        view.backgroundColor = color
+        XCTAssertEqual(view.backgroundColor, darkModeColor)
+    }
+    
+}

--- a/Tests/AppKitTests/NSColorExtensionsTests.swift
+++ b/Tests/AppKitTests/NSColorExtensionsTests.swift
@@ -6,21 +6,22 @@
 //  Copyright © 2019 SwifterSwift
 //
 
-import Foundation
-
 import XCTest
 @testable import SwifterSwift
 
+#if canImport(Cocoa)
+import Cocoa
+
 final class NSColorExtensionsTests: XCTestCase {
-    
+
     @available(OSX 10.15, *)
     func testInitLightDark() {
         let lightModeColor = NSColor.red
         let darkModeColor = NSColor.blue
         let color = NSColor(light: lightModeColor, dark: darkModeColor)
-        
+
         let view = NSView()
-        
+
         NSAppearance.current = NSAppearance(named: .aqua)
         view.backgroundColor = color
         XCTAssertEqual(view.backgroundColor, lightModeColor)
@@ -29,5 +30,7 @@ final class NSColorExtensionsTests: XCTestCase {
         view.backgroundColor = color
         XCTAssertEqual(view.backgroundColor, darkModeColor)
     }
-    
+
 }
+
+#endif

--- a/Tests/AppKitTests/NSColorExtensionsTests.swift
+++ b/Tests/AppKitTests/NSColorExtensionsTests.swift
@@ -14,21 +14,22 @@ import Cocoa
 
 final class NSColorExtensionsTests: XCTestCase {
 
-    @available(OSX 10.15, *)
     func testInitLightDark() {
-        let lightModeColor = NSColor.red
-        let darkModeColor = NSColor.blue
-        let color = NSColor(light: lightModeColor, dark: darkModeColor)
+        if #available(OSX 10.15, *) {
+            let lightModeColor = NSColor.red
+            let darkModeColor = NSColor.blue
+            let color = NSColor(light: lightModeColor, dark: darkModeColor)
 
-        let view = NSView()
+            let view = NSView()
 
-        NSAppearance.current = NSAppearance(named: .aqua)
-        view.backgroundColor = color
-        XCTAssertEqual(view.backgroundColor, lightModeColor)
+            NSAppearance.current = NSAppearance(named: .aqua)
+            view.backgroundColor = color
+            XCTAssertEqual(view.backgroundColor, lightModeColor)
 
-        NSAppearance.current = NSAppearance(named: .darkAqua)
-        view.backgroundColor = color
-        XCTAssertEqual(view.backgroundColor, darkModeColor)
+            NSAppearance.current = NSAppearance(named: .darkAqua)
+            view.backgroundColor = color
+            XCTAssertEqual(view.backgroundColor, darkModeColor)
+        }
     }
 
 }

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 @testable import SwifterSwift
 
+#if canImport(UIKit)
+import UIKit
+
 final class UIColorExtensionsTests: XCTestCase {
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -21,3 +24,5 @@ final class UIColorExtensionsTests: XCTestCase {
     }
 
 }
+
+#endif

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -1,0 +1,23 @@
+//
+//  UIColorExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Max Haertwig on 10/06/19.
+//  Copyright © 2019 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+final class UIColorExtensionsTests: XCTestCase {
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testInitLightDark() {
+        let lightModeColor = UIColor.red
+        let darkModeColor = UIColor.blue
+        let color = UIColor(light: lightModeColor, dark: darkModeColor)
+        XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
+        XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), darkModeColor)
+    }
+
+}


### PR DESCRIPTION
This extension allows to create an NSColor or UIColor with different colors for light mode and dark mode. I created separate `NSColorExtensions.swift` and `UIColorExtensions.swift` files, because NSColor and UIColor use different APIs for this problem and can't be unified.

I couldn't figure out how to create a test for macOS, because it uses NSAppearance instead of UITraitCollection. Any suggestions?

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
