### PR TITLE
Add sum(for keyPath:) to Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **CAGradientLayer**:
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
 - **Sequence**:
-  - Added `sum(for:)` to sum up a Numeric property, referenced by KeyPath, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
+  - Added `sum(for:)` to sum up an `AdditiveArithmetic` property, referenced by `KeyPath`, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **CAGradientLayer**:
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
+- **Sequence**:
+  - Added `sum(for:)` to sum up a Numeric property, referenced by KeyPath, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
 
 ### Changed
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -203,17 +203,15 @@ public extension Sequence {
         return sorted { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
     }
 
-    /// SwifterSwift: Sum of a `Numeric` property of each `Element` in a `Sequence`.
+    /// SwifterSwift: Sum of a `AdditiveArithmetic` property of each `Element` in a `Sequence`.
     ///
     ///     ["James", "Wade", "Bryant"].sum(for: \.count) -> 15
     ///
-    /// - Parameter keyPath: Key path of the `Numeric` property.
-    /// - Returns: The sum of the `Numeric` propertys at `keyPath`.
-    func sum<T: Numeric>(for keyPath: KeyPath<Element, T>) -> T {
-        // Implementation from: https://swiftbysundell.com/articles/reducers-in-swift/
-        return reduce(0) { sum, element in
-            sum + element[keyPath: keyPath]
-        }
+    /// - Parameter keyPath: Key path of the `AdditiveArithmetic` property.
+    /// - Returns: The sum of the `AdditiveArithmetic` propertys at `keyPath`.
+    func sum<T: AdditiveArithmetic>(for keyPath: KeyPath<Element, T>) -> T {
+        // Inspired by: https://swiftbysundell.com/articles/reducers-in-swift/
+        return reduce(.zero) { $0 + $1[keyPath: keyPath] }
     }
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -202,6 +202,19 @@ public extension Sequence {
     func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
         return sorted { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
     }
+
+    /// SwifterSwift: Sum of a `Numeric` property of each `Element` in a `Sequence`.
+    ///
+    ///     ["James", "Wade", "Bryant"].sum(for: \.count) -> 15
+    ///
+    /// - Parameter keyPath: Key path of the `Numeric` property.
+    /// - Returns: The sum of the `Numeric` propertys at `keyPath`.
+    func sum<T: Numeric>(for keyPath: KeyPath<Element, T>) -> T {
+        // Implementation from: https://swiftbysundell.com/articles/reducers-in-swift/
+        return reduce(0) { sum, element in
+            sum + element[keyPath: keyPath]
+        }
+    }
 }
 
 public extension Sequence where Element: Equatable {

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -129,6 +129,11 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].sum(), 17)
     }
 
+    func testKeyPathSum() {
+        XCTAssertEqual(["James", "Wade", "Bryant"].sum(for: \.count), 15)
+        XCTAssertEqual(["a", "b", "c", "d"].sum(for: \.count), 4)
+    }
+
     func testKeyPathSorted() {
         let array = ["James", "Wade", "Bryant"]
         XCTAssertEqual(array.sorted(by: \String.count, with: <), ["Wade", "James", "Bryant"])


### PR DESCRIPTION
🚀 Sum up a Numeric property, referenced by KeyPath, of all elements in a sequence. Originally from https://swiftbysundell.com/articles/reducers-in-swift/.

Resolves #735 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
