### PR TITLE
[GitHub Actions] Fix code coverage report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  token: 9c92b00a-43e8-4dd3-b455-196052f16f86
+
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Our code coverage reports don't work anymore in the new Github actions CI. 
It needs a token. It worked on Travis because:
<img width="1154" alt="Screen Shot 2020-01-04 at 15 37 28" src="https://user-images.githubusercontent.com/8292651/71770148-3f82c500-2f08-11ea-8274-3f1c969d59b4.png">

So adding the token then ... 


## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
