### PR TITLE
adding base64 UIImage initialiser #741 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `enumerateMatches(in:options:range:using:)`, `matches(in:options:range:)`, `numberOfMatches(in:options:range:)`, `firstMatch(in:options:range:)`, `rangeOfFirstMatch(in:options:range:)`, `stringByReplacingMatches(in:options:range:withTemplate:)`, `replaceMatches(in:options:range:withTemplate:)`, which use `String` and `String.Range` in place of `NSString` and `NSRange` to make the calls Swifter. [#727](https://github.com/SwifterSwift/SwifterSwift/pull/727) by [guykogus](https://github.com/guykogus).
 - **UIImage**:
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
+  - Added `init?(base64String string: String)` to create an UIImage from a base64 String. [#741](https://github.com/SwifterSwift/SwifterSwift/issues/741) by [@thisIsTheFoxe](https://github.com/thisisthefoxe)
 - **CAGradientLayer**:
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
 - **Sequence**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `enumerateMatches(in:options:range:using:)`, `matches(in:options:range:)`, `numberOfMatches(in:options:range:)`, `firstMatch(in:options:range:)`, `rangeOfFirstMatch(in:options:range:)`, `stringByReplacingMatches(in:options:range:withTemplate:)`, `replaceMatches(in:options:range:withTemplate:)`, which use `String` and `String.Range` in place of `NSString` and `NSRange` to make the calls Swifter. [#727](https://github.com/SwifterSwift/SwifterSwift/pull/727) by [guykogus](https://github.com/guykogus).
 - **UIImage**:
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
-  - Added `init?(base64String string: String)` to create an UIImage from a base64 String. [#741](https://github.com/SwifterSwift/SwifterSwift/issues/741) by [@thisIsTheFoxe](https://github.com/thisisthefoxe)
+  - Added `init?(base64String:)` to create a `UIImage` from a base-64 `String`. [#741](https://github.com/SwifterSwift/SwifterSwift/issues/741) by [@thisIsTheFoxe](https://github.com/thisisthefoxe)
 - **CAGradientLayer**:
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
 - **Sequence**:

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -311,7 +311,8 @@ public extension UIImage {
     
     /// SwifterSwift: Create a new image from a base 64 string.
     ///
-    /// - Parameter string: Base 64 string.
+    /// - Parameters:
+    ///   - string: a base 64 string, representing the image
     convenience init?(base64String string: String) {
         guard let data = Data(base64Encoded: string, options: .ignoreUnknownCharacters) else { return nil }
         self.init(data: data)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -308,7 +308,7 @@ public extension UIImage {
 
         self.init(cgImage: aCgImage)
     }
-    
+
     /// SwifterSwift: Create a new image from a base 64 string.
     ///
     /// - Parameters:
@@ -317,7 +317,7 @@ public extension UIImage {
         guard let data = Data(base64Encoded: string, options: .ignoreUnknownCharacters) else { return nil }
         self.init(data: data)
     }
-    
+
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -308,7 +308,15 @@ public extension UIImage {
 
         self.init(cgImage: aCgImage)
     }
-
+    
+    /// SwifterSwift: Create a new image from a base 64 string.
+    ///
+    /// - Parameter string: Base 64 string.
+    convenience init?(base64String string: String) {
+        guard let data = Data(base64Encoded: string, options: .ignoreUnknownCharacters) else { return nil }
+        self.init(data: data)
+    }
+    
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -312,9 +312,9 @@ public extension UIImage {
     /// SwifterSwift: Create a new image from a base 64 string.
     ///
     /// - Parameters:
-    ///   - string: a base 64 string, representing the image
-    convenience init?(base64String string: String) {
-        guard let data = Data(base64Encoded: string, options: .ignoreUnknownCharacters) else { return nil }
+    ///   - base64String: a base-64 `String`, representing the image
+    convenience init?(base64String: String) {
+        guard let data = Data(base64Encoded: base64String) else { return nil }
         self.init(data: data)
     }
 

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -122,13 +122,13 @@ final class UIImageExtensionsTests: XCTestCase {
         filledImage = emptyImage.filled(withColor: .red)
         XCTAssertEqual(emptyImage, filledImage)
     }
-    
-    func testBase64(){
+
+    func testBase64() {
         let base64Str = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAE0lEQVR42mP8v5JhEwMaYKSBIADNAwvIr8dhZAAAAABJRU5ErkJggg=="
         let img = UIImage(base64String: base64Str)
         XCTAssertNotNil(img)
     }
-    
+
     func testTinted() {
         let baseImage = UIImage(color: .white, size: CGSize(width: 20, height: 20))
         let tintedImage = baseImage.tint(.black, blendMode: .overlay)

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -128,7 +128,7 @@ final class UIImageExtensionsTests: XCTestCase {
         let image = UIImage(base64String: base64String)
         XCTAssertNotNil(image)
 
-        let size: CGSize = CGSize(width: 5, height: 5)
+        let size = CGSize(width: 5, height: 5)
         XCTAssertEqual(image?.size, size)
 
         XCTAssertEqual(image?.bytesSize, 787)

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -122,7 +122,13 @@ final class UIImageExtensionsTests: XCTestCase {
         filledImage = emptyImage.filled(withColor: .red)
         XCTAssertEqual(emptyImage, filledImage)
     }
-
+    
+    func testBase64(){
+        let base64Str = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAE0lEQVR42mP8v5JhEwMaYKSBIADNAwvIr8dhZAAAAABJRU5ErkJggg=="
+        let img = UIImage(base64String: base64Str)
+        XCTAssertNotNil(img)
+    }
+    
     func testTinted() {
         let baseImage = UIImage(color: .white, size: CGSize(width: 20, height: 20))
         let tintedImage = baseImage.tint(.black, blendMode: .overlay)

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -124,9 +124,14 @@ final class UIImageExtensionsTests: XCTestCase {
     }
 
     func testBase64() {
-        let base64Str = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAE0lEQVR42mP8v5JhEwMaYKSBIADNAwvIr8dhZAAAAABJRU5ErkJggg=="
-        let img = UIImage(base64String: base64Str)
-        XCTAssertNotNil(img)
+        let base64String = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAE0lEQVR42mP8v5JhEwMaYKSBIADNAwvIr8dhZAAAAABJRU5ErkJggg=="
+        let image = UIImage(base64String: base64String)
+        XCTAssertNotNil(image)
+
+        let size: CGSize = CGSize(width: 5, height: 5)
+        XCTAssertEqual(image?.size, size)
+
+        XCTAssertEqual(image?.bytesSize, 787)
     }
 
     func testTinted() {


### PR DESCRIPTION
When you want to create an UIImage using a base 64 string.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [?] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

?  (it compiled without errors or warnings without changing the deployment target so it should work right?)
