### PR TITLE
Added CGRect extensions and its tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `curlString` property to get a cURL command representation of this URL request. [#790](https://github.com/SwifterSwift/SwifterSwift/pull/790) by [DimaZava](https://github.com/DimaZava).
 - **SKProduct**:
   - Added `localizedPrice` to get localized price of product. [#781](https://github.com/SwifterSwift/SwifterSwift/pull/781) by [strawb3rryx7](https://github.com/strawb3rryx7).
+- **CGRect**
+  - Added property `center`. [#814](https://github.com/SwifterSwift/SwifterSwift/pull/814) by [qchenqizhi](https://github.com/qchenqizhi).
+  - Added initializer `init(center:size:)` to create `CGRect` with center and size. [#814](https://github.com/SwifterSwift/SwifterSwift/pull/814) by [qchenqizhi](https://github.com/qchenqizhi).
+  - Added `resizing(to:anchor:)` to create `CGRect` by resizing with anchor. [#814](https://github.com/SwifterSwift/SwifterSwift/pull/814) by [qchenqizhi](https://github.com/qchenqizhi).
 
 ### Changed
 - **Collection**:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ let package = Package(
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/CoreGraphics/CGFloatExtensions.swift"><code>CGFloat extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift"><code>CGPoint extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift"><code>CGSize extensions</code></a></li>
+<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift"><code>CGRect extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/CoreGraphics/CGVectorExtensions.swift"><code>CGVector extensions</code></a></li>
 </ul>
 </details>

--- a/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
@@ -5,6 +5,7 @@
 //  Created by Chen Qizhi on 2020/03/11.
 //  Copyright © 2020 SwifterSwift
 //
+
 #if canImport(CoreGraphics)
 import CoreGraphics
 
@@ -12,9 +13,7 @@ import CoreGraphics
 public extension CGRect {
 
     /// SwifterSwift: Return center of rect
-    var center: CGPoint {
-        return CGPoint(x: midX, y: midY)
-    }
+    var center: CGPoint { CGPoint(x: midX, y: midY) }
 
 }
 
@@ -35,45 +34,25 @@ public extension CGRect {
 // MARK: - Methods
 public extension CGRect {
 
-    /// SwifterSwift: Corners and center of `CGRect`, can be use for resizing,
-    enum Anchor {
-        case topLeft
-        case topRight
-        case bottomLeft
-        case bottomRight
-        case center
-    }
-
     /// SwifterSwift: Create a new `CGRect` by resizing with specified anchor
     /// - Parameters:
     ///   - size: new size to be applied
-    ///   - anchor: specified anchor, excample:
+    ///   - anchor: specified anchor, a point in normalized coordinates -
+    ///     '(0, 0)' is the top left corner of rect，'(1, 1)' is the bottom right corner of rect,
+    ///     defaults to '(0.5, 0.5)'. excample:
     ///
-    ///          anchor = .bottomLeft:
+    ///          anchor = CGPoint(x: 0.0, y: 1.0):
     ///
     ///                       A2------B2
     ///          A----B       |        |
     ///          |    |  -->  |        |
     ///          C----D       C-------D2
     ///
-    func resizing(to size: CGSize, anchor: CGRect.Anchor = .topLeft) -> CGRect {
-        var origin = self.origin
-        switch anchor {
-        case .topRight:
-            origin.x = maxX - size.width
-        case .bottomLeft:
-            origin.y = maxY - size.height
-        case .bottomRight:
-            origin.x = maxX - size.width
-            origin.y = maxY - size.height
-        case .center:
-            origin.x = midX - size.width / 2.0
-            origin.y = midY - size.height / 2.0
-        default:
-            break
-        }
-
-        return CGRect(origin: origin, size: size)
+    func resizing(to size: CGSize, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5)) -> CGRect {
+        let sizeDelta = CGSize(width: size.width - width, height: size.height - height)
+        return CGRect(origin: CGPoint(x: minX - sizeDelta.width * anchor.x,
+                                      y: minY - sizeDelta.height * anchor.y),
+                      size: size)
     }
 
 }

--- a/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
@@ -1,0 +1,81 @@
+//
+//  CGRectExtensions.swift
+//  SwifterSwift
+//
+//  Created by Chen Qizhi on 2020/03/11.
+//  Copyright © 2020 SwifterSwift
+//
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+// MARK: - Properties
+public extension CGRect {
+
+    /// SwifterSwift: Return center of rect
+    var center: CGPoint {
+        return CGPoint(x: midX, y: midY)
+    }
+
+}
+
+// MARK: - Initializers
+public extension CGRect {
+
+    /// SwifterSwift: Create a `CGRect` instance with center and size
+    /// - Parameters:
+    ///   - center: center of the new rect
+    ///   - size: size of the new rect
+    init(center: CGPoint, size: CGSize) {
+        let origin = CGPoint(x: center.x - size.width / 2.0, y: center.y - size.height / 2.0)
+        self.init(origin: origin, size: size)
+    }
+
+}
+
+// MARK: - Methods
+public extension CGRect {
+
+    /// SwifterSwift: Corners and center of `CGRect`, can be use for resizing,
+    enum Anchor {
+        case topLeft
+        case topRight
+        case bottomLeft
+        case bottomRight
+        case center
+    }
+
+    /// SwifterSwift: Create a new `CGRect` by resizing with specified anchor
+    /// - Parameters:
+    ///   - size: new size to be applied
+    ///   - anchor: specified anchor, excample:
+    ///
+    ///          anchor = .bottomLeft:
+    ///
+    ///                       A2------B2
+    ///          A----B       |        |
+    ///          |    |  -->  |        |
+    ///          C----D       C-------D2
+    ///
+    func resizing(to size: CGSize, anchor: CGRect.Anchor = .topLeft) -> CGRect {
+        var origin = self.origin
+        switch anchor {
+        case .topRight:
+            origin.x = maxX - size.width
+        case .bottomLeft:
+            origin.y = maxY - size.height
+        case .bottomRight:
+            origin.x = maxX - size.width
+            origin.y = maxY - size.height
+        case .center:
+            origin.x = midX - size.width / 2.0
+            origin.y = midY - size.height / 2.0
+        default:
+            break
+        }
+
+        return CGRect(origin: origin, size: size)
+    }
+
+}
+
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -328,6 +328,13 @@
 		07FE50451F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */; };
 		07FE50461F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */; };
 		07FE50471F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */; };
+		116090AF24187D5C00DDCD01 /* CGRectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */; };
+		116090B024187D5C00DDCD01 /* CGRectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */; };
+		116090B124187D5C00DDCD01 /* CGRectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */; };
+		116090B224187D5C00DDCD01 /* CGRectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */; };
+		116090B424187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */; };
+		116090B524187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */; };
+		116090B624187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */; };
 		182698AC1F8AB46E0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AD1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
