### PR TITLE
Added right align image on UIButton method to UIButton extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **UIButton**:
+  - Added `rightAlignImage(spacing:)` to align button image on the right.
 - **NotificationCenter**:
   - `observeOnce(forName:object:queue:using:)` for observing a single posting of a notification. [#812](https://github.com/SwifterSwift/SwifterSwift/pull/812) by [guykogus](https://github.com/guykogus)
 - **Optional**:

--- a/Sources/SwifterSwift/UIKit/UIButtonExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIButtonExtensions.swift
@@ -204,7 +204,28 @@ public extension UIButton {
             contentEdgeInsets = UIEdgeInsets(top: 0, left: insetAmount, bottom: 0, right: insetAmount)
         }
     }
-
+    
+    /// SwifterSwift: Put image to the right side of title
+    /// 
+    /// - Parameter spacing: spacing between title text and image.
+    func rightAlignImage(spacing: CGFloat) {
+        guard
+            let imageSize = imageView?.image?.size,
+            let text = titleLabel?.text,
+            let font = titleLabel?.font
+        else { return }
+        
+        let titleSize = text.size(withAttributes: [.font: font])
+        
+        let titleOffset = -(imageSize.width + spacing)
+        titleEdgeInsets = UIEdgeInsets(top: 0, left: titleOffset, bottom: 0, right: imageSize.width)
+        
+        let imageOffset = -(titleSize.width + spacing)
+        imageEdgeInsets = UIEdgeInsets(top: 0, left: titleSize.width, bottom: 0, right: imageOffset)
+        
+        let edgeOffset = spacing / 2.0
+        contentEdgeInsets = UIEdgeInsets(top: 0, left: edgeOffset, bottom: 0, right: edgeOffset)
+    }
 }
 
 #endif

--- a/Tests/UIKitTests/UIButtonExtensionsTests.swift
+++ b/Tests/UIKitTests/UIButtonExtensionsTests.swift
@@ -180,6 +180,25 @@ final class UIButtonExtensionsTests: XCTestCase {
         XCTAssertEqual(titleFrame.midX, imageFrame.midX, accuracy: 1.0)
         XCTAssertEqual(titleFrame.minY - spacing, imageFrame.maxY, accuracy: 1.0)
     }
+    
+    func testRightAlignImage() {
+        let button = UIButton(frame: CGRect(x: 10, y: 10, width: 100, height: 100))
+        let image = UIImage(color: .red, size: CGSize(width: 10, height: 10))
+        button.setTitleForAllStates("Title")
+        button.setImageForAllStates(image)
+        
+        XCTAssertNotNil(button.imageView)
+        XCTAssertNotNil(button.titleLabel)
+        
+        let spacing: CGFloat = 20
+        button.rightAlignImage(spacing: spacing)
+        let imageFrame = button.imageView!.frame
+        let titleFrame = button.titleLabel!.frame
+        
+        XCTAssert(imageFrame.minX > titleFrame.maxX)
+        XCTAssertEqual(titleFrame.midY, imageFrame.midY, accuracy: 1.0)
+        XCTAssertEqual(imageFrame.minX - spacing, titleFrame.maxX, accuracy: 1.0)
+    }
 
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
