### PR TITLE
prevent ugly animation when keyboard is on screen and alert is about to show

### DIFF
--- a/Sources/SwifterSwift/UIKit/UIViewControllerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewControllerExtensions.swift
@@ -55,6 +55,8 @@ public extension UIViewController {
     /// - Returns: UIAlertController object (discardable).
     @discardableResult
     func showAlert(title: String?, message: String?, buttonTitles: [String]? = nil, highlightedButtonIndex: Int? = nil, completion: ((Int) -> Void)? = nil) -> UIAlertController {
+        view.layer.removeAllAnimations()
+        
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         var allButtons = buttonTitles ?? [String]()
         if allButtons.count == 0 {


### PR DESCRIPTION
prevent ugly animation when keyboard is on screen and alert is about to show

![simulator222.gif](https://images.zenhubusercontent.com/5db95b53661d2c00012d1d24/68846779-816c-443e-8992-db0394752b0d)
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
