### PR TITLE
- Added !targetEnvironment(macCatalyst) condition

### DIFF
--- a/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 SwifterSwift
 //
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 
 public extension NSColor {

--- a/Sources/SwifterSwift/AppKit/NSImageExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSImageExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 SwifterSwift
 //
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 
 // MARK: - Methods

--- a/Sources/SwifterSwift/AppKit/NSViewExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSViewExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 SwifterSwift
 //
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 
 // MARK: - Properties

--- a/Sources/SwifterSwift/CoreGraphics/CGColorExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGColorExtensions.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import UIKit
 #endif
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 #endif
 
@@ -27,7 +27,7 @@ public extension CGColor {
     }
     #endif
 
-    #if canImport(Cocoa)
+    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
     /// SwifterSwift: NSColor.
     var nsColor: NSColor? {
         return NSColor(cgColor: self)

--- a/Sources/SwifterSwift/CoreGraphics/CGFloatExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGFloatExtensions.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import UIKit
 #endif
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 #endif
 

--- a/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import UIKit
 #endif
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 #endif
 

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import UIKit
 #endif
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 #endif
 

--- a/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
@@ -13,7 +13,7 @@ import Foundation
 import UIKit
 #endif
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 #endif
 

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -14,7 +14,7 @@ import UIKit
 public typealias Color = UIColor
 #endif
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 /// SwifterSwift: Color
 public typealias Color = NSColor

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -14,7 +14,7 @@ import Foundation
 import UIKit
 #endif
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 #endif
 
@@ -1108,7 +1108,7 @@ public extension String {
     private typealias Font = UIFont
     #endif
 
-    #if canImport(Cocoa)
+    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
     private typealias Font = NSFont
     #endif
 
@@ -1150,7 +1150,7 @@ public extension String {
     }
     #endif
 
-    #if canImport(Cocoa)
+    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
     /// SwifterSwift: Add color to string.
     ///
     /// - Parameter color: text color.

--- a/Tests/AppKitTests/NSColorExtensionsTests.swift
+++ b/Tests/AppKitTests/NSColorExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-#if canImport(Cocoa)
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 
 final class NSColorExtensionsTests: XCTestCase {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -716,7 +716,7 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testColored() {
-        #if canImport(Cocoa)
+        #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
         let coloredString = "hello".colored(with: .orange)
         // swiftlint:disable:next legacy_constructor
         let attrs = coloredString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, coloredString.length))


### PR DESCRIPTION
 Added !targetEnvironment(macCatalyst) condition when building iOS app for MacOS with Catalyst framework Xcode 11 & Catalina

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
