### PR TITLE
Remove the need for UIView Enums 🚀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,16 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
 - **Sequence**:
   - Added `sum(for:)` to sum up an `AdditiveArithmetic` property, referenced by `KeyPath`, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
+- **UIView**
+  - Added `verticalShake(duration:animationType:completion:)` and `horizontalShake(duration:animationType:completion:)` functions to UIView extensions [#756](https://github.com/SwifterSwift/SwifterSwift/pull/756) by [mmdock](https://github.com/mmdock)
+  - Added `rotate(toRadian:animated:duration:completion)`, and `rotate(toDegree:animated:duration:completion)` functions to UIView extensions [#756](https://github.com/SwifterSwift/SwifterSwift/pull/756) by [mmdock](https://github.com/mmdock)
+  - Added `rotate(byRadian:animated:duration:completion)`, and `rotate(byDegree:animated:duration:completion)` functions to UIView extensions [#756](https://github.com/SwifterSwift/SwifterSwift/pull/756) by [mmdock](https://github.com/mmdock)
 
 ### Changed
 - **UIImage**:
   - Implemented `filled(withColor:)` using `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
   - Updated `kilobytesSize` to be computed independently from `bytesSize` [#753](https://github.com/SwifterSwift/SwifterSwift/pull/753) by [mmdock](https://github.com/mmdock)
   - Updated `init?(base64String:)` to take in a `scale` factor paramater. [#753](https://github.com/SwifterSwift/SwifterSwift/pull/753) by [mmdock](https://github.com/mmdock)
-  
-- **UIImage**:
   - Refactored `tint(_:blendMode:)` using UIGraphicsImageRenderer if available. [#731](https://github.com/SwifterSwift/SwifterSwift/pull/731) by [FraDeliro](https://github.com/FraDeliro).
 
 - **Sequence**:
@@ -41,6 +43,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 
 ### Removed
+- **UIView**
+  - Removed enums `ShakeDirection`, `AngleUnit`, `ShakeAnimationType` and their dependent functions.  [#756](https://github.com/SwifterSwift/SwifterSwift/pull/756) by [mmdock](https://github.com/mmdock)
 
 ### Fixed
 

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -9,55 +9,6 @@
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
 
-// MARK: - enums
-public extension UIView {
-
-    /// SwifterSwift: Shake directions of a view.
-    ///
-    /// - horizontal: Shake left and right.
-    /// - vertical: Shake up and down.
-    enum ShakeDirection {
-        /// SwifterSwift: Shake left and right.
-        case horizontal
-
-        /// SwifterSwift: Shake up and down.
-        case vertical
-    }
-
-    /// SwifterSwift: Angle units.
-    ///
-    /// - degrees: degrees.
-    /// - radians: radians.
-    enum AngleUnit {
-        /// SwifterSwift: degrees.
-        case degrees
-
-        /// SwifterSwift: radians.
-        case radians
-    }
-
-    /// SwifterSwift: Shake animations types.
-    ///
-    /// - linear: linear animation.
-    /// - easeIn: easeIn animation.
-    /// - easeOut: easeOut animation.
-    /// - easeInOut: easeInOut animation.
-    enum ShakeAnimationType {
-        /// SwifterSwift: linear animation.
-        case linear
-
-        /// SwifterSwift: easeIn animation.
-        case easeIn
-
-        /// SwifterSwift: easeOut animation.
-        case easeOut
-
-        /// SwifterSwift: easeInOut animation.
-        case easeInOut
-    }
-
-}
-
 // MARK: - Properties
 public extension UIView {
 
@@ -351,35 +302,61 @@ public extension UIView {
         }
     }
 
-    /// SwifterSwift: Rotate view by angle on relative axis.
+    /// SwifterSwift: Rotate view by radians on relative axis.
     ///
     /// - Parameters:
-    ///   - angle: angle to rotate view by.
-    ///   - type: type of the rotation angle.
-    ///   - animated: set true to animate rotation (default is true).
-    ///   - duration: animation duration in seconds (default is 1 second).
-    ///   - completion: optional completion handler to run with animation finishes (default is nil).
-    func rotate(byAngle angle: CGFloat, ofType type: AngleUnit, animated: Bool = false, duration: TimeInterval = 1, completion: ((Bool) -> Void)? = nil) {
-        let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
-        let aDuration = animated ? duration : 0
-        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
-            self.transform = self.transform.rotated(by: angleWithType)
-        }, completion: completion)
-    }
-
-    /// SwifterSwift: Rotate view to angle on fixed axis.
-    ///
-    /// - Parameters:
-    ///   - angle: angle to rotate view to.
-    ///   - type: type of the rotation angle.
+    ///   - radian: radians to rotate view by.
     ///   - animated: set true to animate rotation (default is false).
     ///   - duration: animation duration in seconds (default is 1 second).
     ///   - completion: optional completion handler to run with animation finishes (default is nil).
-    func rotate(toAngle angle: CGFloat, ofType type: AngleUnit, animated: Bool = false, duration: TimeInterval = 1, completion: ((Bool) -> Void)? = nil) {
-        let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
+    func rotate(byRadian radian: CGFloat, animated: Bool = false, duration: TimeInterval = 1, completion: ((Bool) -> Void)? = nil) {
+        let aDuration = animated ? duration : 0
+        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
+            self.transform = self.transform.rotated(by: radian)
+        }, completion: completion)
+    }
+
+    /// SwifterSwift: Rotate view by degrees on relative axis.
+    ///
+    /// - Parameters:
+    ///   - degree: degrees to rotate view by.
+    ///   - animated: set true to animate rotation (default is false).
+    ///   - duration: animation duration in seconds (default is 1 second).
+    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    func rotate(byDegree degree: CGFloat, animated: Bool = false, duration: TimeInterval = 1, completion: ((Bool) -> Void)? = nil) {
+        let radian = .pi * degree / 180.0
+        let aDuration = animated ? duration : 0
+        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
+            self.transform = self.transform.rotated(by: radian)
+        }, completion: completion)
+    }
+
+    /// SwifterSwift: Rotate view to given radian on fixed axis.
+    ///
+    /// - Parameters:
+    ///   - radian: radian to rotate view to.
+    ///   - animated: set true to animate rotation (default is false).
+    ///   - duration: animation duration in seconds (default is 1 second).
+    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    func rotate(toRadian radian: CGFloat, animated: Bool = false, duration: TimeInterval = 1, completion: ((Bool) -> Void)? = nil) {
         let aDuration = animated ? duration : 0
         UIView.animate(withDuration: aDuration, animations: {
-            self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: angleWithType))
+            self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: radian))
+        }, completion: completion)
+    }
+
+    /// SwifterSwift: Rotate view to given degrees on fixed axis.
+    ///
+    /// - Parameters:
+    ///   - degree: degree to rotate view to.
+    ///   - animated: set true to animate rotation (default is false).
+    ///   - duration: animation duration in seconds (default is 1 second).
+    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    func rotate(toDegree degree: CGFloat, animated: Bool = false, duration: TimeInterval = 1, completion: ((Bool) -> Void)? = nil) {
+        let radian = .pi * degree / 180.0
+        let aDuration = animated ? duration : 0
+        UIView.animate(withDuration: aDuration, animations: {
+            self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: radian))
         }, completion: completion)
     }
 
@@ -401,32 +378,33 @@ public extension UIView {
         }
     }
 
-    /// SwifterSwift: Shake view.
+    /// SwifterSwift: Shake view vertically
     ///
     /// - Parameters:
-    ///   - direction: shake direction (horizontal or vertical), (default is .horizontal)
     ///   - duration: animation duration in seconds (default is 1 second).
     ///   - animationType: shake animation type (default is .easeOut).
     ///   - completion: optional completion handler to run with animation finishes (default is nil).
-    func shake(direction: ShakeDirection = .horizontal, duration: TimeInterval = 1, animationType: ShakeAnimationType = .easeOut, completion:(() -> Void)? = nil) {
+    func verticalShake(duration: TimeInterval = 1, animationType: CAMediaTimingFunctionName = .easeOut, completion:(() -> Void)? = nil) {
         CATransaction.begin()
-        let animation: CAKeyframeAnimation
-        switch direction {
-        case .horizontal:
-            animation = CAKeyframeAnimation(keyPath: "transform.translation.x")
-        case .vertical:
-            animation = CAKeyframeAnimation(keyPath: "transform.translation.y")
-        }
-        switch animationType {
-        case .linear:
-            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
-        case .easeIn:
-            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
-        case .easeOut:
-            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
-        case .easeInOut:
-            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-        }
+        let animation = CAKeyframeAnimation(keyPath: "transform.translation.y")
+        animation.timingFunction = CAMediaTimingFunction(name: animationType)
+        CATransaction.setCompletionBlock(completion)
+        animation.duration = duration
+        animation.values = [-20.0, 20.0, -20.0, 20.0, -10.0, 10.0, -5.0, 5.0, 0.0 ]
+        layer.add(animation, forKey: "shake")
+        CATransaction.commit()
+    }
+
+    /// SwifterSwift: Shake view vertically horizontally
+    ///
+    /// - Parameters:
+    ///   - duration: animation duration in seconds (default is 1 second).
+    ///   - animationType: shake animation type (default is .easeOut).
+    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    func horizontalShake(duration: TimeInterval = 1, animationType: CAMediaTimingFunctionName = .easeOut, completion:(() -> Void)? = nil) {
+        CATransaction.begin()
+        let animation = CAKeyframeAnimation(keyPath: "transform.translation.x")
+        animation.timingFunction = CAMediaTimingFunction(name: animationType)
         CATransaction.setCompletionBlock(completion)
         animation.duration = duration
         animation.values = [-20.0, 20.0, -20.0, 20.0, -10.0, 10.0, -5.0, 5.0, 0.0 ]

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -252,15 +252,15 @@ final class UIViewExtensionsTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
-    func testRotateByAngle() {
+    func testRotateByRadians() {
         let view1 = UIView()
         let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(byAngle: 2, ofType: .radians, animated: false, duration: 0, completion: nil)
+        view1.rotate(byRadian: 2, animated: false, duration: 0, completion: nil)
         XCTAssertEqual(view1.transform, transform1)
 
         let view2 = UIView()
-        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
-        view2.rotate(byAngle: 90, ofType: .degrees, animated: false, duration: 0, completion: nil)
+        let transform2 = CGAffineTransform(rotationAngle: CGFloat(90).degreesToRadians)
+        view2.rotate(byRadian: CGFloat(90).degreesToRadians, animated: false, duration: 0, completion: nil)
         XCTAssertEqual(view2.transform, transform2)
 
         let rotateExpectation = expectation(description: "view rotated")
@@ -268,22 +268,22 @@ final class UIViewExtensionsTests: XCTestCase {
         let view3 = UIView()
         let transform3 = CGAffineTransform(rotationAngle: 2)
 
-        view3.rotate(byAngle: 2, ofType: .radians, animated: true, duration: 0.5) { _ in
+        view3.rotate(byRadian: 2, animated: true, duration: 0.5) { _ in
             rotateExpectation.fulfill()
         }
         XCTAssertEqual(view3.transform, transform3)
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
-    func testRotateToAngle() {
+    func testRotateByDegrees() {
         let view1 = UIView()
         let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(toAngle: 2, ofType: .radians, animated: false, duration: 0, completion: nil)
+        view1.rotate(byDegree: CGFloat(2).radiansToDegrees, animated: false, duration: 0, completion: nil)
         XCTAssertEqual(view1.transform, transform1)
 
         let view2 = UIView()
-        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
-        view2.rotate(toAngle: 90, ofType: .degrees, animated: false, duration: 0, completion: nil)
+        let transform2 = CGAffineTransform(rotationAngle: CGFloat(90).degreesToRadians)
+        view2.rotate(byDegree: 90, animated: false, duration: 0, completion: nil)
         XCTAssertEqual(view2.transform, transform2)
 
         let rotateExpectation = expectation(description: "view rotated")
@@ -291,7 +291,53 @@ final class UIViewExtensionsTests: XCTestCase {
         let view3 = UIView()
         let transform3 = CGAffineTransform(rotationAngle: 2)
 
-        view3.rotate(toAngle: 2, ofType: .radians, animated: true, duration: 0.5) { _ in
+        view3.rotate(byDegree: CGFloat(2).radiansToDegrees, animated: true, duration: 0.5) { _ in
+            rotateExpectation.fulfill()
+        }
+        XCTAssertEqual(view3.transform, transform3)
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testRotateToDegree() {
+        let view1 = UIView()
+        let transform1 = CGAffineTransform(rotationAngle: 2)
+        view1.rotate(toDegree: CGFloat(2).radiansToDegrees, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, transform1)
+
+        let view2 = UIView()
+        let transform2 = CGAffineTransform(rotationAngle: CGFloat(90).degreesToRadians)
+        view2.rotate(toDegree: 90, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view2.transform, transform2)
+
+        let rotateExpectation = expectation(description: "view rotated")
+
+        let view3 = UIView()
+        let transform3 = CGAffineTransform(rotationAngle: 2)
+
+        view3.rotate(toDegree: CGFloat(2).radiansToDegrees, animated: true, duration: 0.5) { _ in
+            rotateExpectation.fulfill()
+        }
+        XCTAssertEqual(view3.transform, transform3)
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testRotateToRadian() {
+        let view1 = UIView()
+        let transform1 = CGAffineTransform(rotationAngle: 2)
+        view1.rotate(toRadian: 2, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, transform1)
+
+        let view2 = UIView()
+        let transform2 = CGAffineTransform(rotationAngle: CGFloat(90).degreesToRadians)
+        view2.rotate(toRadian: CGFloat(90).degreesToRadians, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view2.transform, transform2)
+
+        let rotateExpectation = expectation(description: "view rotated")
+
+        let view3 = UIView()
+        let transform3 = CGAffineTransform(rotationAngle: 2)
+
+        view3.rotate(toRadian: 2, animated: true, duration: 0.5) { _ in
             rotateExpectation.fulfill()
         }
         XCTAssertEqual(view3.transform, transform3)
@@ -312,6 +358,22 @@ final class UIViewExtensionsTests: XCTestCase {
 
         XCTAssertEqual(view1.transform, view2.transform)
         XCTAssertEqual(view1.transform, view3.transform)
+    }
+
+    func testHorizontalShake() {
+        let view = UIView()
+        view.horizontalShake(animationType: .easeIn)
+        let currentAnimation = view.layer.animation(forKey: view.layer.animationKeys()?.first ?? "")
+
+        XCTAssertEqual(currentAnimation?.timingFunction, CAMediaTimingFunction(name: .easeIn))
+    }
+
+    func testVerticalShake() {
+        let view = UIView()
+        view.verticalShake(animationType: .linear)
+        let currentAnimation = view.layer.animation(forKey: view.layer.animationKeys()?.first ?? "")
+
+        XCTAssertEqual(currentAnimation?.timingFunction, CAMediaTimingFunction(name: .linear))
     }
 
     func testRemoveSubviews() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.


Further Details;

Removed enums `ShakeDirection`, `AngleUnit`, `ShakeAnimationType` and their dependent functions (or more correctly, re-wrote them)

One of the goals of SwifterSwift is to allow for anyone to just copy what they need without needing to copy anything else.  While these enums do allow for a cleaner code read, I feel they take away from the spirit of the project.

Note:  I did, however, remove those enums and dependent functions, instead of maybe more gently deprecating them for now for anyone who may be using the SwifterSwift pod directly in their project.