### PR TITLE
Make group(by:) generic for all Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `sum(for:)` to sum up an `AdditiveArithmetic` property, referenced by `KeyPath`, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
 
 ### Changed
+- **Collection**:
+  - Refactored `group(by:)` to be generic for all `Collection`s, not only `where Index == Int`. [#758](https://github.com/SwifterSwift/SwifterSwift/pull/758) by [guykogus](https://github.com/guykogus)
 - **UIImage**:
   - Implemented `filled(withColor:)` using `UIGraphicsImageRenderer` when available. [#733](https://github.com/SwifterSwift/SwifterSwift/pull/733)
   - Updated `kilobytesSize` to be computed independently from `bytesSize` [#753](https://github.com/SwifterSwift/SwifterSwift/pull/753) by [mmdock](https://github.com/mmdock)

--- a/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
@@ -41,6 +41,26 @@ public extension Collection {
         return indices.contains(index) ? self[index] : nil
     }
 
+    /// SwifterSwift: Returns an array of slices of length "size" from the array. If array can't be split evenly, the final slice will be the remaining elements.
+    ///
+    ///     [0, 2, 4, 7].group(by: 2) -> [[0, 2], [4, 7]]
+    ///     [0, 2, 4, 7, 6].group(by: 2) -> [[0, 2], [4, 7], [6]]
+    ///
+    /// - Parameter size: The size of the slices to be returned.
+    /// - Returns: grouped self.
+    func group(by size: Int) -> [[Element]]? {
+        // Inspired by: https://lodash.com/docs/4.17.4#chunk
+        guard size > 0, !isEmpty else { return nil }
+        var start = startIndex
+        var slices = [[Element]]()
+        while start != endIndex {
+            let end = index(start, offsetBy: size, limitedBy: endIndex) ?? endIndex
+            slices.append(Array(self[start..<end]))
+            start = end
+        }
+        return slices
+    }
+
 }
 
 // MARK: - Methods (Int)
@@ -76,25 +96,6 @@ public extension Collection where Index == Int {
             try body(Array(self[Swift.max(value, startIndex)..<Swift.min(value + slice, endIndex)]))
             value += slice
         }
-    }
-
-    /// SwifterSwift: Returns an array of slices of length "size" from the array. If array can't be split evenly, the final slice will be the remaining elements.
-    ///
-    ///     [0, 2, 4, 7].group(by: 2) -> [[0, 2], [4, 7]]
-    ///     [0, 2, 4, 7, 6].group(by: 2) -> [[0, 2], [4, 7], [6]]
-    ///
-    /// - Parameter size: The size of the slices to be returned.
-    /// - Returns: grouped self.
-    func group(by size: Int) -> [[Element]]? {
-        // Inspired by: https://lodash.com/docs/4.17.4#chunk
-        guard size > 0, !isEmpty else { return nil }
-        var value: Int = 0
-        var slices: [[Element]] = []
-        while value < count {
-            slices.append(Array(self[Swift.max(value, startIndex)..<Swift.min(value + size, endIndex)]))
-            value += size
-        }
-        return slices
     }
 
 }


### PR DESCRIPTION
🚀
This change allows the function to be used on `String`, for example.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
