### PR TITLE
Fix image cropped issue when scale not equal to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Fixed
 - Fixed build error occurring when building AppKit extensions for macCatalyst. [#762](https://github.com/SwifterSwift/SwifterSwift/pull/762) by [MaxHaertwig](https://github.com/maxhaertwig).
 - Fixed `String.base64Decoded` making it a safe decode by including padding on the string. [#801](https://github.com/SwifterSwift/SwifterSwift/pull/801) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+- Fixed `UIImage.cropped(to:)` making it work correctly with scaled image. [#811](https://github.com/SwifterSwift/SwifterSwift/pull/811) by [qchenqizhi](https://github.com/qchenqizhi).
 
 ### Security
 

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -61,8 +61,8 @@ public extension UIImage {
     func cropped(to rect: CGRect) -> UIImage {
         guard rect.size.width <= size.width && rect.size.height <= size.height else { return self }
         let scaledRect = rect.applying(CGAffineTransform(scaleX: scale, y: scale))
-        guard let image: CGImage = cgImage?.cropping(to: scaledRect) else { return self }
-        return UIImage(cgImage: image, scale: scale, orientation: self.imageOrientation)
+        guard let image = cgImage?.cropping(to: scaledRect) else { return self }
+        return UIImage(cgImage: image, scale: scale, orientation: imageOrientation)
     }
 
     /// SwifterSwift: UIImage scaled to height with respect to aspect ratio.

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -60,8 +60,9 @@ public extension UIImage {
     /// - Returns: cropped UIImage
     func cropped(to rect: CGRect) -> UIImage {
         guard rect.size.width <= size.width && rect.size.height <= size.height else { return self }
-        guard let image: CGImage = cgImage?.cropping(to: rect) else { return self }
-        return UIImage(cgImage: image)
+        let scaledRect = rect.applying(CGAffineTransform(scaleX: scale, y: scale))
+        guard let image: CGImage = cgImage?.cropping(to: scaledRect) else { return self }
+        return UIImage(cgImage: image, scale: scale, orientation: self.imageOrientation)
     }
 
     /// SwifterSwift: UIImage scaled to height with respect to aspect ratio.

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -70,6 +70,21 @@ final class UIImageExtensionsTests: XCTestCase {
 
         let equalWidth = image.cropped(to: CGRect(x: 0, y: 0, width: 20, height: 18))
         XCTAssertNotEqual(image, equalWidth)
+
+        guard let cgImage = image.cgImage else {
+            XCTFail("Get cgImage from image failed")
+            return
+        }
+
+        let imageWithScale = UIImage(cgImage: cgImage, scale: 2.0, orientation: .up)
+        cropped = imageWithScale.cropped(to: CGRect(x: 0, y: 0, width: 15, height: 15))
+        XCTAssertEqual(imageWithScale, cropped)
+
+        cropped = imageWithScale.cropped(to: CGRect(x: 0, y: 0, width: 5, height: 6))
+        XCTAssertEqual(imageWithScale.scale, cropped.scale)
+
+        XCTAssertEqual(10, cropped.size.width * cropped.scale)
+        XCTAssertEqual(12, cropped.size.height * cropped.scale)
     }
 
     func testScaledToHeight() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
