### PR TITLE
Add `init(grouping:by:)` for Dictionary that uses a keypath. 🚀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 - **Sequence**:
   - Added `grouped(by:)` to group up a sequence by a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
+- **Dictionary**:
+  - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:
   - Added `removeDuplicates(keyPath:)` for removing duplicate elements based on key path. [#737](https://github.com/SwifterSwift/SwifterSwift/pull/737) by [Ilya Glushchuk](https://github.com/iglushchuk).
 - **Color**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
-- **Sequence**:
-  - Added `grouped(by:)` to group up a sequence by a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **Dictionary**:
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Sequence**:
+  - Added `grouped(by:)` to group up a sequence by a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:
   - Added `removeDuplicates(keyPath:)` for removing duplicate elements based on key path. [#737](https://github.com/SwifterSwift/SwifterSwift/pull/737) by [Ilya Glushchuk](https://github.com/iglushchuk).
 - **Color**:
@@ -29,6 +31,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 - **UIImage**:
   - Refactored `tint(_:blendMode:)` using UIGraphicsImageRenderer if available. [#731](https://github.com/SwifterSwift/SwifterSwift/pull/731) by [FraDeliro](https://github.com/FraDeliro).
+
+- **Sequence**:
+  - Corrected documentation for `sorted(by:with:)` and `sorted(by:)`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 
 ### Deprecated
 

--- a/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
@@ -13,6 +13,15 @@ import Foundation
 // MARK: - Methods
 public extension Dictionary {
 
+    /// SwifterSwift: Creates a Dictionary from a given sequence grouped by a given Keypath
+    ///
+    /// - Parameters:
+    ///   - grouping: Sequence being grouped
+    ///   - by: The Keypath to group by.
+    init<S: Sequence>(grouping sequence: S, by keyPath: KeyPath<S.Element, Key>) where Value == [S.Element] {
+      self.init(grouping: sequence, by: { $0[keyPath: keyPath] })
+    }
+
     /// SwifterSwift: Check if key exists in dictionary.
     ///
     ///        let dict: [String: Any] = ["testKey": "testValue", "testArrayKey": [1, 2, 3, 4, 5]]

--- a/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
@@ -16,10 +16,10 @@ public extension Dictionary {
     /// SwifterSwift: Creates a Dictionary from a given sequence grouped by a given Keypath
     ///
     /// - Parameters:
-    ///   - grouping: Sequence being grouped
-    ///   - by: The Keypath to group by.
+    ///   - sequence: Sequence being grouped
+    ///   - keypath: The Keypath to group by.
     init<S: Sequence>(grouping sequence: S, by keyPath: KeyPath<S.Element, Key>) where Value == [S.Element] {
-      self.init(grouping: sequence, by: { $0[keyPath: keyPath] })
+       self.init(grouping: sequence, by: { $0[keyPath: keyPath] })
     }
 
     /// SwifterSwift: Check if key exists in dictionary.

--- a/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
@@ -13,11 +13,11 @@ import Foundation
 // MARK: - Methods
 public extension Dictionary {
 
-    /// SwifterSwift: Creates a Dictionary from a given sequence grouped by a given Keypath
+    /// SwifterSwift: Creates a Dictionary from a given sequence grouped by a given key path.
     ///
     /// - Parameters:
     ///   - sequence: Sequence being grouped
-    ///   - keypath: The Keypath to group by.
+    ///   - keypath: The key path to group by.
     init<S: Sequence>(grouping sequence: S, by keyPath: KeyPath<S.Element, Key>) where Value == [S.Element] {
        self.init(grouping: sequence, by: { $0[keyPath: keyPath] })
     }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -186,15 +186,6 @@ public extension Sequence {
         return (Array(matching), Array(nonMatching))
     }
 
-    /// SwifterSwift: Return a map grouped on a keypath value.
-    ///
-    /// - Parameter by: Key path to group by.  Must be Hashable.
-    /// - Returns: Dictionary of arrays using the keypath value as the key.
-    func grouped<T: Hashable>(by keyPath: KeyPath<Element, T>) -> [T: [Element]] {
-        // https://twitter.com/johnsundell/status/1106886417756704768?lang=en
-        return Dictionary(grouping: self, by: { $0[keyPath: keyPath] })
-    }
-
     /// SwifterSwift: Return a sorted array  based on a keypath and a compare function.
     ///
     /// - Parameter path: Key path to sort.

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -185,17 +185,26 @@ public extension Sequence {
         }
         return (Array(matching), Array(nonMatching))
     }
+    
+    /// SwifterSwift: Return a map grouped on a keypath value.
+    ///
+    /// - Parameter by: Key path to group by.  Must be Hashable.
+    /// - Returns: Dictionary of arrays using the keypath value as the key.
+    func grouped<T: Hashable>(by keyPath: KeyPath<Element, T>) -> [T: [Element]] {
+        // https://twitter.com/johnsundell/status/1106886417756704768?lang=en
+        return .init(grouping: self, by: { $0[keyPath: keyPath] })
+    }
 
     /// SwifterSwift: Return a sorted array  based on a keypath and a compare function.
     ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
+    /// - Parameter path: Key path to sort.
     /// - Parameter compare: Comparation function that will determine the ordering.
     /// - Returns: The sorted array.
     func sorted<T>(by keyPath: KeyPath<Element, T>, with compare: (T, T) -> Bool) -> [Element] {
         return sorted { compare($0[keyPath: keyPath], $1[keyPath: keyPath]) }
     }
 
-    /// SwifterSwift: Return a sorted array  based on a keypath and a compare function.
+    /// SwifterSwift: Return a sorted array  based on a keypath.
     ///
     /// - Parameter path: Key path to sort. The key path type must be Comparable.
     /// - Returns: The sorted array.

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -192,7 +192,7 @@ public extension Sequence {
     /// - Returns: Dictionary of arrays using the keypath value as the key.
     func grouped<T: Hashable>(by keyPath: KeyPath<Element, T>) -> [T: [Element]] {
         // https://twitter.com/johnsundell/status/1106886417756704768?lang=en
-        return .init(grouping: self, by: { $0[keyPath: keyPath] })
+        return Dictionary(grouping: self, by: { $0[keyPath: keyPath] })
     }
 
     /// SwifterSwift: Return a sorted array  based on a keypath and a compare function.

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -185,7 +185,7 @@ public extension Sequence {
         }
         return (Array(matching), Array(nonMatching))
     }
-    
+
     /// SwifterSwift: Return a map grouped on a keypath value.
     ///
     /// - Parameter by: Key path to group by.  Must be Hashable.

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -152,4 +152,15 @@ final class DictionaryExtensionsTests: XCTestCase {
         XCTAssertEqual(words, ["0": .zero, "1": .one, "2": .two])
     }
 
+    func testInitGroupedByKeyPath() {
+        let array1 = ["James", "Wade", "Bryant", "John"]
+        let array2 = ["James", "Wade", "Bryant", "John", "", ""]
+        let array3: [String] = []
+
+        XCTAssertEqual(Dictionary(grouping: array1, by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"]])
+        XCTAssertEqual(Dictionary(grouping: array1, by: \String.first), [Optional("B"): ["Bryant"], Optional("J"): ["James", "John"], Optional("W"): ["Wade"]])
+        XCTAssertEqual(Dictionary(grouping: array2, by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"], 0: ["", ""]])
+        XCTAssertEqual(Dictionary(grouping: array3, by: \String.count), [:])
+    }
+
 }

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -151,7 +151,7 @@ final class SequenceExtensionsTests: XCTestCase {
         let array2 = ["James", "Wade", "Bryant", ""]
         XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
     }
-    
+
     func testKeyPathGrouped() {
         let array = ["James", "Wade", "Bryant", "John"]
         XCTAssertEqual(array.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"]])

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -152,14 +152,4 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
     }
 
-    func testKeyPathGrouped() {
-        let array1 = ["James", "Wade", "Bryant", "John"]
-        let array2 = ["James", "Wade", "Bryant", "John", "", ""]
-        let array3: [String] = []
-        XCTAssertEqual(array1.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"]])
-        XCTAssertEqual(array1.grouped(by: \String.first), [Optional("B"): ["Bryant"], Optional("J"): ["James", "John"], Optional("W"): ["Wade"]])
-        XCTAssertEqual(array2.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"], 0: ["", ""]])
-        XCTAssertEqual(array3.grouped(by: \String.count), [:])
-    }
-
 }

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -153,8 +153,13 @@ final class SequenceExtensionsTests: XCTestCase {
     }
 
     func testKeyPathGrouped() {
-        let array = ["James", "Wade", "Bryant", "John"]
-        XCTAssertEqual(array.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"]])
+        let array1 = ["James", "Wade", "Bryant", "John"]
+        let array2 = ["James", "Wade", "Bryant", "John", "", ""]
+        let array3: [String] = []
+        XCTAssertEqual(array1.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"]])
+        XCTAssertEqual(array1.grouped(by: \String.first), [Optional("B"): ["Bryant"], Optional("J"): ["James", "John"], Optional("W"): ["Wade"]])
+        XCTAssertEqual(array2.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"], 0: ["", ""]])
+        XCTAssertEqual(array3.grouped(by: \String.count), [:])
     }
 
 }

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -151,5 +151,10 @@ final class SequenceExtensionsTests: XCTestCase {
         let array2 = ["James", "Wade", "Bryant", ""]
         XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
     }
+    
+    func testKeyPathGrouped() {
+        let array = ["James", "Wade", "Bryant", "John"]
+        XCTAssertEqual(array.grouped(by: \String.count), [6: ["Bryant"], 5: ["James"], 4: ["Wade", "John"]])
+    }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 5.0.
- [X] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
