### PR TITLE
Xcode 11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: osx
 language: swift
-osx_image: xcode11
+osx_image: xcode11.1
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: osx
 language: swift
-osx_image: xcode11.1
+osx_image: xcode11.2
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![codecov](https://codecov.io/gh/SwifterSwift/SwifterSwift/branch/master/graph/badge.svg)](https://codecov.io/gh/SwifterSwift/SwifterSwift)
 [![docs](http://swifterswift.com/docs/badge.svg)](http://swifterswift.com/docs)
 [![Swift](https://img.shields.io/badge/Swift-5.0-orange.svg)](https://swift.org)
-[![Xcode](https://img.shields.io/badge/Xcode-11-blue.svg)](https://developer.apple.com/xcode)
+[![Xcode](https://img.shields.io/badge/Xcode-11.1-blue.svg)](https://developer.apple.com/xcode)
 [![MIT](https://img.shields.io/badge/License-MIT-red.svg)](https://opensource.org/licenses/MIT)
 [![Slack Channel](https://slackin-ppvrggbpgn.now.sh/badge.svg)](https://slackin-ppvrggbpgn.now.sh/)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![codecov](https://codecov.io/gh/SwifterSwift/SwifterSwift/branch/master/graph/badge.svg)](https://codecov.io/gh/SwifterSwift/SwifterSwift)
 [![docs](http://swifterswift.com/docs/badge.svg)](http://swifterswift.com/docs)
 [![Swift](https://img.shields.io/badge/Swift-5.0-orange.svg)](https://swift.org)
-[![Xcode](https://img.shields.io/badge/Xcode-11.1-blue.svg)](https://developer.apple.com/xcode)
+[![Xcode](https://img.shields.io/badge/Xcode-11.2-blue.svg)](https://developer.apple.com/xcode)
 [![MIT](https://img.shields.io/badge/License-MIT-red.svg)](https://opensource.org/licenses/MIT)
 [![Slack Channel](https://slackin-ppvrggbpgn.now.sh/badge.svg)](https://slackin-ppvrggbpgn.now.sh/)
 

--- a/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSColorExtensions.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 SwifterSwift
 //
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 
 public extension NSColor {
 

--- a/Sources/SwifterSwift/AppKit/NSImageExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSImageExtensions.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 SwifterSwift
 //
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 
 // MARK: - Methods
 public extension NSImage {

--- a/Sources/SwifterSwift/AppKit/NSViewExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSViewExtensions.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 SwifterSwift
 //
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 
 // MARK: - Properties
 public extension NSView {

--- a/Sources/SwifterSwift/CoreGraphics/CGColorExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGColorExtensions.swift
@@ -13,8 +13,8 @@ import CoreGraphics
 import UIKit
 #endif
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 #endif
 
 // MARK: - Properties
@@ -27,7 +27,7 @@ public extension CGColor {
     }
     #endif
 
-    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     /// SwifterSwift: NSColor.
     var nsColor: NSColor? {
         return NSColor(cgColor: self)

--- a/Sources/SwifterSwift/CoreGraphics/CGColorExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGColorExtensions.swift
@@ -27,7 +27,7 @@ public extension CGColor {
     }
     #endif
 
-    #if canImport(Cocoa)
+    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
     /// SwifterSwift: NSColor.
     var nsColor: NSColor? {
         return NSColor(cgColor: self)

--- a/Sources/SwifterSwift/CoreGraphics/CGFloatExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGFloatExtensions.swift
@@ -9,12 +9,8 @@
 #if canImport(CoreGraphics)
 import CoreGraphics
 
-#if canImport(UIKit)
-import UIKit
-#endif
-
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(Foundation)
+import Foundation
 #endif
 
 // MARK: - Properties
@@ -25,20 +21,24 @@ public extension CGFloat {
         return Swift.abs(self)
     }
 
+    #if canImport(Foundation)
     /// SwifterSwift: Ceil of CGFloat value.
     var ceil: CGFloat {
         return Foundation.ceil(self)
     }
+    #endif
 
     /// SwifterSwift: Radian value of degree input.
     var degreesToRadians: CGFloat {
         return .pi * self / 180.0
     }
 
+    #if canImport(Foundation)
     /// SwifterSwift: Floor of CGFloat value.
     var floor: CGFloat {
         return Foundation.floor(self)
     }
+    #endif
 
     /// SwifterSwift: Check if CGFloat is positive.
     var isPositive: Bool {

--- a/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift
@@ -9,14 +9,6 @@
 #if canImport(CoreGraphics)
 import CoreGraphics
 
-#if canImport(UIKit)
-import UIKit
-#endif
-
-#if canImport(Cocoa)
-import Cocoa
-#endif
-
 // MARK: - Methods
 public extension CGPoint {
 

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -9,14 +9,6 @@
 #if canImport(CoreGraphics)
 import CoreGraphics
 
-#if canImport(UIKit)
-import UIKit
-#endif
-
-#if canImport(Cocoa)
-import Cocoa
-#endif
-
 // MARK: - Methods
 public extension CGSize {
 

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -257,7 +257,11 @@ public extension Date {
             return calendar.component(.nanosecond, from: self)
         }
         set {
+            #if targetEnvironment(macCatalyst)
+            let allowedRange = 0..<1000000000
+            #else
             let allowedRange = calendar.range(of: .nanosecond, in: .second, for: self)!
+            #endif
             guard allowedRange.contains(newValue) else { return }
 
             let currentNanoseconds = calendar.component(.nanosecond, from: self)
@@ -282,7 +286,11 @@ public extension Date {
         }
         set {
             let nanoSeconds = newValue * 1000000
+            #if targetEnvironment(macCatalyst)
+            let allowedRange = 0..<1000000000
+            #else
             let allowedRange = calendar.range(of: .nanosecond, in: .second, for: self)!
+            #endif
             guard allowedRange.contains(nanoSeconds) else { return }
 
             if let date = calendar.date(bySetting: .nanosecond, value: nanoSeconds, of: self) {
@@ -541,7 +549,11 @@ public extension Date {
     func changing(_ component: Calendar.Component, value: Int) -> Date? {
         switch component {
         case .nanosecond:
+            #if targetEnvironment(macCatalyst)
+            let allowedRange = 0..<1000000000
+            #else
             let allowedRange = calendar.range(of: .nanosecond, in: .second, for: self)!
+            #endif
             guard allowedRange.contains(value) else { return nil }
             let currentNanoseconds = calendar.component(.nanosecond, from: self)
             let nanosecondsToAdd = value - currentNanoseconds

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -552,7 +552,8 @@ public extension Date {
         switch component {
         case .nanosecond:
             #if targetEnvironment(macCatalyst)
-            let allowedRange = 0..<1000000000
+            // The `Calendar` implementation in `macCatalyst` does not know that a nanosecond is 1/1,000,000,000th of a second
+            let allowedRange = 0..<1_000_000_000
             #else
             let allowedRange = calendar.range(of: .nanosecond, in: .second, for: self)!
             #endif

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -258,7 +258,8 @@ public extension Date {
         }
         set {
             #if targetEnvironment(macCatalyst)
-            let allowedRange = 0..<1000000000
+            // The `Calendar` implementation in `macCatalyst` does not know that a nanosecond is 1/1,000,000,000th of a second
+            let allowedRange = 0..<1_000_000_000
             #else
             let allowedRange = calendar.range(of: .nanosecond, in: .second, for: self)!
             #endif
@@ -282,12 +283,13 @@ public extension Date {
     ///
     var millisecond: Int {
         get {
-            return calendar.component(.nanosecond, from: self) / 1000000
+            return calendar.component(.nanosecond, from: self) / 1_000_000
         }
         set {
-            let nanoSeconds = newValue * 1000000
+            let nanoSeconds = newValue * 1_000_000
             #if targetEnvironment(macCatalyst)
-            let allowedRange = 0..<1000000000
+            // The `Calendar` implementation in `macCatalyst` does not know that a nanosecond is 1/1,000,000,000th of a second
+            let allowedRange = 0..<1_000_000_000
             #else
             let allowedRange = calendar.range(of: .nanosecond, in: .second, for: self)!
             #endif

--- a/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
@@ -75,22 +75,12 @@ public extension NSAttributedString {
     }
     #endif
 
-    #if os(macOS)
+    #if canImport(AppKit) || canImport(UIKit)
     /// SwifterSwift: Add color to NSAttributedString.
     ///
     /// - Parameter color: text color.
     /// - Returns: a NSAttributedString colored with given color.
-    func colored(with color: NSColor) -> NSAttributedString {
-        return applying(attributes: [.foregroundColor: color])
-    }
-    #endif
-
-    #if canImport(UIKit)
-    /// SwifterSwift: Add color to NSAttributedString.
-    ///
-    /// - Parameter color: text color.
-    /// - Returns: a NSAttributedString colored with given color.
-    func colored(with color: UIColor) -> NSAttributedString {
+    func colored(with color: Color) -> NSAttributedString {
         return applying(attributes: [.foregroundColor: color])
     }
     #endif

--- a/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
@@ -13,8 +13,8 @@ import Foundation
 import UIKit
 #endif
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 #endif
 
 // MARK: - Properties

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -14,8 +14,8 @@ import UIKit
 public typealias Color = UIColor
 #endif
 
-#if canImport(AppKit)
-import AppKit
+#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
+import Cocoa
 /// SwifterSwift: Color
 public typealias Color = NSColor
 #endif

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -14,8 +14,8 @@ import UIKit
 public typealias Color = UIColor
 #endif
 
-#if canImport(Cocoa) && !targetEnvironment(macCatalyst)
-import Cocoa
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+import AppKit
 /// SwifterSwift: Color
 public typealias Color = NSColor
 #endif

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -14,8 +14,8 @@ import Foundation
 import UIKit
 #endif
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 #endif
 
 #if canImport(CoreGraphics)
@@ -1108,7 +1108,7 @@ public extension String {
     private typealias Font = UIFont
     #endif
 
-    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     private typealias Font = NSFont
     #endif
 
@@ -1150,7 +1150,7 @@ public extension String {
     }
     #endif
 
-    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     /// SwifterSwift: Add color to string.
     ///
     /// - Parameter color: text color.

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -249,7 +249,7 @@ public extension String {
     var isNumeric: Bool {
         let scanner = Scanner(string: self)
         scanner.locale = NSLocale.current
-        #if os(Linux)
+        #if os(Linux) || targetEnvironment(macCatalyst)
         return scanner.scanDecimal() != nil && scanner.isAtEnd
         #else
         return scanner.scanDecimal(nil) && scanner.isAtEnd
@@ -1108,7 +1108,7 @@ public extension String {
     private typealias Font = UIFont
     #endif
 
-    #if canImport(Cocoa)
+    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
     private typealias Font = NSFont
     #endif
 
@@ -1150,7 +1150,7 @@ public extension String {
     }
     #endif
 
-    #if canImport(Cocoa)
+    #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
     /// SwifterSwift: Add color to string.
     ///
     /// - Parameter color: text color.

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1140,22 +1140,12 @@ public extension String {
     }
     #endif
 
-    #if canImport(UIKit)
+    #if canImport(AppKit) || canImport(UIKit)
     /// SwifterSwift: Add color to string.
     ///
     /// - Parameter color: text color.
     /// - Returns: a NSAttributedString versions of string colored with given color.
-    func colored(with color: UIColor) -> NSAttributedString {
-        return NSMutableAttributedString(string: self, attributes: [.foregroundColor: color])
-    }
-    #endif
-
-    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    /// SwifterSwift: Add color to string.
-    ///
-    /// - Parameter color: text color.
-    /// - Returns: a NSAttributedString versions of string colored with given color.
-    func colored(with color: NSColor) -> NSAttributedString {
+    func colored(with color: Color) -> NSAttributedString {
         return NSMutableAttributedString(string: self, attributes: [.foregroundColor: color])
     }
     #endif

--- a/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
@@ -23,7 +23,12 @@ public extension UIAlertController {
     ///   - vibrate: set true to vibrate the device while presenting the alert (default is false).
     ///   - completion: an optional completion handler to be called after presenting alert controller (default is nil).
     func show(animated: Bool = true, vibrate: Bool = false, completion: (() -> Void)? = nil) {
-        UIApplication.shared.keyWindow?.rootViewController?.present(self, animated: animated, completion: completion)
+        #if targetEnvironment(macCatalyst)
+        let window = UIApplication.shared.windows.last
+        #else
+        let window = UIApplication.shared.keyWindow
+        #endif
+        window?.rootViewController?.present(self, animated: animated, completion: completion)
         if vibrate {
             #if canImport(AudioToolbox)
             AudioServicesPlayAlertSound(kSystemSoundID_Vibrate)

--- a/Sources/SwifterSwift/UIKit/UITextViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UITextViewExtensions.swift
@@ -34,10 +34,10 @@ public extension UITextView {
 
     /// SwifterSwift: Wrap to the content (Text / Attributed Text).
     func wrapToContent() {
-        contentInset = UIEdgeInsets.zero
-        scrollIndicatorInsets = UIEdgeInsets.zero
-        contentOffset = CGPoint.zero
-        textContainerInset = UIEdgeInsets.zero
+        contentInset = .zero
+        scrollIndicatorInsets = .zero
+        contentOffset = .zero
+        textContainerInset = .zero
         textContainer.lineFragmentPadding = 0
         sizeToFit()
     }

--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -25,12 +25,12 @@ Pod::Spec.new do |s|
 
   # SwiftStdlib Extensions
   s.subspec 'SwiftStdlib' do |sp|
-    sp.source_files  = 'Sources/SwifterSwift/SwiftStdlib/*.swift'
+    sp.source_files  = 'Sources/SwifterSwift/Shared/*.swift', 'Sources/SwifterSwift/SwiftStdlib/*.swift'
   end
 
   # Foundation Extensions
   s.subspec 'Foundation' do |sp|
-    sp.source_files  = 'Sources/SwifterSwift/Foundation/*.swift'
+    sp.source_files  = 'Sources/SwifterSwift/Shared/*.swift', 'Sources/SwifterSwift/Foundation/*.swift'
   end
 
   # UIKit Extensions

--- a/Tests/AppKitTests/NSColorExtensionsTests.swift
+++ b/Tests/AppKitTests/NSColorExtensionsTests.swift
@@ -9,8 +9,8 @@
 import XCTest
 @testable import SwifterSwift
 
-#if canImport(Cocoa)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 
 final class NSColorExtensionsTests: XCTestCase {
 

--- a/Tests/CoreGraphicsTests/CGColorExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGColorExtensionsTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import CoreGraphics
 
 #if os(macOS)
-import Cocoa
+import AppKit
 #else
 import UIKit
 #endif

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -71,20 +71,20 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 
     // MARK: - Methods
     func testColored() {
-        #if canImport(UIKit)
+        #if canImport(AppKit) || canImport(UIKit)
         let string = NSAttributedString(string: "Colored")
         var out = string.colored(with: .red)
         var attributes = out.attributes(at: 0, effectiveRange: nil)
         let filteredAttributes = attributes.filter { (key, value) -> Bool in
-            return (key == NSAttributedString.Key.foregroundColor && (value as? UIColor) == .red)
+            return (key == NSAttributedString.Key.foregroundColor && (value as? Color) == .red)
         }
 
         XCTAssertEqual(filteredAttributes.count, 1)
 
         out = out.colored(with: .blue)
         attributes = out.attributes(at: 0, effectiveRange: nil)
-        XCTAssertEqual(attributes[NSAttributedString.Key.foregroundColor] as? UIColor, UIColor.blue)
-        XCTAssertNotEqual(attributes[NSAttributedString.Key.foregroundColor] as? UIColor, .red)
+        XCTAssertEqual(attributes[NSAttributedString.Key.foregroundColor] as? Color, .blue)
+        XCTAssertNotEqual(attributes[NSAttributedString.Key.foregroundColor] as? Color, .red)
         #endif
     }
 

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-#if canImport(UIKit) || canImport(AppKit)
+#if canImport(AppKit) || canImport(UIKit)
 
 #if !os(watchOS)
 import CoreImage

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -9,15 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-#if canImport(UIKit) || canImport(Cocoa)
-
-#if os(macOS)
-import Cocoa
-public typealias Color = NSColor
-#else
-import UIKit
-public typealias Color = UIColor
-#endif
+#if canImport(UIKit) || canImport(AppKit)
 
 #if !os(watchOS)
 import CoreImage

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -267,7 +267,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("8.23".float(locale: Locale(identifier: "en_US_POSIX")))
         XCTAssertEqual("8.23".float(locale: Locale(identifier: "en_US_POSIX")), Float(8.23))
 
-        #if os(Linux)
+        #if os(Linux) || targetEnvironment(macCatalyst)
         XCTAssertEqual("8s".float(), 8)
         #else
         XCTAssertNil("8s".float())
@@ -281,7 +281,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("8.23".double(locale: Locale(identifier: "en_US_POSIX")))
         XCTAssertEqual("8.23".double(locale: Locale(identifier: "en_US_POSIX")), 8.23)
 
-        #if os(Linux)
+        #if os(Linux) || targetEnvironment(macCatalyst)
         XCTAssertEqual("8s".double(), 8)
         #else
         XCTAssertNil("8s".double())
@@ -296,7 +296,11 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("8.23".cgFloat(locale: Locale(identifier: "en_US_POSIX")))
         XCTAssertEqual("8.23".cgFloat(locale: Locale(identifier: "en_US_POSIX")), CGFloat(8.23))
 
+        #if targetEnvironment(macCatalyst)
+        XCTAssertEqual("8s".cgFloat(), 8)
+        #else
         XCTAssertNil("8s".cgFloat())
+        #endif
         #endif
     }
 
@@ -716,17 +720,17 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testColored() {
-        #if canImport(Cocoa)
+        #if canImport(Cocoa) || canImport(UIKit)
         let coloredString = "hello".colored(with: .orange)
         // swiftlint:disable:next legacy_constructor
         let attrs = coloredString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, coloredString.length))
         XCTAssertNotNil(attrs[NSAttributedString.Key.foregroundColor])
 
-        guard let color = attrs[.foregroundColor] as? NSColor else {
+        guard let color = attrs[.foregroundColor] as? Color else {
             XCTFail("Unable to find color in testColored")
             return
         }
-        XCTAssertEqual(color, NSColor.orange)
+        XCTAssertEqual(color, .orange)
         #endif
     }
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -720,7 +720,7 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testColored() {
-        #if canImport(Cocoa) || canImport(UIKit)
+        #if canImport(AppKit) || canImport(UIKit)
         let coloredString = "hello".colored(with: .orange)
         // swiftlint:disable:next legacy_constructor
         let attrs = coloredString.attributes(at: 0, longestEffectiveRange: nil, in: NSMakeRange(0, coloredString.length))

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -41,7 +41,7 @@ final class UITextViewExtensionsTests: XCTestCase {
         let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 
         // initial setting
-        textView.frame = CGRect(x: 0, y: 0, width: 100, height: 20)
+        textView.bounds = CGRect(origin: .zero, size: CGSize(width: 100, height: 20))
         textView.font = UIFont.systemFont(ofSize: 20.0)
         textView.text = text
 
@@ -64,7 +64,7 @@ final class UITextViewExtensionsTests: XCTestCase {
         // This is important to set the frame after calling the wrapToContent, otherwise
         // boundingRect can give you fractional value, and method call `sizeToFit` inside the
         // wrapToContent would change to the fractional value instead of the ceil value.
-        textView.frame = CGRect(origin: .zero, size: textSize)
+        textView.bounds = CGRect(origin: .zero, size: textSize)
 
         // after setting wrap, content size will be equal to bounds
         XCTAssertEqual(textView.bounds.size, textView.contentSize)

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -64,7 +64,7 @@ final class UITextViewExtensionsTests: XCTestCase {
         // This is important to set the frame after calling the wrapToContent, otherwise
         // boundingRect can give you fractional value, and method call `sizeToFit` inside the
         // wrapToContent would change to the fractional value instead of the ceil value.
-        textView.bounds = CGRect(x: 0, y: 0, width: textSize.width, height: textSize.height)
+        textView.frame = CGRect(origin: .zero, size: textSize)
 
         // after setting wrap, content size will be equal to bounds
         XCTAssertEqual(textView.bounds.size, textView.contentSize)

--- a/Tests/UIKitTests/UITextViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITextViewExtensionsTests.swift
@@ -41,7 +41,7 @@ final class UITextViewExtensionsTests: XCTestCase {
         let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 
         // initial setting
-        textView.bounds = CGRect(origin: .zero, size: CGSize(width: 100, height: 20))
+        textView.frame = CGRect(origin: .zero, size: CGSize(width: 100, height: 20))
         textView.font = UIFont.systemFont(ofSize: 20.0)
         textView.text = text
 

--- a/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
@@ -57,7 +57,6 @@ final class UIViewControllerExtensionsTests: XCTestCase {
 
     func testShowAlert() {
         let viewController = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = viewController
         let title = "test title"
         let message = "test message"
         let actionButtons = ["OK", "Cancel"]


### PR DESCRIPTION
🚀
Fix imports and tests for Xcode 11.2 and macCatalyst. I fixed some of the tests for macCatalyst but there are a few with incredibly strange results. At the very least this can now be used and tested with Xcode 11.2.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
