### PR TITLE
Fix watchOS destination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
         - MACOS_SCHEME='SwifterSwift-macOS'
         - IOS_DESTINATION='platform=iOS Simulator,name=iPhone 11'
         - TVOS_DESTINATION='platform=tvOS Simulator,name=Apple TV 4K (at 1080p)'
-        - WATCHOS_DESTINATION='name=Apple Watch - 42mm'
+        - WATCHOS_DESTINATION='name=Apple Watch Series 5 - 40mm'
         - MACOS_DESTINATION='platform=OS X'
       before_install:
         - bundle install


### PR DESCRIPTION
Looks like the possible destinations in the Travis builds have changed for watchOS, which is why all the other builds are failing