### PR TITLE
Fixed build errors in KeyedDecodingContainerTests

### DIFF
--- a/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
@@ -1,5 +1,5 @@
 //
-//  KeyedDecodingContainerTests.swift
+//  KeyedDecodingContainerExtensionsTests.swift
 //  SwifterSwift
 //
 //  Created by Francesco Deliro on 23/10/2019.

--- a/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
@@ -31,7 +31,7 @@ final class KeyedDecodingContainerTests: XCTestCase {
     func testDecodeBoolAsIntOrStringDataAsIntSuccessful() {
         let isPlayingAndIsFullScreenAsInt = #"{"isPlaying": 1, "isFullScreen": 0}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsInt)
-        let video = try? JSONDecoder().decode(Video.self, from: data)
+        let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
         XCTAssertNotNil(video)
         XCTAssertEqual(video?.isPlaying, true)
         XCTAssertEqual(video?.isFullScreen, false)

--- a/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
@@ -34,7 +34,6 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
         XCTAssertTrue(video.isPlaying)
         XCTAssertEqual(video.isFullScreen, false)
-
     }
 
     func testDecodeBoolAsIntOrStringDataAsStringSuccessful() {
@@ -43,7 +42,6 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
         XCTAssertTrue(video.isPlaying)
         XCTAssertEqual(video.isFullScreen, false)
-
     }
 
     func testDecodeBoolAsIntOrStringDataAsBoolSuccessful() {
@@ -52,7 +50,6 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
         XCTAssertTrue(video.isPlaying)
         XCTAssertEqual(video.isFullScreen, false)
-
     }
 
     func testDecodeBoolAsIntOrStringIfPresentSuccessful() {

--- a/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
@@ -32,36 +32,35 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let isPlayingAndIsFullScreenAsInt = #"{"isPlaying": 1, "isFullScreen": 0}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsInt)
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
-        XCTAssertNotNil(video)
-        XCTAssertEqual(video?.isPlaying, true)
-        XCTAssertEqual(video?.isFullScreen, false)
+        XCTAssertTrue(video.isPlaying)
+        XCTAssertEqual(video.isFullScreen, false)
+
     }
 
     func testDecodeBoolAsIntOrStringDataAsStringSuccessful() {
         let isPlayingAndIsFullScreenAsString = #"{"isPlaying": "true", "isFullScreen": "false"}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsString)
-        let video = try? JSONDecoder().decode(Video.self, from: data)
-        XCTAssertNotNil(video)
-        XCTAssertEqual(video?.isPlaying, true)
-        XCTAssertEqual(video?.isFullScreen, false)
+        let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
+        XCTAssertTrue(video.isPlaying)
+        XCTAssertEqual(video.isFullScreen, false)
+
     }
 
     func testDecodeBoolAsIntOrStringDataAsBoolSuccessful() {
         let isPlayingAndIsFullScreenAsBool = #"{"isPlaying": true, "isFullScreen": false}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsBool)
-        let video = try? JSONDecoder().decode(Video.self, from: data)
-        XCTAssertNotNil(video)
-        XCTAssertEqual(video?.isPlaying, true)
-        XCTAssertEqual(video?.isFullScreen, false)
+        let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
+        XCTAssertTrue(video.isPlaying)
+        XCTAssertEqual(video.isFullScreen, false)
+
     }
 
     func testDecodeBoolAsIntOrStringIfPresentSuccessful() {
         let isPlayingAsIntAndIsFullScreenNotPresent = #"{"isPlaying": 0}"#
         let data = mockJsonData(from: isPlayingAsIntAndIsFullScreenNotPresent)
-        let video = try? JSONDecoder().decode(Video.self, from: data)
-        XCTAssertNotNil(video)
-        XCTAssertEqual(video?.isPlaying, false)
-        XCTAssertNil(video?.isFullScreen)
+        let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
+        XCTAssertFalse(video.isPlaying)
+        XCTAssertNil(video.isFullScreen)
     }
 
     func testDecodeBoolAsIntOrStringThrowsError() {

--- a/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
@@ -31,33 +31,37 @@ final class KeyedDecodingContainerTests: XCTestCase {
     func testDecodeBoolAsIntOrStringDataAsIntSuccessful() {
         let isPlayingAndIsFullScreenAsInt = #"{"isPlaying": 1, "isFullScreen": 0}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsInt)
-        let video = try! JSONDecoder().decode(Video.self, from: data)
-        XCTAssertTrue(video.isPlaying)
-        XCTAssertEqual(video.isFullScreen, false)
+        let video = try? JSONDecoder().decode(Video.self, from: data)
+        XCTAssertNotNil(video)
+        XCTAssertEqual(video?.isPlaying, true)
+        XCTAssertEqual(video?.isFullScreen, false)
     }
 
     func testDecodeBoolAsIntOrStringDataAsStringSuccessful() {
         let isPlayingAndIsFullScreenAsString = #"{"isPlaying": "true", "isFullScreen": "false"}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsString)
-        let video = try! JSONDecoder().decode(Video.self, from: data)
-        XCTAssertTrue(video.isPlaying)
-        XCTAssertEqual(video.isFullScreen, false)
+        let video = try? JSONDecoder().decode(Video.self, from: data)
+        XCTAssertNotNil(video)
+        XCTAssertEqual(video?.isPlaying, true)
+        XCTAssertEqual(video?.isFullScreen, false)
     }
 
     func testDecodeBoolAsIntOrStringDataAsBoolSuccessful() {
         let isPlayingAndIsFullScreenAsBool = #"{"isPlaying": true, "isFullScreen": false}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsBool)
-        let video = try! JSONDecoder().decode(Video.self, from: data)
-        XCTAssertTrue(video.isPlaying)
-        XCTAssertEqual(video.isFullScreen, false)
+        let video = try? JSONDecoder().decode(Video.self, from: data)
+        XCTAssertNotNil(video)
+        XCTAssertEqual(video?.isPlaying, true)
+        XCTAssertEqual(video?.isFullScreen, false)
     }
 
     func testDecodeBoolAsIntOrStringIfPresentSuccessful() {
         let isPlayingAsIntAndIsFullScreenNotPresent = #"{"isPlaying": 0}"#
         let data = mockJsonData(from: isPlayingAsIntAndIsFullScreenNotPresent)
-        let video = try! JSONDecoder().decode(Video.self, from: data)
-        XCTAssertFalse(video.isPlaying)
-        XCTAssertNil(video.isFullScreen)
+        let video = try? JSONDecoder().decode(Video.self, from: data)
+        XCTAssertNotNil(video)
+        XCTAssertEqual(video?.isPlaying, false)
+        XCTAssertNil(video?.isFullScreen)
     }
 
     func testDecodeBoolAsIntOrStringThrowsError() {
@@ -65,7 +69,7 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let data = mockJsonData(from: isPlayingAndIsFullScreenTypeMismatch)
         XCTAssertThrowsError(try JSONDecoder().decode(Video.self, from: data))
     }
-  
+
     private func mockJsonData(from json: String) -> Data {
         return Data(json.utf8)
     }


### PR DESCRIPTION
🚀 Fixed build errors in `KeyedDecodingContainerTests` caused by `try!`.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