@@ -729,6 +736,8 @@
 		07C50D291F5EB03200F46E5A /* NSAttributedStringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensionsTests.swift; sourceTree = "<group>"; };
 		07C50D2A1F5EB03200F46E5A /* NSViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewExtensionsTests.swift; sourceTree = "<group>"; };
 		07FE50441F891C95000766AA /* SignedNumericExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedNumericExtensionsTests.swift; sourceTree = "<group>"; };
+		116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensions.swift; sourceTree = "<group>"; };
+		116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensionsTests.swift; sourceTree = "<group>"; };
 		185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGColorExtensionsTests.swift; sourceTree = "<group>"; };
 		18C8E5DD2074C58100F8AF51 /* SequenceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensions.swift; sourceTree = "<group>"; };
 		18C8E5E22074C67000F8AF51 /* SequenceExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionsTests.swift; sourceTree = "<group>"; };
@@ -1178,6 +1187,7 @@
 				07B7F15E1F5EB41600E6F910 /* CGFloatExtensions.swift */,
 				07B7F15F1F5EB41600E6F910 /* CGPointExtensions.swift */,
 				07B7F1601F5EB41600E6F910 /* CGSizeExtensions.swift */,
+				116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */,
 				734307F72108C2240029CD16 /* CGVectorExtensions.swift */,
 			);
 			path = CoreGraphics;
@@ -1189,6 +1199,7 @@
 				07C50D251F5EB03200F46E5A /* CGFloatExtensionsTests.swift */,
 				07C50D261F5EB03200F46E5A /* CGPointExtensionsTests.swift */,
 				07C50D271F5EB03200F46E5A /* CGSizeExtensionsTests.swift */,
+				116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */,
 				185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */,
 				734307F92108C7F80029CD16 /* CGVectorExtensionsTests.swift */,
 			);
@@ -1880,6 +1891,7 @@
 				F8C1AE6F225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				9D806A6F2258DE23008E500A /* SCNCylinderExtensions.swift in Sources */,
 				9D806A362258AC0D008E500A /* UIBezierPathExtensions.swift in Sources */,
+				116090AF24187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
 				07B7F2101F5EB43C00E6F910 /* DateExtensions.swift in Sources */,
 				86B3F7AC208D3D5C00BC297B /* UIScrollViewExtensions.swift in Sources */,
 				9D806A412258B931008E500A /* SCNVector3Extensions.swift in Sources */,
