### PR TITLE
Convert ISO region code into flag emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `decodeBoolAsIntOrString(key:)` to try to decode a `Bool` as `Int` then `String` before decoding as Bool. [#750](https://github.com/SwifterSwift/SwifterSwift/pull/750) by [FraDeliro](https://github.com/FraDeliro).
   - Added `decodeBoolAsIntOrStringIfPresent(key:)` to try to decode a `Bool` as `Int` then `String` before decoding as `Bool` if present. [#750](https://github.com/SwifterSwift/SwifterSwift/pull/750) by [FraDeliro](https://github.com/FraDeliro).
 - **Locale**:
-  - Added `is12HourTimeFormat` to indicate if locale has 12h format. [#793](https://github.com/SwifterSwift/SwifterSwift/pull/793) by [DimaZava](https://github.com/DimaZava). 
+  - Added `is12HourTimeFormat` to indicate if locale has 12h format. [#793](https://github.com/SwifterSwift/SwifterSwift/pull/793) by [DimaZava](https://github.com/DimaZava).
+  - `flagEmoji(forRegionCode:)` to convert a region code into the corresponding flag emoji. [#813](https://github.com/SwifterSwift/SwifterSwift/pull/813) by [guykogus](https://github.com/guykogus)
 - **URLRequest**:
   - Added `curlString` property to get a cURL command representation of this URL request. [#790](https://github.com/SwifterSwift/SwifterSwift/pull/790) by [DimaZava](https://github.com/DimaZava).
 - **SKProduct**:

--- a/Sources/SwifterSwift/Foundation/LocaleExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/LocaleExtensions.swift
@@ -37,7 +37,9 @@ public extension Locale {
     ///
     /// Adapted from https://stackoverflow.com/a/30403199/1627511
     static func flagEmoji(forRegionCode isoRegionCode: String) -> String? {
+        #if !os(Linux)
         guard isoRegionCodes.contains(isoRegionCode) else { return nil }
+        #endif
 
         return isoRegionCode.unicodeScalars.reduce(into: String()) {
             guard let flagScalar = UnicodeScalar(UInt32(127397) + $1.value) else { return }

--- a/Sources/SwifterSwift/Foundation/LocaleExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/LocaleExtensions.swift
@@ -26,6 +26,25 @@ public extension Locale {
         let dateString = dateFormatter.string(from: Date())
         return dateString.contains(dateFormatter.amSymbol) || dateString.contains(dateFormatter.pmSymbol)
     }
+
+}
+
+// MARK: - Functions
+public extension Locale {
+
+    /// SwifterSwift: Get the flag emoji for a given country region code.
+    /// - Parameter isoRegionCode: The IOS region code.
+    ///
+    /// Adapted from https://stackoverflow.com/a/30403199/1627511
+    static func flagEmoji(forRegionCode isoRegionCode: String) -> String? {
+        guard isoRegionCodes.contains(isoRegionCode) else { return nil }
+
+        return isoRegionCode.unicodeScalars.reduce(into: String()) {
+            guard let flagScalar = UnicodeScalar(UInt32(127397) + $1.value) else { return }
+            $0.unicodeScalars.append(flagScalar)
+        }
+    }
+
 }
 
 #endif

--- a/Tests/FoundationTests/LocaleExtensionsTests.swift
+++ b/Tests/FoundationTests/LocaleExtensionsTests.swift
@@ -27,6 +27,17 @@ final class LocaleExtensionsTests: XCTestCase {
         XCTAssertFalse(twentyFourLocale.is12HourTimeFormat)
     }
 
+    func testFlagEmoji() {
+        XCTAssertEqual(Locale.flagEmoji(forRegionCode: "AC"), "🇦🇨")
+        XCTAssertNil(Locale.flagEmoji(forRegionCode: "ac"))
+        XCTAssertEqual(Locale.flagEmoji(forRegionCode: "ZW"), "🇿🇼")
+        XCTAssertNil(Locale.flagEmoji(forRegionCode: ""))
+
+        for regionCode in Locale.isoRegionCodes {
+            XCTAssertNotNil(Locale.flagEmoji(forRegionCode: regionCode))
+        }
+    }
+
 }
 
 #endif

--- a/Tests/FoundationTests/LocaleExtensionsTests.swift
+++ b/Tests/FoundationTests/LocaleExtensionsTests.swift
@@ -29,9 +29,11 @@ final class LocaleExtensionsTests: XCTestCase {
 
     func testFlagEmoji() {
         XCTAssertEqual(Locale.flagEmoji(forRegionCode: "AC"), "🇦🇨")
-        XCTAssertNil(Locale.flagEmoji(forRegionCode: "ac"))
         XCTAssertEqual(Locale.flagEmoji(forRegionCode: "ZW"), "🇿🇼")
+        #if !os(Linux)
         XCTAssertNil(Locale.flagEmoji(forRegionCode: ""))
+        XCTAssertNil(Locale.flagEmoji(forRegionCode: "ac"))
+        #endif
 
         for regionCode in Locale.isoRegionCodes {
             XCTAssertNotNil(Locale.flagEmoji(forRegionCode: regionCode))


### PR DESCRIPTION
🚀
E.g. convert `"AU"` -> `🇦🇺`

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
