### PR TITLE
🚀 UIGraphicsImageRenderer in filled(withColor:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `enumerateMatches(in:options:range:using:)`, `matches(in:options:range:)`, `numberOfMatches(in:options:range:)`, `firstMatch(in:options:range:)`, `rangeOfFirstMatch(in:options:range:)`, `stringByReplacingMatches(in:options:range:withTemplate:)`, `replaceMatches(in:options:range:withTemplate:)`, which use `String` and `String.Range` in place of `NSString` and `NSRange` to make the calls Swifter. [#727](https://github.com/SwifterSwift/SwifterSwift/pull/727) by [guykogus](https://github.com/guykogus).
 - **UIImage**:
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
-  - Implemented `filled(withColor:)` using `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
 
 ### Changed
+- **UIImage**:
+  - Implemented `filled(withColor:)` using `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `enumerateMatches(in:options:range:using:)`, `matches(in:options:range:)`, `numberOfMatches(in:options:range:)`, `firstMatch(in:options:range:)`, `rangeOfFirstMatch(in:options:range:)`, `stringByReplacingMatches(in:options:range:withTemplate:)`, `replaceMatches(in:options:range:withTemplate:)`, which use `String` and `String.Range` in place of `NSString` and `NSRange` to make the calls Swifter. [#727](https://github.com/SwifterSwift/SwifterSwift/pull/727) by [guykogus](https://github.com/guykogus).
 - **UIImage**:
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
-  - Dropped watchOS support for `filled(withColor:)` in favor of using an implementation based on `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
+  - Implemented `filled(withColor:)` using `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `enumerateMatches(in:options:range:using:)`, `matches(in:options:range:)`, `numberOfMatches(in:options:range:)`, `firstMatch(in:options:range:)`, `rangeOfFirstMatch(in:options:range:)`, `stringByReplacingMatches(in:options:range:withTemplate:)`, `replaceMatches(in:options:range:withTemplate:)`, which use `String` and `String.Range` in place of `NSString` and `NSRange` to make the calls Swifter. [#727](https://github.com/SwifterSwift/SwifterSwift/pull/727) by [guykogus](https://github.com/guykogus).
 - **UIImage**:
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
+  - Dropped watchOS support for `filled(withColor:)` in favor of using an implementation based on `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
 
 ### Changed
 

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -159,6 +159,7 @@ public extension UIImage {
         return newImage
     }
 
+    #if !os(watchOS)
     /// SwifterSwift: UIImage filled with color
     ///
     /// - Parameter color: color to fill image with.
@@ -191,6 +192,7 @@ public extension UIImage {
             return newImage
         }
     }
+    #endif
 
     /// SwifterSwift: UIImage tinted with color
     ///

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -170,7 +170,7 @@ public extension UIImage {
             let format = UIGraphicsImageRendererFormat()
             format.scale = scale
             let renderer = UIGraphicsImageRenderer(size: size, format: format)
-            return renderer.image { (context) in
+            return renderer.image { context in
                 color.setFill()
                 context.fill(CGRect(origin: .zero, size: size))
             }

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -159,12 +159,13 @@ public extension UIImage {
         return newImage
     }
 
-    #if !os(watchOS)
     /// SwifterSwift: UIImage filled with color
     ///
     /// - Parameter color: color to fill image with.
     /// - Returns: UIImage filled with given color.
     func filled(withColor color: UIColor) -> UIImage {
+
+        #if !os(watchOS)
         if #available(iOS 10, tvOS 10, *) {
             let format = UIGraphicsImageRendererFormat()
             format.scale = scale
@@ -173,26 +174,26 @@ public extension UIImage {
                 color.setFill()
                 context.fill(CGRect(origin: .zero, size: size))
             }
-        } else {
-            UIGraphicsBeginImageContextWithOptions(size, false, scale)
-            color.setFill()
-            guard let context = UIGraphicsGetCurrentContext() else { return self }
-
-            context.translateBy(x: 0, y: size.height)
-            context.scaleBy(x: 1.0, y: -1.0)
-            context.setBlendMode(CGBlendMode.normal)
-
-            let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-            guard let mask = cgImage else { return self }
-            context.clip(to: rect, mask: mask)
-            context.fill(rect)
-
-            let newImage = UIGraphicsGetImageFromCurrentImageContext()!
-            UIGraphicsEndImageContext()
-            return newImage
         }
+        #endif
+
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        color.setFill()
+        guard let context = UIGraphicsGetCurrentContext() else { return self }
+
+        context.translateBy(x: 0, y: size.height)
+        context.scaleBy(x: 1.0, y: -1.0)
+        context.setBlendMode(CGBlendMode.normal)
+
+        let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+        guard let mask = cgImage else { return self }
+        context.clip(to: rect, mask: mask)
+        context.fill(rect)
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        return newImage
     }
-    #endif
 
     /// SwifterSwift: UIImage tinted with color
     ///

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -164,22 +164,32 @@ public extension UIImage {
     /// - Parameter color: color to fill image with.
     /// - Returns: UIImage filled with given color.
     func filled(withColor color: UIColor) -> UIImage {
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        color.setFill()
-        guard let context = UIGraphicsGetCurrentContext() else { return self }
+        if #available(iOS 10, tvOS 10, *) {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = scale
+            let renderer = UIGraphicsImageRenderer(size: size, format: format)
+            return renderer.image { (context) in
+                color.setFill()
+                context.fill(CGRect(origin: .zero, size: size))
+            }
+        } else {
+            UIGraphicsBeginImageContextWithOptions(size, false, scale)
+            color.setFill()
+            guard let context = UIGraphicsGetCurrentContext() else { return self }
 
-        context.translateBy(x: 0, y: size.height)
-        context.scaleBy(x: 1.0, y: -1.0)
-        context.setBlendMode(CGBlendMode.normal)
+            context.translateBy(x: 0, y: size.height)
+            context.scaleBy(x: 1.0, y: -1.0)
+            context.setBlendMode(CGBlendMode.normal)
 
-        let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        guard let mask = cgImage else { return self }
-        context.clip(to: rect, mask: mask)
-        context.fill(rect)
+            let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+            guard let mask = cgImage else { return self }
+            context.clip(to: rect, mask: mask)
+            context.fill(rect)
 
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()!
-        UIGraphicsEndImageContext()
-        return newImage
+            let newImage = UIGraphicsGetImageFromCurrentImageContext()!
+            UIGraphicsEndImageContext()
+            return newImage
+        }
     }
 
     /// SwifterSwift: UIImage tinted with color

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -241,7 +241,11 @@
 		07C50D491F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D161F5EB03200F46E5A /* UINavigationBarExtensionTests.swift */; };
 		07C50D4A1F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D171F5EB03200F46E5A /* UINavigationControllerExtensionsTests.swift */; };
 		07C50D4B1F5EB04700F46E5A /* UINavigationItemExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D181F5EB03200F46E5A /* UINavigationItemExtensionsTests.swift */; };
+		07C50D4C1F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D191F5EB03200F46E5A /* UISearchBarExtensionsTests.swift */; };
 		07C50D4D1F5EB04700F46E5A /* UISegmentedControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1A1F5EB03200F46E5A /* UISegmentedControlExtensionsTests.swift */; };
+		07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1B1F5EB03200F46E5A /* UISliderExtensionsTests.swift */; };
+		07C50D4F1F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1C1F5EB03200F46E5A /* UIStoryboardExtensionsTests.swift */; };
+		07C50D501F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1D1F5EB03200F46E5A /* UISwitchExtensionsTests.swift */; };
 		07C50D511F5EB04700F46E5A /* UITabBarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1E1F5EB03200F46E5A /* UITabBarExtensionsTests.swift */; };
 		07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1F1F5EB03200F46E5A /* UITableViewExtensionsTests.swift */; };
 		07C50D531F5EB04700F46E5A /* UITextFieldExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D201F5EB03200F46E5A /* UITextFieldExtensionsTests.swift */; };
@@ -2124,6 +2128,7 @@
 				07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
 				078916DB2076077000AC0665 /* FloatingPointExtensionsTests.swift in Sources */,
 				F8C1AE75225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
+				07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
 				07C50D451F5EB04700F46E5A /* ColorExtensionsTests.swift in Sources */,
 				784C75382051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
 				07C50D491F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */,
@@ -2145,9 +2150,11 @@
 				9DC29CF52349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */,
 				07C50D661F5EB05100F46E5A /* BoolExtensionsTests.swift in Sources */,
 				07FE50461F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */,
+				07C50D4F1F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */,
 				734307FD2108C85D0029CD16 /* CGVectorExtensionsTests.swift in Sources */,
 				9D806A7F2258F41B008E500A /* SCNMaterialExtensionsTests.swift in Sources */,
 				9D9784E51FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
+				07C50D4C1F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */,
 				8D4B4250212972E7002A5923 /* UILayoutPriorityExtensionsTests.swift in Sources */,
 				07C50D871F5EB06000F46E5A /* CGFloatExtensionsTests.swift in Sources */,
 				9D806AA42258FF98008E500A /* SCNPlaneExtensionsTests.swift in Sources */,
@@ -2156,6 +2163,7 @@
 				07C50D541F5EB04700F46E5A /* UITextViewExtensionsTests.swift in Sources */,
 				074EAF201F7BA74700C74636 /* UIFontExtensionsTests.swift in Sources */,
 				07C50D461F5EB04700F46E5A /* UIImageExtensionsTests.swift in Sources */,
+				07C50D501F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */,
 				07C50D4A1F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */,
 				9D806A3E2258AED4008E500A /* UIBezierPathExtensionsTests.swift in Sources */,
 				07C50D681F5EB05100F46E5A /* CollectionExtensionsTests.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -241,11 +241,7 @@
 		07C50D491F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D161F5EB03200F46E5A /* UINavigationBarExtensionTests.swift */; };
 		07C50D4A1F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D171F5EB03200F46E5A /* UINavigationControllerExtensionsTests.swift */; };
 		07C50D4B1F5EB04700F46E5A /* UINavigationItemExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D181F5EB03200F46E5A /* UINavigationItemExtensionsTests.swift */; };
-		07C50D4C1F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D191F5EB03200F46E5A /* UISearchBarExtensionsTests.swift */; };
 		07C50D4D1F5EB04700F46E5A /* UISegmentedControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1A1F5EB03200F46E5A /* UISegmentedControlExtensionsTests.swift */; };
-		07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1B1F5EB03200F46E5A /* UISliderExtensionsTests.swift */; };
-		07C50D4F1F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1C1F5EB03200F46E5A /* UIStoryboardExtensionsTests.swift */; };
-		07C50D501F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1D1F5EB03200F46E5A /* UISwitchExtensionsTests.swift */; };
 		07C50D511F5EB04700F46E5A /* UITabBarExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1E1F5EB03200F46E5A /* UITabBarExtensionsTests.swift */; };
 		07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D1F1F5EB03200F46E5A /* UITableViewExtensionsTests.swift */; };
 		07C50D531F5EB04700F46E5A /* UITextFieldExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C50D201F5EB03200F46E5A /* UITextFieldExtensionsTests.swift */; };
@@ -2128,7 +2124,6 @@
 				07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
 				078916DB2076077000AC0665 /* FloatingPointExtensionsTests.swift in Sources */,
 				F8C1AE75225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
-				07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
 				07C50D451F5EB04700F46E5A /* ColorExtensionsTests.swift in Sources */,
 				784C75382051BE1D001C48DD /* MKPolylineTests.swift in Sources */,
 				07C50D491F5EB04700F46E5A /* UINavigationBarExtensionTests.swift in Sources */,
@@ -2150,11 +2145,9 @@
 				9DC29CF52349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */,
 				07C50D661F5EB05100F46E5A /* BoolExtensionsTests.swift in Sources */,
 				07FE50461F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */,
-				07C50D4F1F5EB04700F46E5A /* UIStoryboardExtensionsTests.swift in Sources */,
 				734307FD2108C85D0029CD16 /* CGVectorExtensionsTests.swift in Sources */,
 				9D806A7F2258F41B008E500A /* SCNMaterialExtensionsTests.swift in Sources */,
 				9D9784E51FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
-				07C50D4C1F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */,
 				8D4B4250212972E7002A5923 /* UILayoutPriorityExtensionsTests.swift in Sources */,
 				07C50D871F5EB06000F46E5A /* CGFloatExtensionsTests.swift in Sources */,
 				9D806AA42258FF98008E500A /* SCNPlaneExtensionsTests.swift in Sources */,
@@ -2163,7 +2156,6 @@
 				07C50D541F5EB04700F46E5A /* UITextViewExtensionsTests.swift in Sources */,
 				074EAF201F7BA74700C74636 /* UIFontExtensionsTests.swift in Sources */,
 				07C50D461F5EB04700F46E5A /* UIImageExtensionsTests.swift in Sources */,
-				07C50D501F5EB04700F46E5A /* UISwitchExtensionsTests.swift in Sources */,
 				07C50D4A1F5EB04700F46E5A /* UINavigationControllerExtensionsTests.swift in Sources */,
 				9D806A3E2258AED4008E500A /* UIBezierPathExtensionsTests.swift in Sources */,
 				07C50D681F5EB05100F46E5A /* CollectionExtensionsTests.swift in Sources */,


### PR DESCRIPTION
🚀 This provides a fix for Issue #732. In iOS/tvOS 10, Apple introduced the [UIGraphicsImageRenderer API](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer), which effectively replaces the older `UIGraphicsImageContext` method this method was using before

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

I didn't add any new extensions in this PR. I changed the internals of one to use a newer API, but everything looks exactly the same to a consumer of the method, and all the pre-existing tests pass. Do I need to check any of the other boxes?