### PR TITLE
Observe a single posting of a notification

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -38,5 +38,4 @@ disabled_rules:
 - file_length
 
 excluded:
-  - Tests/*/XCTestManifests.swift
   - vendor # Folder created by bundle install command that we run on CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **NotificationCenter**:
+  - `observeOnce(forName:object:queue:using:)` for observing a single posting of a notification. [#812](https://github.com/SwifterSwift/SwifterSwift/pull/812) by [guykogus](https://github.com/guykogus)
 - **Optional**:
   - Conform to `Equatable` when `Wrapped` is `RawRepresentable` and its `RawValue` is `Equatable`. [#804](https://github.com/SwifterSwift/SwifterSwift/pull/804) by [guykogus](https://github.com/guykogus)
 - **CoreLocation**:

--- a/Dangerfile
+++ b/Dangerfile
@@ -20,7 +20,6 @@ end
 # Swiftlint Danger
 # Workaround see: https://github.com/ashfurrow/danger-ruby-swiftlint/issues/87
 files_to_lint = (git.modified_files - git.deleted_files) + git.added_files
-files_to_lint.reject! { |f| f.end_with?('XCTestManifests.swift') }
 swiftlint.lint_files(files_to_lint, additional_swiftlint_args: '--no-force-exclude')
         
 # Checks if pull request is labeled as [WIP]

--- a/Sources/SwifterSwift/Foundation/NotificationCenterExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NotificationCenterExtensions.swift
@@ -1,0 +1,44 @@
+//
+//  NotificationCenterExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 6/3/20.
+//  Copyright © 2020 SwifterSwift
+//
+
+#if canImport(Foundation)
+import Foundation
+
+public extension NotificationCenter {
+
+    /// SwifterSwift: Adds a one-time entry to the notification center's dispatch table that includes a notification queue and a block to add to the queue, and an optional notification name and sender.
+    /// - Parameters:
+    ///   - name: The name of the notification for which to register the observer; that is, only notifications with this name are used to add the block to the operation queue.
+    ///
+    ///     If you pass `nil`, the notification center doesn’t use a notification’s name to decide whether to add the block to the operation queue.
+    ///   - obj: The object whose notifications the observer wants to receive; that is, only notifications sent by this sender are delivered to the observer.
+    ///
+    ///     If you pass `nil`, the notification center doesn’t use a notification’s sender to decide whether to deliver it to the observer.
+    ///   - queue: The operation queue to which block should be added.
+    ///
+    ///     If you pass `nil`, the block is run synchronously on the posting thread.
+    ///   - block: The block to be executed when the notification is received.
+    ///
+    ///     The block is copied by the notification center and (the copy) held until the observer registration is removed.
+    ///
+    ///     The block takes one argument:
+    ///   - notification: The notification.
+    func observeOnce(forName name: NSNotification.Name?,
+                     object obj: Any? = nil,
+                     queue: OperationQueue? = nil,
+                     using block: @escaping (_ notification: Notification) -> Void) {
+        var handler: NSObjectProtocol!
+        handler = addObserver(forName: name, object: obj, queue: queue) { [unowned self] in
+            self.removeObserver(handler!)
+            block($0)
+        }
+    }
+
+}
+
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -571,6 +571,13 @@
 		D9F36CF623521F440057258F /* MKMapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F36CF523521F440057258F /* MKMapViewTests.swift */; };
 		E5E5EB3A2350EED400B04C42 /* CAGradientLayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */; };
 		E5E5EB3D2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */; };
