### PR TITLE
Add min. platform to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwifterSwift",
     platforms: [
-        .iOS(SupportedPlatform.IOSVersion.v10),
+        .iOS(SupportedPlatform.IOSVersion.v10)
     ],
     products: [
         .library(name: "SwifterSwift", targets: ["SwifterSwift"])

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwifterSwift",
+    platforms: [
+        .iOS(SupportedPlatform.IOSVersion.v10),
+    ],
     products: [
         .library(name: "SwifterSwift", targets: ["SwifterSwift"])
     ],


### PR DESCRIPTION
In #800 min. target was updated to iOS 10. When using SPM, target is set as oldest supported by SDK. This PR adds min. target to Package.swift. Without it, the compiler fails due to iOS 9 availability checks.

> This predefined deployment version will be the oldest deployment target version supported by the installed SDK for a given platform.
https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#supportedplatform

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