@@ -1928,6 +1940,7 @@
 				07B7F2361F5EB45200E6F910 /* CGPointExtensions.swift in Sources */,
 				07B7F1AB1F5EB42000E6F910 /* UICollectionViewExtensions.swift in Sources */,
 				07B7F1B91F5EB42000E6F910 /* UITableViewExtensions.swift in Sources */,
+				116090B024187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
 				B2EEA14B211A7ACA00EF7F8E /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				7832C2B0209BB19300224EED /* ComparableExtensions.swift in Sources */,
 				077BA0901F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
@@ -2044,6 +2057,7 @@
 				07B7F1E91F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F1F61F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F22D1F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
+				116090B124187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
 				9D806A712258DE23008E500A /* SCNCylinderExtensions.swift in Sources */,
 				07B7F1C31F5EB42200E6F910 /* UIImageExtensions.swift in Sources */,
 				077BA08C1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
@@ -2137,6 +2151,7 @@
 				9D806A892258F624008E500A /* SCNGeometryExtensions.swift in Sources */,
 				07B7F1D91F5EB43B00E6F910 /* DataExtensions.swift in Sources */,
 				07B7F1E41F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
+				116090B224187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
 				9D4914861F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
 				07B7F2271F5EB44600E6F910 /* NSViewExtensions.swift in Sources */,
 				C7E027C72360942000F1061E /* KeyedDecodingContainerExtensions.swift in Sources */,
@@ -2232,6 +2247,7 @@
 				07C50D5E1F5EB05000F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTests.swift in Sources */,
 				18C8E5E32074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
+				116090B424187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */,
 				07C50D5D1F5EB05000F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				748B191F23B4F4FA0030FABB /* SKProductTests.swift in Sources */,
 				07C50D5B1F5EB05000F46E5A /* DataExtensionsTests.swift in Sources */,
@@ -2291,6 +2307,7 @@
 				9D806A7F2258F41B008E500A /* SCNMaterialExtensionsTests.swift in Sources */,
 				9D9784E51FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
 				07C50D4C1F5EB04700F46E5A /* UISearchBarExtensionsTests.swift in Sources */,
+				116090B524187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */,
 				8D4B4250212972E7002A5923 /* UILayoutPriorityExtensionsTests.swift in Sources */,
 				07C50D871F5EB06000F46E5A /* CGFloatExtensionsTests.swift in Sources */,
 				9D806AA42258FF98008E500A /* SCNPlaneExtensionsTests.swift in Sources */,
@@ -2391,6 +2408,7 @@
 				07C50D811F5EB05800F46E5A /* CGFloatExtensionsTests.swift in Sources */,
 				9D806A992258FD81008E500A /* SCNCylinderExtensionsTests.swift in Sources */,
 				F8A710F123BF3F8600112DAD /* EdgeInsetsExtensionsTests.swift in Sources */,
+				116090B624187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */,
 				07FE50471F891C95000766AA /* SignedNumericExtensionsTests.swift in Sources */,
 				A94AA78C202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */,
 				B29527B420F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */,