+		F87AA5D5241257E3005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
+		F87AA5D624125808005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
+		F87AA5D724125808005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
+		F87AA5D824125808005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
+		F87AA5DA24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D924125C19005F5B28 /* NotificationCenterExtensionsTests.swift */; };
+		F87AA5DB24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D924125C19005F5B28 /* NotificationCenterExtensionsTests.swift */; };
+		F87AA5DC24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D924125C19005F5B28 /* NotificationCenterExtensionsTests.swift */; };
 		F8A710E923BF3EF100112DAD /* EdgeInsetsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A710E823BF3EF100112DAD /* EdgeInsetsExtensions.swift */; };
 		F8A710EA23BF3F7300112DAD /* EdgeInsetsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A710E823BF3EF100112DAD /* EdgeInsetsExtensions.swift */; };
 		F8A710EB23BF3F7400112DAD /* EdgeInsetsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A710E823BF3EF100112DAD /* EdgeInsetsExtensions.swift */; };
@@ -818,6 +825,8 @@
 		D9F36CF523521F440057258F /* MKMapViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKMapViewTests.swift; sourceTree = "<group>"; };
 		E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensions.swift; sourceTree = "<group>"; };
 		E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensionsTests.swift; sourceTree = "<group>"; };
+		F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensions.swift; sourceTree = "<group>"; };
+		F87AA5D924125C19005F5B28 /* NotificationCenterExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensionsTests.swift; sourceTree = "<group>"; };
 		F8A710E823BF3EF100112DAD /* EdgeInsetsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetsExtensions.swift; sourceTree = "<group>"; };
 		F8A710ED23BF3F8200112DAD /* EdgeInsetsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetsExtensionsTests.swift; sourceTree = "<group>"; };
 		F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRegularExpressionExtensions.swift; sourceTree = "<group>"; };
@@ -1023,6 +1032,7 @@
 				07B7F16B1F5EB41600E6F910 /* DateExtensions.swift */,
 				A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */,
 				07B7F1731F5EB41600E6F910 /* LocaleExtensions.swift */,
+				F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */,
 				07B7F1621F5EB41600E6F910 /* NSAttributedStringExtensions.swift */,
 				9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */,
 				F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */,
@@ -1103,6 +1113,7 @@
 				07C50CFF1F5EB03200F46E5A /* DateExtensionsTests.swift */,
 				A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */,
 				07C50D041F5EB03200F46E5A /* LocaleExtensionsTests.swift */,
+				F87AA5D924125C19005F5B28 /* NotificationCenterExtensionsTests.swift */,
 				07C50D291F5EB03200F46E5A /* NSAttributedStringExtensionsTests.swift */,
 				9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */,
 				F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */,
@@ -1890,6 +1901,7 @@
 				07B7F20F1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F19C1F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				9D806A5B2258D2B8008E500A /* SCNMaterialExtensions.swift in Sources */,
+				F87AA5D5241257E3005F5B28 /* NotificationCenterExtensions.swift in Sources */,
 				07B7F1A51F5EB42000E6F910 /* UITextViewExtensions.swift in Sources */,
 				9D806A512258CFF9008E500A /* SCNSphereExtensions.swift in Sources */,
 			);
@@ -1962,6 +1974,7 @@
 				07A1C448224FFE16003272E4 /* UIApplicationExtensions.swift in Sources */,
 				B29527AE20F99F9900E1F75D /* RandomAccessCollectionExtensions.swift in Sources */,
 				9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
+				F87AA5D624125808005F5B28 /* NotificationCenterExtensions.swift in Sources */,
 				07B7F2011F5EB43C00E6F910 /* FloatExtensions.swift in Sources */,
 				9D806A7A2258E6A0008E500A /* SCNCapsule.swift in Sources */,
 				07B7F2001F5EB43C00E6F910 /* DoubleExtensions.swift in Sources */,
@@ -2030,6 +2043,7 @@
 				07B7F1CC1F5EB42200E6F910 /* UIStoryboardExtensions.swift in Sources */,
 				9D806A6C2258DC3E008E500A /* SCNShape.swift in Sources */,
 				07B7F1C61F5EB42200E6F910 /* UINavigationBarExtensions.swift in Sources */,
