### PR TITLE
Ns regular expression extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **String**:
-    - Added `withPrefix(_:)`, which provides a method to add a prefix to a string. If the string already has that prefix, it simply returns the original string. [#720](https://github.com/SwifterSwift/SwifterSwift/pull/720) by [Zach Frew](https://github.com/zmfrew).
+  - Added `withPrefix(_:)`, which provides a method to add a prefix to a string. If the string already has that prefix, it simply returns the original string. [#720](https://github.com/SwifterSwift/SwifterSwift/pull/720) by [Zach Frew](https://github.com/zmfrew).
+- **NSRegularExpression**:
+  - Added `enumerateMatches(in:options:range:using:)`, `matches(in:options:range:)`, `numberOfMatches(in:options:range:)`, `firstMatch(in:options:range:)`, `rangeOfFirstMatch(in:options:range:)`, `stringByReplacingMatches(in:options:range:withTemplate:)`, `replaceMatches(in:options:range:withTemplate:)`, which use `String` and `String.Range` in place of `NSString` and `NSRange` to make the calls Swifter. [#???](https://github.com/SwifterSwift/SwifterSwift/pull/???) by [guykogus](https://github.com/guykogus).
 - **UIImage**:
-    - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
+  - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
 
 ### Changed
 

--- a/Sources/SwifterSwift/Foundation/NSRegularExpressionExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSRegularExpressionExtensions.swift
@@ -1,0 +1,144 @@
+//
+//  NSRegularExpressionExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 09/10/2019.
+//  Copyright © 2019 SwifterSwift
+//
+
+#if canImport(Foundation)
+import Foundation
+
+public extension NSRegularExpression {
+    /// Enumerates the string allowing the Block to handle each regular expression match.
+    ///
+    /// - Parameters:
+    ///   - string: The string.
+    ///   - options: The matching options to report. See `NSRegularExpression.MatchingOptions` for the supported values.
+    ///   - range: The range of the string to test.
+    ///   - block: The Block enumerates the matches of the regular expression in the string.
+    ///     The block takes three arguments and returns `Void`:
+    ///   - result:
+    ///     An `NSTextCheckingResult` specifying the match. This result gives the overall matched range via its `range` property, and the range of each individual capture group via its `range(at:)` method. The range {NSNotFound, 0} is returned if one of the capture groups did not participate in this particular match.
+    ///   - flags:
+    ///     The current state of the matching progress. See `NSRegularExpression.MatchingFlags` for the possible values.
+    ///   - stop:
+    ///     A reference to a Boolean value. The Block can set the value to true to stop further processing of the array. The stop argument is an out-only argument. You should only ever set this Boolean to true within the Block.
+    func enumerateMatches(in string: String,
+                          options: MatchingOptions = [],
+                          range: Range<String.Index>,
+                          using block: (_ result: NSTextCheckingResult?, _ flags: MatchingFlags, _ stop: inout Bool) -> Void) {
+        enumerateMatches(in: string,
+                         options: options,
+                         range: NSRange(range, in: string)) { result, flags, stop in
+                            var shouldStop = false
+                            block(result, flags, &shouldStop)
+                            if shouldStop {
+                                stop.pointee = true
+                            }
+        }
+    }
+
+    /// Returns an array containing all the matches of the regular expression in the string.
+    ///
+    /// - Parameters:
+    ///   - string: The string to search.
+    ///   - options: The matching options to use. See NSRegularExpression.MatchingOptions for possible values.
+    ///   - range: The range of the string to search.
+    /// - Returns: An array of `NSTextCheckingResult` objects. Each result gives the overall matched range via its `range` property, and the range of each individual capture group via its `range(at:)` method. The range {NSNotFound, 0} is returned if one of the capture groups did not participate in this particular match.
+    func matches(in string: String,
+                 options: MatchingOptions = [],
+                 range: Range<String.Index>) -> [NSTextCheckingResult] {
+        return matches(in: string,
+                       options: options,
+                       range: NSRange(range, in: string))
+    }
+
+    /// Returns the number of matches of the regular expression within the specified range of the string.
+    ///
+    /// - Parameters:
+    ///   - string: The string to search.
+    ///   - options: The matching options to use. See NSRegularExpression.MatchingOptions for possible values.
+    ///   - range: The range of the string to search.
+    /// - Returns: The number of matches of the regular expression.
+    func numberOfMatches(in string: String,
+                         options: MatchingOptions = [],
+                         range: Range<String.Index>) -> Int {
+        return numberOfMatches(in: string,
+                               options: options,
+                               range: NSRange(range, in: string))
+    }
+
+    /// Returns the first match of the regular expression within the specified range of the string.
+    ///
+    /// - Parameters:
+    ///   - string: The string to search.
+    ///   - options: The matching options to use. See `NSRegularExpression.MatchingOptions` for possible values.
+    ///   - range: The range of the string to search.
+    /// - Returns: An `NSTextCheckingResult` object. This result gives the overall matched range via its `range` property, and the range of each individual capture group via its `range(at:)` method. The range {NSNotFound, 0} is returned if one of the capture groups did not participate in this particular match.
+    func firstMatch(in string: String,
+                    options: MatchingOptions = [],
+                    range: Range<String.Index>) -> NSTextCheckingResult? {
+        return firstMatch(in: string,
+                          options: options,
+                          range: NSRange(range, in: string))
+    }
+
+    /// Returns the range of the first match of the regular expression within the specified range of the string.
+    ///
+    /// - Parameters:
+    ///   - string: The string to search.
+    ///   - options: The matching options to use. See `NSRegularExpression.MatchingOptions` for possible values.
+    ///   - range: The range of the string to search.
+    /// - Returns: The range of the first match. Returns `nil` if no match is found.
+    func rangeOfFirstMatch(in string: String,
+                           options: MatchingOptions = [],
+                           range: Range<String.Index>) -> Range<String.Index>? {
+        return Range(rangeOfFirstMatch(in: string,
+                                       options: options,
+                                       range: NSRange(range, in: string)),
+                     in: string)
+    }
+
+    /// Returns a new string containing matching regular expressions replaced with the template string.
+    ///
+    /// - Parameters:
+    ///   - string: The string to search for values within.
+    ///   - options: The matching options to use. See `NSRegularExpression.MatchingOptions` for possible values.
+    ///   - range: The range of the string to search.
+    ///   - templ: The substitution template used when replacing matching instances.
+    /// - Returns: A string with matching regular expressions replaced by the template string.
+    func stringByReplacingMatches(in string: String,
+                                  options: MatchingOptions = [],
+                                  range: Range<String.Index>,
+                                  withTemplate templ: String) -> String {
+        return stringByReplacingMatches(in: string,
+                                        options: options,
+                                        range: NSRange(range, in: string),
+                                        withTemplate: templ)
+    }
+
+    /// Replaces regular expression matches within the mutable string using the template string.
+    ///
+    /// - Parameters:
+    ///   - string: The mutable string to search and replace values within.
+    ///   - options: The matching options to use. See `NSRegularExpression.MatchingOptions` for possible values.
+    ///   - range: The range of the string to search.
+    ///   - templ: The substitution template used when replacing matching instances.
+    /// - Returns: The number of matches.
+    @discardableResult
+    func replaceMatches(in string: inout String,
+                        options: MatchingOptions = [],
+                        range: Range<String.Index>,
+                        withTemplate templ: String) -> Int {
+        let mutableString = NSMutableString(string: string)
+        let matches = replaceMatches(in: mutableString,
+                                     options: options,
+                                     range: NSRange(range, in: string),
+                                     withTemplate: templ)
+        string = mutableString.copy() as! String // swiftlint:disable:this force_cast
+        return matches
+    }
+}
+
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -529,6 +529,13 @@
 		CAC5EBD02125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
 		CAC5EBD12125273100AB27EC /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = CAC5EBBF2125270A00AB27EC /* TestImage.png */; };
 		CF30948A216AAC7A005609BC /* UIActivityExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF309489216AAC7A005609BC /* UIActivityExtensions.swift */; };
+		F8C1AE6F225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
+		F8C1AE70225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
+		F8C1AE71225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
+		F8C1AE72225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
+		F8C1AE74225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */; };
+		F8C1AE75225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */; };
+		F8C1AE76225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -746,6 +753,8 @@
 		CAC5EBC42125270A00AB27EC /* UITableViewHeaderFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UITableViewHeaderFooterView.xib; sourceTree = "<group>"; };
 		CAC5EBC52125270A00AB27EC /* big_buck_bunny_720p_1mb.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = big_buck_bunny_720p_1mb.mp4; sourceTree = "<group>"; };
 		CF309489216AAC7A005609BC /* UIActivityExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityExtensions.swift; sourceTree = "<group>"; };
+		F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRegularExpressionExtensions.swift; sourceTree = "<group>"; };
+		F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRegularExpressionExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -940,6 +949,7 @@
 				07B7F1731F5EB41600E6F910 /* LocaleExtensions.swift */,
 				07B7F1621F5EB41600E6F910 /* NSAttributedStringExtensions.swift */,
 				9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */,
