### PR TITLE
Filter by key path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `sum(for:)` to sum up an `AdditiveArithmetic` property, referenced by `KeyPath`, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
   - Added `map(by:)` to map the sequence elements by a given key path. [#763](https://github.com/SwifterSwift/SwifterSwift/pull/763) by [Roman Podymov](https://github.com/RomanPodymov).
   - Added `compactMap(by:)` to map the sequence elements by a given key path to the non-nil elements array. [#766](https://github.com/SwifterSwift/SwifterSwift/pull/766) by [Roman Podymov](https://github.com/RomanPodymov).
-  - Added `filter(by:)` to filter the sequence elements by a given boolean key path. [#770](https://github.com/SwifterSwift/SwifterSwift/pull/770) by [Roman Podymov](https://github.com/RomanPodymov).
+  - Added `filter(by:)` to filter the sequence elements by a given boolean key path. [#771](https://github.com/SwifterSwift/SwifterSwift/pull/771) by [Roman Podymov](https://github.com/RomanPodymov).
 - **MutableCollection**:
   - Added `assignToAll(value:keyPath:)` to assign given value to field `keyPath` of every element in the collection. [#759](https://github.com/SwifterSwift/SwifterSwift/issues/759) by [cyber-gh](https://github.com/cyber-gh).
 - **KeyedDecodingContainer**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `sum(for:)` to sum up an `AdditiveArithmetic` property, referenced by `KeyPath`, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
   - Added `map(by:)` to map the sequence elements by a given key path. [#763](https://github.com/SwifterSwift/SwifterSwift/pull/763) by [Roman Podymov](https://github.com/RomanPodymov).
   - Added `compactMap(by:)` to map the sequence elements by a given key path to the non-nil elements array. [#766](https://github.com/SwifterSwift/SwifterSwift/pull/766) by [Roman Podymov](https://github.com/RomanPodymov).
+  - Added `filter(by:)` to filter the sequence elements by a given boolean key path. [#770](https://github.com/SwifterSwift/SwifterSwift/pull/770) by [Roman Podymov](https://github.com/RomanPodymov).
 - **MutableCollection**:
   - Added `assignToAll(value:keyPath:)` to assign given value to field `keyPath` of every element in the collection. [#759](https://github.com/SwifterSwift/SwifterSwift/issues/759) by [cyber-gh](https://github.com/cyber-gh).
 - **KeyedDecodingContainer**:

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -229,6 +229,14 @@ public extension Sequence {
     func compactMap<T>(by keyPath: KeyPath<Element, T?>) -> [T] {
         return compactMap { $0[keyPath: keyPath] }
     }
+
+    /// SwifterSwift: Returns an array containing the results of filtering the sequence’s elements by a boolean key path.
+    ///
+    /// - Parameter keyPath: Boolean key path. If it's value is `true` the element will be added to result.
+    /// - Returns: An array containing filtered elements.
+    func filter(by keyPath: KeyPath<Element, Bool>) -> [Element] {
+        return filter { $0[keyPath: keyPath] }
+    }
 }
 
 public extension Sequence where Element: Equatable {

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -167,4 +167,9 @@ final class SequenceExtensionsTests: XCTestCase {
         let array2 = [Person(name: "Daniel", age: 45, location: Location(city: "Pittsburgh")), Person(name: "Michael", age: nil, location: Location(city: "Dresden")), Person(name: "Pierre", age: 20, location: Location(city: "Paris"))]
         XCTAssertEqual(array2.compactMap(by: \.age), [45, 20])
     }
+
+    func testFilterByKeyPath() {
+        let array1 = [Person(name: "Iveta", age: 20, location: Location(city: "Prague"), isStudent: true), Person(name: "Victor", age: 44, location: Location(city: "Dallas"), isStudent: false), Person(name: "Lukasz", age: 62, location: nil), Person(name: "Anna", age: 18, location: Location(city: "Minsk"), isStudent: true)]
+        XCTAssertEqual(array1.filter(by: \.isStudent), [Person(name: "Iveta", age: 20, location: Location(city: "Prague"), isStudent: true), Person(name: "Anna", age: 18, location: Location(city: "Minsk"), isStudent: true)])
+    }
 }

--- a/Tests/SwiftStdlibTests/TestHelpers.swift
+++ b/Tests/SwiftStdlibTests/TestHelpers.swift
@@ -14,11 +14,13 @@ struct Person: Equatable {
     var name: String
     var age: Int?
     var location: Location?
+    var isStudent: Bool
 
-    init(name: String, age: Int?, location: Location? = nil) {
+    init(name: String, age: Int?, location: Location? = nil, isStudent: Bool = false) {
         self.name = name
         self.age = age
         self.location = location
+        self.isStudent = isStudent
     }
 }
 


### PR DESCRIPTION
🚀 Added `Sequence.filter(by:)` similar to [map](https://github.com/SwifterSwift/SwifterSwift/pull/763) and [compactMap](https://github.com/SwifterSwift/SwifterSwift/pull/766).

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