--- a/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
@@ -34,39 +34,39 @@ final class CGRectExtensionsTests: XCTestCase {
         var resizingRect: CGRect
         let newSize = CGSize(width: 40, height: 50)
 
-        // By anchor top left
-        resizingRect = rect.resizing(to: newSize)
-        let rect2 = rect.resizing(to: newSize, anchor: .topLeft)
+        // By anchor center
+        resizingRect = rect.resizing(to: newSize, anchor: CGPoint(x: 0.5, y: 0.5))
+        let rect2 = rect.resizing(to: newSize)
         XCTAssertEqual(resizingRect, rect2)
+        XCTAssertEqual(rect.midX, resizingRect.midX)
+        XCTAssertEqual(rect.midY, resizingRect.midY)
+        XCTAssertNotEqual(rect.size, resizingRect.size)
+        XCTAssertEqual(newSize, resizingRect.size)
+
+        // By anchor top left
+        resizingRect = rect.resizing(to: newSize, anchor: .zero)
         XCTAssertEqual(rect.origin, resizingRect.origin)
         XCTAssertNotEqual(rect.size, resizingRect.size)
         XCTAssertEqual(newSize, resizingRect.size)
 
         // By anchor top right
-        resizingRect = rect.resizing(to: newSize, anchor: .topRight)
+        resizingRect = rect.resizing(to: newSize, anchor: CGPoint(x: 1.0, y: 0.0))
         XCTAssertEqual(rect.maxX, resizingRect.maxX)
         XCTAssertEqual(rect.minY, resizingRect.minY)
         XCTAssertNotEqual(rect.size, resizingRect.size)
         XCTAssertEqual(newSize, resizingRect.size)
 
         // By anchor bottom left
-        resizingRect = rect.resizing(to: newSize, anchor: .bottomLeft)
+        resizingRect = rect.resizing(to: newSize, anchor: CGPoint(x: 0.0, y: 1.0))
         XCTAssertEqual(rect.minX, resizingRect.minX)
         XCTAssertEqual(rect.maxY, resizingRect.maxY)
         XCTAssertNotEqual(rect.size, resizingRect.size)
         XCTAssertEqual(newSize, resizingRect.size)
 
         // By anchor bottom right
-        resizingRect = rect.resizing(to: newSize, anchor: .bottomRight)
+        resizingRect = rect.resizing(to: newSize, anchor: CGPoint(x: 1.0, y: 1.0))
         XCTAssertEqual(rect.maxX, resizingRect.maxX)
         XCTAssertEqual(rect.maxY, resizingRect.maxY)
-        XCTAssertNotEqual(rect.size, resizingRect.size)
-        XCTAssertEqual(newSize, resizingRect.size)
-
-        // By anchor center
-        resizingRect = rect.resizing(to: newSize, anchor: .center)
-        XCTAssertEqual(rect.midX, resizingRect.midX)
-        XCTAssertEqual(rect.midY, resizingRect.midY)
         XCTAssertNotEqual(rect.size, resizingRect.size)
         XCTAssertEqual(newSize, resizingRect.size)
     }

--- a/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
@@ -1,0 +1,76 @@
+//
+//  CGRectExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Chen Qizhi on 2020/03/11.
+//  Copyright © 2020 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+final class CGRectExtensionsTests: XCTestCase {
+
+    func testCenter() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        let center = rect.center
+        XCTAssertEqual(center.x, 25)
+        XCTAssertEqual(center.y, 40)
+    }
+
+    func testInitWithCenterAndSize() {
+        let rect = CGRect(center: CGPoint(x: 10, y: 20), size: CGSize(width: 30, height: 40))
+        XCTAssertEqual(rect.midX, 10)
+        XCTAssertEqual(rect.midY, 20)
+        XCTAssertEqual(rect.width, 30)
+        XCTAssertEqual(rect.height, 40)
+    }
+
+    func testResizingWithAnchor() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        var resizingRect: CGRect
+        let newSize = CGSize(width: 40, height: 50)
+
+        // By anchor top left
+        resizingRect = rect.resizing(to: newSize)
+        let rect2 = rect.resizing(to: newSize, anchor: .topLeft)
+        XCTAssertEqual(resizingRect, rect2)
+        XCTAssertEqual(rect.origin, resizingRect.origin)
+        XCTAssertNotEqual(rect.size, resizingRect.size)
+        XCTAssertEqual(newSize, resizingRect.size)
+
+        // By anchor top right
+        resizingRect = rect.resizing(to: newSize, anchor: .topRight)
+        XCTAssertEqual(rect.maxX, resizingRect.maxX)
+        XCTAssertEqual(rect.minY, resizingRect.minY)
+        XCTAssertNotEqual(rect.size, resizingRect.size)
+        XCTAssertEqual(newSize, resizingRect.size)
+
+        // By anchor bottom left
+        resizingRect = rect.resizing(to: newSize, anchor: .bottomLeft)
+        XCTAssertEqual(rect.minX, resizingRect.minX)
+        XCTAssertEqual(rect.maxY, resizingRect.maxY)
+        XCTAssertNotEqual(rect.size, resizingRect.size)
+        XCTAssertEqual(newSize, resizingRect.size)
+
+        // By anchor bottom right
+        resizingRect = rect.resizing(to: newSize, anchor: .bottomRight)
+        XCTAssertEqual(rect.maxX, resizingRect.maxX)
+        XCTAssertEqual(rect.maxY, resizingRect.maxY)
+        XCTAssertNotEqual(rect.size, resizingRect.size)
+        XCTAssertEqual(newSize, resizingRect.size)
+
+        // By anchor center
+        resizingRect = rect.resizing(to: newSize, anchor: .center)
+        XCTAssertEqual(rect.midX, resizingRect.midX)
+        XCTAssertEqual(rect.midY, resizingRect.midY)
+        XCTAssertNotEqual(rect.size, resizingRect.size)
+        XCTAssertEqual(newSize, resizingRect.size)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
  - Added property `center`.
  - Added initializer `init(center:size:)` to create `CGRect` with center and size.
  - Added `resizing(to:anchor:)` to create `CGRect` by resizing with anchor.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