+				F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */,
 				07B7F1781F5EB41600E6F910 /* URLExtensions.swift */,
 				077BA0891F6BE81F00D9C4AC /* URLRequestExtensions.swift */,
 				077BA08E1F6BE83600D9C4AC /* UserDefaultsExtensions.swift */,
@@ -1017,6 +1027,7 @@
 				07C50D041F5EB03200F46E5A /* LocaleExtensionsTests.swift */,
 				07C50D291F5EB03200F46E5A /* NSAttributedStringExtensionsTests.swift */,
 				9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */,
+				F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */,
 				07C50D071F5EB03200F46E5A /* URLExtensionsTests.swift */,
 				077BA0941F6BE98500D9C4AC /* URLRequestExtensionsTests.swift */,
 				077BA0991F6BE99F00D9C4AC /* UserDefaultsExtensionsTests.swift */,
@@ -1743,6 +1754,7 @@
 				07B7F22E1F5EB45100E6F910 /* CGColorExtensions.swift in Sources */,
 				70269A2B1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */,
 				07B7F2161F5EB43C00E6F910 /* LocaleExtensions.swift in Sources */,
+				F8C1AE6F225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				9D806A6F2258DE23008E500A /* SCNCylinderExtensions.swift in Sources */,
 				9D806A362258AC0D008E500A /* UIBezierPathExtensions.swift in Sources */,
 				07B7F2101F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
