### PR TITLE
Enable sequence and collection to be sorted by multiple key paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,13 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(colors:locations:startPoint:endPoint:type:)` convenience initializer. [#726](https://github.com/SwifterSwift/SwifterSwift/pull/726) by [JayMehta97](https://github.com/JayMehta97).
 - **Sequence**:
   - Added `sum(for:)` to sum up an `AdditiveArithmetic` property, referenced by `KeyPath`, of all elements in a sequence. [#736](https://github.com/SwifterSwift/SwifterSwift/pull/736) by [Moritz Sternemann](https://github.com/moritzsternemann).
+  - Added `sorted(by:and:)` and `sorted(by:and:and:)` to obtain a sorted sequence based on multiple key paths. [#796](https://github.com/SwifterSwift/SwifterSwift/pull/796) by [MaxHaertwig](https://github.com/maxhaertwig).
   - Added `map(by:)` to map the sequence elements by a given key path. [#763](https://github.com/SwifterSwift/SwifterSwift/pull/763) by [Roman Podymov](https://github.com/RomanPodymov).
   - Added `compactMap(by:)` to map the sequence elements by a given key path to the non-nil elements array. [#766](https://github.com/SwifterSwift/SwifterSwift/pull/766) by [Roman Podymov](https://github.com/RomanPodymov).
   - Added `filter(by:)` to filter the sequence elements by a given boolean key path. [#771](https://github.com/SwifterSwift/SwifterSwift/pull/771) by [Roman Podymov](https://github.com/RomanPodymov).
 - **MutableCollection**:
   - Added `assignToAll(value:keyPath:)` to assign given value to field `keyPath` of every element in the collection. [#759](https://github.com/SwifterSwift/SwifterSwift/issues/759) by [cyber-gh](https://github.com/cyber-gh).
+  - Added `sort(by:and:)` and `sort(by:and:and:)` to sort a sequence based on multiple key paths. [#796](https://github.com/SwifterSwift/SwifterSwift/pull/796) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **KeyedDecodingContainer**:
   - Added `decodeBoolAsIntOrString(key:)` to try to decode a `Bool` as `Int` then `String` before decoding as Bool. [#750](https://github.com/SwifterSwift/SwifterSwift/pull/750) by [FraDeliro](https://github.com/FraDeliro).
   - Added `decodeBoolAsIntOrStringIfPresent(key:)` to try to decode a `Bool` as `Int` then `String` before decoding as `Bool` if present. [#750](https://github.com/SwifterSwift/SwifterSwift/pull/750) by [FraDeliro](https://github.com/FraDeliro).

--- a/Sources/SwifterSwift/SwiftStdlib/MutableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/MutableCollectionExtensions.swift
@@ -7,19 +7,54 @@
 //
 
 public extension MutableCollection where Self: RandomAccessCollection {
-    /// SwifterSwift: Sort the collection  based on a keypath and a compare function.
+    /// SwifterSwift: Sort the collection based on a keypath and a compare function.
     ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
+    /// - Parameter keyPath: Key path to sort by. The key path type must be Comparable.
     /// - Parameter compare: Comparation function that will determine the ordering.
     mutating func sort<T>(by keyPath: KeyPath<Element, T>, with compare: (T, T) -> Bool) {
         sort { compare($0[keyPath: keyPath], $1[keyPath: keyPath]) }
     }
 
-    /// SwifterSwift: Sort the collection  based on a keypath and a compare function.
+    /// SwifterSwift: Sort the collection based on a keypath.
     ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
+    /// - Parameter keyPath: Key path to sort by. The key path type must be Comparable.
     mutating func sort<T: Comparable>(by keyPath: KeyPath<Element, T>) {
         sort { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
+    }
+
+    /// SwifterSwift: Sort the collection based on two key paths. The second one will be used in case the values of the first one match.
+    ///
+    /// - Parameters:
+    ///     - keyPath1: Key path to sort by. Must be Comparable.
+    ///     - keyPath2: Key path to sort by in case the values of `keyPath1` match. Must be Comparable.
+    mutating func sort<T: Comparable, U: Comparable>(by keyPath1: KeyPath<Element, T>,
+                                                     and keyPath2: KeyPath<Element, U>) {
+        sort {
+            if $0[keyPath: keyPath1] != $1[keyPath: keyPath1] {
+                return $0[keyPath: keyPath1] < $1[keyPath: keyPath1]
+            }
+            return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
+        }
+    }
+
+    /// SwifterSwift: Sort the collection based on three key paths. Whenever the values of one key path match, the next one will be used.
+    ///
+    /// - Parameters:
+    ///     - keyPath1: Key path to sort by. Must be Comparable.
+    ///     - keyPath2: Key path to sort by in case the values of `keyPath1` match. Must be Comparable.
+    ///     - keyPath3: Key path to sort by in case the values of `keyPath1` and `keyPath2` match. Must be Comparable.
+    mutating func sort<T: Comparable, U: Comparable, V: Comparable>(by keyPath1: KeyPath<Element, T>,
+                                                                    and keyPath2: KeyPath<Element, U>,
+                                                                    and keyPath3: KeyPath<Element, V>) {
+        sort {
+            if $0[keyPath: keyPath1] != $1[keyPath: keyPath1] {
+                return $0[keyPath: keyPath1] < $1[keyPath: keyPath1]
+            }
+            if $0[keyPath: keyPath2] != $1[keyPath: keyPath2] {
+                return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
+            }
+            return $0[keyPath: keyPath3] < $1[keyPath: keyPath3]
+        }
     }
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -186,21 +186,56 @@ public extension Sequence {
         return (Array(matching), Array(nonMatching))
     }
 
-    /// SwifterSwift: Return a sorted array  based on a keypath and a compare function.
+    /// SwifterSwift: Return a sorted array based on a key path and a compare function.
     ///
-    /// - Parameter path: Key path to sort.
+    /// - Parameter keyPath: Key path to sort by.
     /// - Parameter compare: Comparation function that will determine the ordering.
     /// - Returns: The sorted array.
     func sorted<T>(by keyPath: KeyPath<Element, T>, with compare: (T, T) -> Bool) -> [Element] {
         return sorted { compare($0[keyPath: keyPath], $1[keyPath: keyPath]) }
     }
 
-    /// SwifterSwift: Return a sorted array  based on a keypath.
+    /// SwifterSwift: Return a sorted array based on a key path.
     ///
-    /// - Parameter path: Key path to sort. The key path type must be Comparable.
+    /// - Parameter keyPath: Key path to sort by. The key path type must be Comparable.
     /// - Returns: The sorted array.
     func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
         return sorted { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
+    }
+
+    /// SwifterSwift: Returns a sorted sequence based on two key paths. The second one will be used in case the values of the first one match.
+    ///
+    /// - Parameters:
+    ///     - keyPath1: Key path to sort by. Must be Comparable.
+    ///     - keyPath2: Key path to sort by in case the values of `keyPath1` match. Must be Comparable.
+    func sorted<T: Comparable, U: Comparable>(by keyPath1: KeyPath<Element, T>,
+                                              and keyPath2: KeyPath<Element, U>) -> [Element] {
+        return sorted {
+            if $0[keyPath: keyPath1] != $1[keyPath: keyPath1] {
+                return $0[keyPath: keyPath1] < $1[keyPath: keyPath1]
+            }
+            return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
+        }
+    }
+
+    /// SwifterSwift: Returns a sorted sequence based on three key paths. Whenever the values of one key path match, the next one will be used.
+    ///
+    /// - Parameters:
+    ///     - keyPath1: Key path to sort by. Must be Comparable.
+    ///     - keyPath2: Key path to sort by in case the values of `keyPath1` match. Must be Comparable.
+    ///     - keyPath3: Key path to sort by in case the values of `keyPath1` and `keyPath2` match. Must be Comparable.
+    func sorted<T: Comparable, U: Comparable, V: Comparable>(by keyPath1: KeyPath<Element, T>,
+                                                             and keyPath2: KeyPath<Element, U>,
+                                                             and keyPath3: KeyPath<Element, V>) -> [Element] {
+        return sorted {
+            if $0[keyPath: keyPath1] != $1[keyPath: keyPath1] {
+                return $0[keyPath: keyPath1] < $1[keyPath: keyPath1]
+            }
+            if $0[keyPath: keyPath2] != $1[keyPath: keyPath2] {
+                return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
+            }
+            return $0[keyPath: keyPath3] < $1[keyPath: keyPath3]
+        }
     }
 
     /// SwifterSwift: Sum of a `AdditiveArithmetic` property of each `Element` in a `Sequence`.

--- a/Tests/SwiftStdlibTests/MutableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/MutableCollectionTests.swift
@@ -34,6 +34,38 @@ final class MutableCollectionTests: XCTestCase {
         XCTAssertEqual(array2, ["Bryant", "James", "Wade", ""])
     }
 
+    func testSortByTwoKeyPaths() {
+        var people = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Max", surname: "James", age: 34)
+        ]
+        people.sort(by: \.surname, and: \.age)
+        let expectedResult = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57)
+        ]
+        XCTAssertEqual(people, expectedResult)
+    }
+
+    func testSortByThreeKeyPaths() {
+        var people = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 82)
+        ]
+        people.sort(by: \.surname, and: \.forename, and: \.age)
+        let expectedResult = [
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 82)
+        ]
+        XCTAssertEqual(people, expectedResult)
+    }
+
     func testAssignToAll() {
         var collection: [TestStruct] = [1, 2, 3, 4, 5]
         collection.assignToAll(value: 0, by: \.testField)

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -152,6 +152,36 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
     }
 
+    func testSortedByTwoKeyPaths() {
+        let people = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Max", surname: "James", age: 34)
+        ]
+        let expectedResult = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57)
+        ]
+        XCTAssertEqual(people.sorted(by: \.surname, and: \.age), expectedResult)
+    }
+
+    func testSortedByThreeKeyPaths() {
+        let people = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 82)
+        ]
+        let expectedResult = [
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 82)
+        ]
+        XCTAssertEqual(people.sorted(by: \.surname, and: \.forename, and: \.age), expectedResult)
+    }
+
     func testMapByKeyPath() {
         let array1 = [Person(name: "John", age: 30, location: Location(city: "Boston")), Person(name: "Jan", age: 22, location: Location(city: "Prague")), Person(name: "Roman", age: 26, location: Location(city: "Moscow"))]
         XCTAssertEqual(array1.map(by: \.name), ["John", "Jan", "Roman"])

--- a/Tests/SwiftStdlibTests/TestHelpers.swift
+++ b/Tests/SwiftStdlibTests/TestHelpers.swift
@@ -10,6 +10,11 @@
  These structs used to test ArrayExtensions and RangeReplaceableCollection.
  Feel free to use it for your needs.
  */
+struct SimplePerson: Equatable {
+    let forename, surname: String
+    let age: Int
+}
+
 struct Person: Equatable {
     var name: String
     var age: Int?


### PR DESCRIPTION
…and:and:) to sort collections/sequences by multiple key paths

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 8.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
