### PR TITLE
Add base64String methods to UIImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIImage**:
   - Added `withBackgroundColor(_:)` to specify a background color for a partially transparent image. [#721](https://github.com/SwifterSwift/SwifterSwift/pull/721) by [MaxHaertwig](https://github.com/maxhaertwig).
   - Added `init?(base64String:)` to create a `UIImage` from a base-64 `String`. [#741](https://github.com/SwifterSwift/SwifterSwift/issues/741) by [@thisIsTheFoxe](https://github.com/thisisthefoxe)
+  - Added `pngBase64String()`, `jpegBase64String(compressionQuality:)` which return a Base 64 `String` representation of the `UIImage`s PNG or JPEG data. [#747](https://github.com/SwifterSwift/SwifterSwift/pull/747) by [Moritz Sternemann](https://github.com/moritzsternemann).
 - **CAGradientLayer**:
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
 - **Sequence**:

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -32,11 +32,6 @@ public extension UIImage {
         return withRenderingMode(.alwaysTemplate)
     }
 
-    /// SwifterSwift: Base 64 encoded PNG data of the image.
-    var base64String: String? {
-        return pngData()?.base64EncodedString()
-    }
-
 }
 
 // MARK: - Methods
@@ -284,6 +279,21 @@ public extension UIImage {
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return image
+    }
+
+    /// SwifterSwift: Base 64 encoded PNG data of the image.
+    ///
+    /// - returns: Base 64 encoded PNG data of the image as a String.
+    func pngBase64String() -> String? {
+        return pngData()?.base64EncodedString()
+    }
+
+    /// SwifterSwift: Base 64 encoded JPEG data of the image.
+    ///
+    /// - parameter compressionQuality: The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality).
+    /// - returns: Base 64 encoded JPEG data of the image as a String.
+    func jpegBase64String(compressionQuality: CGFloat) -> String? {
+        return jpegData(compressionQuality: compressionQuality)?.base64EncodedString()
     }
 
 }

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -32,6 +32,11 @@ public extension UIImage {
         return withRenderingMode(.alwaysTemplate)
     }
 
+    /// SwifterSwift: Base 64 encoded PNG data of the image.
+    var base64String: String? {
+        return pngData()?.base64EncodedString()
+    }
+
 }
 
 // MARK: - Methods

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -37,11 +37,6 @@ final class UIImageExtensionsTests: XCTestCase {
         XCTAssertEqual(image.template, image.withRenderingMode(.alwaysTemplate))
     }
 
-    func testBase64String() {
-        let image = UIImage(color: .blue, size: CGSize(width: 1, height: 1))
-        XCTAssertEqual(image.base64String, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAaADAAQAAAABAAAAAQAAAAD5Ip3+AAAADUlEQVQIHWNgYPj/HwADAgH/p+FUpQAAAABJRU5ErkJggg==")
-    }
-
     func testCompressed() {
         let bundle = Bundle.init(for: UIImageExtensionsTests.self)
         let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
@@ -161,6 +156,16 @@ final class UIImageExtensionsTests: XCTestCase {
         XCTAssertNotNil(image.withRoundedCorners(radius: 5))
         XCTAssertNotNil(image.withRoundedCorners(radius: -10))
         XCTAssertNotNil(image.withRoundedCorners(radius: 30))
+    }
+
+    func testPNGBase64String() {
+        let image = UIImage(color: .blue, size: CGSize(width: 1, height: 1))
+        XCTAssertEqual(image.pngBase64String(), "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAaADAAQAAAABAAAAAQAAAAD5Ip3+AAAADUlEQVQIHWNgYPj/HwADAgH/p+FUpQAAAABJRU5ErkJggg==")
+    }
+
+    func testJPEGBase64String() {
+        let image = UIImage(color: .blue, size: CGSize(width: 1, height: 1))
+        XCTAssertEqual(image.jpegBase64String(compressionQuality: 1), "/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZgAATU0AKgAAAAgAAgESAAMAAAABAAEAAIdpAAQAAAABAAAAJgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAaADAAQAAAABAAAAAQAAAAD/7QA4UGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAAA4QklNBCUAAAAAABDUHYzZjwCyBOmACZjs+EJ+/8AAEQgAAQABAwERAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/bAEMBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/dAAQAAf/aAAwDAQACEQMRAD8A/jnr/v4P5XP/2Q==")
     }
 
 }

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -37,6 +37,11 @@ final class UIImageExtensionsTests: XCTestCase {
         XCTAssertEqual(image.template, image.withRenderingMode(.alwaysTemplate))
     }
 
+    func testBase64String() {
+        let image = UIImage(color: .blue, size: CGSize(width: 1, height: 1))
+        XCTAssertEqual(image.base64String, "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAaADAAQAAAABAAAAAQAAAAD5Ip3+AAAADUlEQVQIHWNgYPj/HwADAgH/p+FUpQAAAABJRU5ErkJggg==")
+    }
+
     func testCompressed() {
         let bundle = Bundle.init(for: UIImageExtensionsTests.self)
         let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!


### PR DESCRIPTION
🚀 Base64-encode a `UIImage`s `pngData()` and `jpegData(compressionQuality:)` and return it as a string.

Resolves #742 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