@@ -1805,6 +1817,7 @@
 				074C8D82224F86450050F040 /* MKMapViewExtensions.swift in Sources */,
 				07B7F1B11F5EB42000E6F910 /* UINavigationControllerExtensions.swift in Sources */,
 				07B7F1B51F5EB42000E6F910 /* UISliderExtensions.swift in Sources */,
+				F8C1AE70225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				07B7F1A91F5EB42000E6F910 /* UIBarButtonItemExtensions.swift in Sources */,
 				07B7F1B81F5EB42000E6F910 /* UITabBarExtensions.swift in Sources */,
 				664CB96E2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */,
@@ -1922,6 +1935,7 @@
 				664CB96F2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */,
 				07B7F1C81F5EB42200E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				07B7F1D11F5EB42200E6F910 /* UITextViewExtensions.swift in Sources */,
+				F8C1AE71225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				B29527AF20F99F9900E1F75D /* RandomAccessCollectionExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1976,6 +1990,7 @@
 				B29527B020F99F9A00E1F75D /* RandomAccessCollectionExtensions.swift in Sources */,
 				07B7F1D51F5EB43B00E6F910 /* ArrayExtensions.swift in Sources */,
 				7832C2B2209BB19300224EED /* ComparableExtensions.swift in Sources */,
+				F8C1AE72225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				B2A0DAC32336DA87002B0BC5 /* MutableCollectionExtensions.swift in Sources */,
 				664CB986217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */,
 				9D806A892258F624008E500A /* SCNGeometryExtensions.swift in Sources */,
@@ -2043,6 +2058,7 @@
 				07C50D3A1F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */,
 				07C50D341F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */,
 				752AC7A520BC9FF500659E76 /* SpriteKitTests.swift in Sources */,
+				F8C1AE74225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
 				07C50D5A1F5EB05000F46E5A /* CollectionExtensionsTests.swift in Sources */,
 				076AEC8D1FDB49480077D153 /* UIDatePickerExtensionsTests.swift in Sources */,
 				07C50D351F5EB04700F46E5A /* UINavigationItemExtensionsTests.swift in Sources */,
@@ -2093,6 +2109,7 @@
 				07C50D441F5EB04700F46E5A /* UICollectionViewExtensionsTests.swift in Sources */,
 				07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
 				078916DB2076077000AC0665 /* FloatingPointExtensionsTests.swift in Sources */,
+				F8C1AE75225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
 				07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
 				07C50D451F5EB04700F46E5A /* ColorExtensionsTests.swift in Sources */,
 				784C75382051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
