### PR TITLE
Improve UIImage.tint(color:blendMode:) using UIGraphicsImageRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Changed
 
+- **UIImage**:
+  - Refactored `tint(_:blendMode:)` using UIGraphicsImageRenderer if available. [#731](https://github.com/SwifterSwift/SwifterSwift/pull/731) by [FraDeliro](https://github.com/FraDeliro).
+
 ### Deprecated
 
 ### Removed
+
+- **UIImage**:
+  - Removed watchOS support for `tint(_:blendMode:)` because UIGraphicsImageRenderer is not available. [#731](https://github.com/SwifterSwift/SwifterSwift/pull/731) by [FraDeliro](https://github.com/FraDeliro).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Removed
 
-- **UIImage**:
-  - Removed watchOS support for `tint(_:blendMode:)` because UIGraphicsImageRenderer is not available. [#731](https://github.com/SwifterSwift/SwifterSwift/pull/731) by [FraDeliro](https://github.com/FraDeliro).
-
 ### Fixed
 
 ### Security

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -195,7 +195,6 @@ public extension UIImage {
         return newImage
     }
 
-    #if !os(watchOS)
     /// SwifterSwift: UIImage tinted with color
     ///
     /// - Parameters:
@@ -204,6 +203,8 @@ public extension UIImage {
     /// - Returns: UIImage tinted with given color.
     func tint(_ color: UIColor, blendMode: CGBlendMode, alpha: CGFloat = 1.0) -> UIImage {
         let drawRect = CGRect(origin: .zero, size: size)
+
+        #if !os(watchOS)
         if #available(iOS 10.0, tvOS 10.0, *) {
             let format = UIGraphicsImageRendererFormat()
             format.scale = scale
@@ -213,6 +214,7 @@ public extension UIImage {
                 draw(in: drawRect, blendMode: blendMode, alpha: alpha)
             }
         }
+        #endif
 
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
         defer {
@@ -231,6 +233,8 @@ public extension UIImage {
     ///   - backgroundColor: Color to use as background color
     /// - Returns: UIImage with a background color that is visible where alpha < 1
     func withBackgroundColor(_ backgroundColor: UIColor) -> UIImage {
+
+        #if !os(watchOS)
         if #available(iOS 10.0, tvOS 10.0, *) {
             let format = UIGraphicsImageRendererFormat()
             format.scale = scale
@@ -240,6 +244,7 @@ public extension UIImage {
                 draw(at: .zero)
             }
         }
+        #endif
 
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
         defer { UIGraphicsEndImageContext() }
@@ -250,7 +255,6 @@ public extension UIImage {
 
         return UIGraphicsGetImageFromCurrentImageContext()!
     }
-    #endif
 
     /// SwifterSwift: UIImage with rounded corners
     ///

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -189,19 +189,15 @@ public extension UIImage {
     ///   - color: color to tint image with.
     ///   - blendMode: how to blend the tint
     /// - Returns: UIImage tinted with given color.
-    func tint(_ color: UIColor, blendMode: CGBlendMode) -> UIImage {
+    func tint(_ color: UIColor, blendMode: CGBlendMode, alpha: CGFloat = 1.0) -> UIImage {
         let drawRect = CGRect(origin: .zero, size: size)
         if #available(iOS 10.0, tvOS 10.0, *) {
             let format = UIGraphicsImageRendererFormat()
             format.scale = scale
-            let renderer = UIGraphicsImageRenderer(
-                size: size,
-                format: format
-            )
-            return renderer.image { context in
+            return UIGraphicsImageRenderer(size: size, format: format).image { context in
                 color.setFill()
                 context.fill(drawRect)
-                draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
+                draw(in: drawRect, blendMode: blendMode, alpha: alpha)
             }
         } else {
             UIGraphicsBeginImageContextWithOptions(size, false, scale)
@@ -211,7 +207,7 @@ public extension UIImage {
             let context = UIGraphicsGetCurrentContext()
             color.setFill()
             context?.fill(drawRect)
-            draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
+            draw(in: drawRect, blendMode: blendMode, alpha: alpha)
             return UIGraphicsGetImageFromCurrentImageContext()!
         }
     }

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -182,6 +182,7 @@ public extension UIImage {
         return newImage
     }
 
+    #if !os(watchOS)
     /// SwifterSwift: UIImage tinted with color
     ///
     /// - Parameters:
@@ -215,7 +216,6 @@ public extension UIImage {
         }
     }
 
-    #if !os(watchOS)
     /// SwifterSwift: UImage with background color
     ///
     /// - Parameters:

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -189,16 +189,30 @@ public extension UIImage {
     ///   - blendMode: how to blend the tint
     /// - Returns: UIImage tinted with given color.
     func tint(_ color: UIColor, blendMode: CGBlendMode) -> UIImage {
-        let drawRect = CGRect(x: 0.0, y: 0.0, width: size.width, height: size.height)
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        defer {
-            UIGraphicsEndImageContext()
+        let drawRect = CGRect(origin: .zero, size: size)
+        if #available(iOS 10.0, tvOS 10.0, *) {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = scale
+            let renderer = UIGraphicsImageRenderer(
+                size: size,
+                format: format
+            )
+            return renderer.image { context in
+                color.setFill()
+                context.fill(drawRect)
+                draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
+            }
+        } else {
+            UIGraphicsBeginImageContextWithOptions(size, false, scale)
+            defer {
+                UIGraphicsEndImageContext()
+            }
+            let context = UIGraphicsGetCurrentContext()
+            color.setFill()
+            context?.fill(drawRect)
+            draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
+            return UIGraphicsGetImageFromCurrentImageContext()!
         }
-        let context = UIGraphicsGetCurrentContext()
-        color.setFill()
-        context?.fill(drawRect)
-        draw(in: drawRect, blendMode: blendMode, alpha: 1.0)
-        return UIGraphicsGetImageFromCurrentImageContext()!
     }
 
     #if !os(watchOS)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -212,17 +212,17 @@ public extension UIImage {
                 context.fill(drawRect)
                 draw(in: drawRect, blendMode: blendMode, alpha: alpha)
             }
-        } else {
-            UIGraphicsBeginImageContextWithOptions(size, false, scale)
-            defer {
-                UIGraphicsEndImageContext()
-            }
-            let context = UIGraphicsGetCurrentContext()
-            color.setFill()
-            context?.fill(drawRect)
-            draw(in: drawRect, blendMode: blendMode, alpha: alpha)
-            return UIGraphicsGetImageFromCurrentImageContext()!
         }
+
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        defer {
+            UIGraphicsEndImageContext()
+        }
+        let context = UIGraphicsGetCurrentContext()
+        color.setFill()
+        context?.fill(drawRect)
+        draw(in: drawRect, blendMode: blendMode, alpha: alpha)
+        return UIGraphicsGetImageFromCurrentImageContext()!
     }
 
     /// SwifterSwift: UImage with background color


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- This PR improve the UIImage.tint(color:blendMode:) function using UIGraphicsImageRenderer as specified in the #731 issue.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