+				F87AA5D724125808005F5B28 /* NotificationCenterExtensions.swift in Sources */,
 				07B7F1C01F5EB42200E6F910 /* UIButtonExtensions.swift in Sources */,
 				07B7F1F71F5EB43B00E6F910 /* URLExtensions.swift in Sources */,
 				07B7F1C71F5EB42200E6F910 /* UINavigationControllerExtensions.swift in Sources */,
@@ -2134,6 +2148,7 @@
 				F8C1AE72225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				B2A0DAC32336DA87002B0BC5 /* MutableCollectionExtensions.swift in Sources */,
 				664CB986217243D200FC87B4 /* DispatchQueueExtensions.swift in Sources */,
+				F87AA5D824125808005F5B28 /* NotificationCenterExtensions.swift in Sources */,
 				9D806A892258F624008E500A /* SCNGeometryExtensions.swift in Sources */,
 				07B7F1D91F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1E41F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
@@ -2163,6 +2178,7 @@
 				664CB98A21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */,
 				664CB97B21718B1D00FC87B4 /* BinaryFloatingPointExtensionsTests.swift in Sources */,
 				07C50D3C1F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
+				F87AA5DA24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */,
 				078916DE20760DA700AC0665 /* SignedIntegerExtensionsTests.swift in Sources */,
 				07C50D381F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
 				07C50D2F1F5EB04600F46E5A /* ColorExtensionsTests.swift in Sources */,
@@ -2327,6 +2343,7 @@
 				07C50D6B1F5EB05100F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				07C50D691F5EB05100F46E5A /* DataExtensionsTests.swift in Sources */,
 				07C50D6F1F5EB05100F46E5A /* LocaleExtensionsTests.swift in Sources */,
+				F87AA5DB24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */,
 				07C50D8B1F5EB06000F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				18C8E5E42074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				07A494EC23C7D60300DFCBFC /* CLVisitExtensionsTests.swift in Sources */,
@@ -2353,6 +2370,7 @@
 				07C50D741F5EB05100F46E5A /* BoolExtensionsTests.swift in Sources */,
 				9D806A802258F41B008E500A /* SCNMaterialExtensionsTests.swift in Sources */,
 				078916E020760DA700AC0665 /* SignedIntegerExtensionsTests.swift in Sources */,
+				F87AA5DC24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */,
 				07C50D861F5EB05800F46E5A /* NSViewExtensionsTests.swift in Sources */,
 				07C50D851F5EB05800F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07C50D7C1F5EB05100F46E5A /* IntExtensionsTests.swift in Sources */,

--- a/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
+++ b/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
@@ -9,9 +9,6 @@
 import XCTest
 @testable import SwifterSwift
 