@@ -2178,6 +2195,7 @@
 				07C50D861F5EB05800F46E5A /* NSViewExtensionsTests.swift in Sources */,
 				07C50D851F5EB05800F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07C50D7C1F5EB05100F46E5A /* IntExtensionsTests.swift in Sources */,
+				F8C1AE76225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
 				07C50D791F5EB05100F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D7B1F5EB05100F46E5A /* FloatExtensionsTests.swift in Sources */,
 				07C50D7F1F5EB05100F46E5A /* StringExtensionsTests.swift in Sources */,

--- a/Tests/FoundationTests/NSRegularExpressionExtensionsTests.swift
+++ b/Tests/FoundationTests/NSRegularExpressionExtensionsTests.swift
@@ -1,0 +1,99 @@
+//
+//  NSRegularExpressionExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 09/10/2019.
+//  Copyright © 2019 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if canImport(Foundation)
+import Foundation
+
+final class NSRegularExpressionExtensionsTests: XCTestCase {
+    private let string = "bar foo bar foo bar"
+    private let searchString = "bar"
+    private let expectedMatches = 3
+    private lazy var regularExpression = try! NSRegularExpression(pattern: searchString) // swiftlint:disable:this force_try
+
+    func testEnumerateMatches() {
+        var count = 0
+        regularExpression.enumerateMatches(in: string,
+                                           options: [],
+                                           range: string.startIndex..<string.endIndex) { (result, _, _) in
+                                            XCTAssertEqual(String(string[Range(result!.range, in: string)!]), searchString)
+                                            count += 1
+        }
+        XCTAssertEqual(count, expectedMatches)
+
+        count = 0
+        let max = 2 // must be less than expectedMatches
+        regularExpression.enumerateMatches(in: string,
+                                           options: [],
+                                           range: string.startIndex..<string.endIndex) { (result, _, stop) in
+                                            XCTAssertEqual(String(string[Range(result!.range, in: string)!]), searchString)
+                                            count += 1
+                                            stop = count >= max
+        }
+        XCTAssertEqual(count, max)
+    }
+
+    func testMatches() {
+        let matches = regularExpression.matches(in: string,
+                                                options: [],
+                                                range: string.startIndex..<string.endIndex)
+        XCTAssertEqual(matches.count, expectedMatches)
+        for match in matches {
+            XCTAssertEqual(String(string[Range(match.range, in: string)!]), searchString)
+        }
+    }
+
+    func testNumberOfMatches() {
+        XCTAssertEqual(regularExpression.numberOfMatches(in: string,
+                                                         options: [],
+                                                         range: string.startIndex..<string.endIndex),
+                       expectedMatches)
+    }
+
+    func testFirstMatch() {
+        let firstMatch = regularExpression.firstMatch(in: string,
+                                                      options: [],
+                                                      range: string.startIndex..<string.endIndex)
+        XCTAssertNotNil(firstMatch)
+        XCTAssertEqual(firstMatch?.range.location, 0)
+        XCTAssertEqual(String(string[Range(firstMatch!.range, in: string)!]), searchString)
+    }
+
+    func testRangeOfFirstMatch() {
+        let range = regularExpression.rangeOfFirstMatch(in: string,
+                                                        options: [],
+                                                        range: string.startIndex..<string.endIndex)
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range?.lowerBound, string.startIndex)
+        XCTAssertEqual(range?.upperBound, string.index(string.startIndex, offsetBy: searchString.count))
+        XCTAssertEqual(String(string[range!]), searchString)
+    }
+
+    func testStringByReplacingMatches() {
+        let newString = regularExpression.stringByReplacingMatches(in: string,
+                                                                   options: [],
+                                                                   range: string.startIndex..<string.endIndex,
+                                                                   withTemplate: "$0$0")
+        XCTAssertEqual(newString, "barbar foo barbar foo barbar")
+    }
+
+    func testReplaceMatches() {
+        var newString = string
+        let matches = regularExpression.replaceMatches(in: &newString,
+                                                       options: [],
+                                                       range: string.startIndex..<string.endIndex,
+                                                       withTemplate: "$0$0")
+        XCTAssertEqual(newString, "barbar foo barbar foo barbar")
+        XCTAssertEqual(matches, expectedMatches)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
🚀
No more using `NSString`, `NSRange` and `UnsafeMutablePointer<ObjCBool>` with `NSRegularExpression` calls.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
