### PR TITLE
Modified UIImage extension compressed so it doesn't use other extensions

### DIFF
--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -42,7 +42,7 @@ public extension UIImage {
     /// - Parameter quality: The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality), (default is 0.5).
     /// - Returns: optional UIImage (if applicable).
     func compressed(quality: CGFloat = 0.5) -> UIImage? {
-        guard let data = compressedData(quality: quality) else { return nil }
+        guard let data = jpegData(compressionQuality: quality) else { return nil }
         return UIImage(data: data)
     }
 


### PR DESCRIPTION
Modified UIImage extension compressed so it doesn't use other extensions, fixes #757  🚀

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x] New extensions are written in Swift 5.0.
- [ x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ x] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ x ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
