### PR TITLE
Add sorted(like:keyPath:) to Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **Array**:
+  - Added `sorted(like:keyPath:)` to sort an array like another array based on a keyPath. [#772](https://github.com/SwifterSwift/SwifterSwift/pull/772) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **Dictionary**:
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **Array**:
-  - Added `sorted(like:keyPath:)` to sort an array like another array based on a keyPath. [#772](https://github.com/SwifterSwift/SwifterSwift/pull/772) by [MaxHaertwig](https://github.com/maxhaertwig).
+  - Added `sorted(like:keyPath:)` to sort an array like another array based on a key path. [#772](https://github.com/SwifterSwift/SwifterSwift/pull/772) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **Dictionary**:
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -34,7 +34,7 @@ public extension Array {
         swapAt(index, otherIndex)
     }
 
-    /// SwifterSwift: Sort an array like another array based on a keyPath. If the other array doesn't contain a certain value, it will be sorted last.
+    /// SwifterSwift: Sort an array like another array based on a key path. If the other array doesn't contain a certain value, it will be sorted last.
     ///
     ///        [MyStruct(x: 3), MyStruct(x: 1), MyStruct(x: 2)].sorted(like: [1, 2, 3], keyPath: \.x)
     ///            -> [MyStruct(x: 1), MyStruct(x: 2), MyStruct(x: 3)]

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -33,6 +33,24 @@ public extension Array {
         guard startIndex..<endIndex ~= otherIndex else { return }
         swapAt(index, otherIndex)
     }
+
+    /// SwifterSwift: Sort an array like another array based on a keyPath. If the other array doesn't contain a certain value, it will be sorted last.
+    ///
+    ///        [MyStruct(x: 3), MyStruct(x: 1), MyStruct(x: 2)].sorted(like: [1, 2, 3], keyPath: \.x)
+    ///            -> [MyStruct(x: 1), MyStruct(x: 2), MyStruct(x: 3)]
+    ///
+    /// - Parameters:
+    ///   - otherArray: array containing elements in the desired order.
+    ///   - keyPath: keyPath indiciating the property that the array should be sorted by
+    /// - Returns: sorted array.
+    func sorted<T: Hashable>(like otherArray: [T], keyPath: KeyPath<Element, T>) -> [Element] {
+        let dict = otherArray.enumerated().reduce(into: [:]) { $0[$1.element] = $1.offset }
+        return sorted {
+            guard let thisIndex = dict[$0[keyPath: keyPath]] else { return false }
+            guard let otherIndex = dict[$1[keyPath: keyPath]] else { return true }
+            return thisIndex < otherIndex
+        }
+    }
 }
 
 // MARK: - Methods (Equatable)

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -36,6 +36,21 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(swappedEmptyArray, emptyArray)
     }
 
+    func testSortedLike() {
+        let expected1 = [1, 2, 3, 4, 5]
+        let candidate1 = [2, 5, 3, 1, 4]
+        XCTAssertEqual(candidate1.sorted(like: expected1, keyPath: \.self), expected1)
+
+        let candidate2 = [2, 5, 3, 6, 1, 4]
+        XCTAssertEqual(candidate2.sorted(like: expected1, keyPath: \.self), [1, 2, 3, 4, 5, 6])
+
+        // swiftlint:disable:next nesting
+        struct TestStruct { let prop: String }
+        let case3 = ["1", "2", "3", "4", "5"]
+        let candidate3 = [TestStruct(prop: "3"), TestStruct(prop: "2"), TestStruct(prop: "2"), TestStruct(prop: "1"), TestStruct(prop: "3")]
+        XCTAssertEqual(candidate3.sorted(like: case3, keyPath: \.prop).map { $0.prop }, ["1", "2", "2", "3", "3"])
+    }
+
     func testRemoveAll() {
         var arr = [0, 1, 2, 0, 3, 4, 5, 0, 0]
         arr.removeAll(0)

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -37,18 +37,18 @@ final class ArrayExtensionsTests: XCTestCase {
     }
 
     func testSortedLike() {
-        let expected1 = [1, 2, 3, 4, 5]
+        let order1 = [1, 2, 3, 4, 5]
         let candidate1 = [2, 5, 3, 1, 4]
-        XCTAssertEqual(candidate1.sorted(like: expected1, keyPath: \.self), expected1)
+        XCTAssertEqual(candidate1.sorted(like: order1, keyPath: \.self), order1)
 
         let candidate2 = [2, 5, 3, 6, 1, 4]
-        XCTAssertEqual(candidate2.sorted(like: expected1, keyPath: \.self), [1, 2, 3, 4, 5, 6])
+        XCTAssertEqual(candidate2.sorted(like: order1, keyPath: \.self), [1, 2, 3, 4, 5, 6])
 
         // swiftlint:disable:next nesting
         struct TestStruct { let prop: String }
-        let case3 = ["1", "2", "3", "4", "5"]
+        let order3 = ["1", "2", "3", "4", "5"]
         let candidate3 = [TestStruct(prop: "3"), TestStruct(prop: "2"), TestStruct(prop: "2"), TestStruct(prop: "1"), TestStruct(prop: "3")]
-        XCTAssertEqual(candidate3.sorted(like: case3, keyPath: \.prop).map { $0.prop }, ["1", "2", "2", "3", "3"])
+        XCTAssertEqual(candidate3.sorted(like: order3, keyPath: \.prop).map { $0.prop }, ["1", "2", "2", "3", "3"])
     }
 
     func testRemoveAll() {


### PR DESCRIPTION
Add sorted(like:keyPath:) to Array to sort an array like another array based on a keyPath.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [/] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [/] New extensions are written in Swift 5.0.
- [/] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [/] I have added tests for new extensions, and they passed.
- [/] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [/] All extensions are declared as **public**.
- [/] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