-#if canImport(Foundation)
-import Foundation
-
 final class NotificationCenterExtensionsTests: XCTestCase {
 
     func testObserveOnce() {
@@ -19,29 +16,30 @@ final class NotificationCenterExtensionsTests: XCTestCase {
 
         let notificationCenter = NotificationCenter()
         let notificationName = Notification.Name(rawValue: "foo")
+        let object = NSObject()
         let operationQueue = OperationQueue()
         let increment = { (_: Notification) in count += 1 }
         notificationCenter.observeOnce(forName: notificationName,
-                                       object: self,
+                                       object: object,
                                        queue: operationQueue,
                                        using: increment)
 
         let wrongNotificationName = Notification.Name(rawValue: "bar")
 
-        notificationCenter.post(name: wrongNotificationName, object: self)
+        notificationCenter.post(name: wrongNotificationName, object: object)
         XCTAssertEqual(count, 0)
         notificationCenter.post(name: notificationName, object: nil)
         XCTAssertEqual(count, 0)
-        notificationCenter.post(name: notificationName, object: self)
+        notificationCenter.post(name: notificationName, object: object)
         XCTAssertEqual(count, 1)
-        notificationCenter.post(name: notificationName, object: self)
+        notificationCenter.post(name: notificationName, object: object)
         XCTAssertEqual(count, 1)
 
         notificationCenter.observeOnce(forName: nil,
-                                       object: self,
+                                       object: object,
                                        queue: operationQueue,
                                        using: increment)
-        notificationCenter.post(name: wrongNotificationName, object: self)
+        notificationCenter.post(name: wrongNotificationName, object: object)
         XCTAssertEqual(count, 2)
 
         notificationCenter.observeOnce(forName: notificationName,
@@ -52,13 +50,11 @@ final class NotificationCenterExtensionsTests: XCTestCase {
         XCTAssertEqual(count, 3)
 
         notificationCenter.observeOnce(forName: notificationName,
-                                       object: self,
+                                       object: object,
                                        queue: nil,
                                        using: increment)
-        notificationCenter.post(name: notificationName, object: self)
+        notificationCenter.post(name: notificationName, object: object)
         XCTAssertEqual(count, 4)
     }
 
 }
-
-#endif

--- a/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
+++ b/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
@@ -1,0 +1,59 @@
+//
+//  NotificationCenterExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 6/3/20.
+//  Copyright © 2020 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+final class NotificationCenterExtensionsTests: XCTestCase {
+
+    func testObserveOnce() {
+        var count = 0
+
+        let notificationCenter = NotificationCenter()
+        let notificationName = Notification.Name(rawValue: "foo")
+        let operationQueue = OperationQueue()
+        let increment = { (_: Notification) in count += 1 }
+        notificationCenter.observeOnce(forName: notificationName,
+                                       object: self,
+                                       queue: operationQueue,
+                                       using: increment)
+
+        let wrongNotificationName = Notification.Name(rawValue: "bar")
+
+        notificationCenter.post(name: wrongNotificationName, object: self)
+        XCTAssertEqual(count, 0)
+        notificationCenter.post(name: notificationName, object: nil)
+        XCTAssertEqual(count, 0)
+        notificationCenter.post(name: notificationName, object: self)
+        XCTAssertEqual(count, 1)
+        notificationCenter.post(name: notificationName, object: self)
+        XCTAssertEqual(count, 1)
+
+        notificationCenter.observeOnce(forName: nil,
+                                       object: self,
+                                       queue: operationQueue,
+                                       using: increment)
+        notificationCenter.post(name: wrongNotificationName, object: self)
+        XCTAssertEqual(count, 2)
+
+        notificationCenter.observeOnce(forName: notificationName,
+                                       object: nil,
+                                       queue: operationQueue,
+                                       using: increment)
+        notificationCenter.post(name: notificationName, object: nil)
+        XCTAssertEqual(count, 3)
+
+        notificationCenter.observeOnce(forName: notificationName,
+                                       object: self,
+                                       queue: nil,
+                                       using: increment)
+        notificationCenter.post(name: notificationName, object: self)
+        XCTAssertEqual(count, 4)
+    }
+
+}

--- a/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
+++ b/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 SwifterSwift
 //
 
+#if canImport(Foundation)
+
 import XCTest
 @testable import SwifterSwift
 
@@ -57,3 +59,5 @@ final class NotificationCenterExtensionsTests: XCTestCase {
     }
 
 }
+
+#endif

--- a/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
+++ b/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 @testable import SwifterSwift
 
+#if canImport(Foundation)
+import Foundation
+
 final class NotificationCenterExtensionsTests: XCTestCase {
 
     func testObserveOnce() {
@@ -57,3 +60,5 @@ final class NotificationCenterExtensionsTests: XCTestCase {
     }
 
 }
+
+#endif

--- a/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
+++ b/Tests/FoundationTests/NotificationCenterExtensionsTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2020 SwifterSwift
 //
 
-#if canImport(Foundation)
-
 import XCTest
 @testable import SwifterSwift
 
@@ -59,5 +57,3 @@ final class NotificationCenterExtensionsTests: XCTestCase {
     }
 
 }
-
-#endif


### PR DESCRIPTION
🚀
Sometimes you just want to know if a notification has been sent only once (e.g. when internet connection has been recovered).

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
