### PR TITLE
Add initializer for a `URL` with an optional `String`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `is12HourTimeFormat` to indicate if locale has 12h format. [#793](https://github.com/SwifterSwift/SwifterSwift/pull/793) by [DimaZava](https://github.com/DimaZava).
   - `flagEmoji(forRegionCode:)` to convert a region code into the corresponding flag emoji. [#813](https://github.com/SwifterSwift/SwifterSwift/pull/813) by [guykogus](https://github.com/guykogus)
 - **URLRequest**:
+  - `init(string:relativeTo:)` to allow initializing a `URL` with an optional `String`. [#818](https://github.com/SwifterSwift/SwifterSwift/pull/818) by [guykogus](https://github.com/guykogus)
   - Added `curlString` property to get a cURL command representation of this URL request. [#790](https://github.com/SwifterSwift/SwifterSwift/pull/790) by [DimaZava](https://github.com/DimaZava).
 - **SKProduct**:
   - Added `localizedPrice` to get localized price of product. [#781](https://github.com/SwifterSwift/SwifterSwift/pull/781) by [strawb3rryx7](https://github.com/strawb3rryx7).

--- a/Sources/SwifterSwift/Foundation/URLExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLExtensions.swift
@@ -32,6 +32,20 @@ public extension URL {
 
 }
 
+// MARK: - Initializers
+public extension URL {
+
+    /// SwifterSwift: Initializes an `URL` object with a base URL and a relative string. If `string` was malformed, returns `nil`.
+    /// - Parameters:
+    ///   - string: The URL string with which to initialize the `URL` object. Must conform to RFC 2396. `string` is interpreted relative to `url`.
+    ///   - url: The base URL for the `URL` object.
+    init?(string: String?, relativeTo url: URL? = nil) {
+        guard let string = string else { return nil }
+        self.init(string: string, relativeTo: url)
+    }
+
+}
+
 // MARK: - Methods
 public extension URL {
 

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -18,15 +18,6 @@ final class URLExtensionsTests: XCTestCase {
     let params = ["q": "swifter swift"]
     let queryUrl = URL(string: "https://www.google.com?q=swifter%20swift")!
 
-    func testAppendingQueryParameters() {
-        XCTAssertEqual(url.appendingQueryParameters(params), queryUrl)
-    }
-
-    func testAppendQueryParameters() {
-        url.appendQueryParameters(params)
-        XCTAssertEqual(url, queryUrl)
-    }
-
     func testQueryParameters() {
         let url = URL(string: "https://www.google.com?q=swifter%20swift&steve=jobs&empty")!
         guard let parameters = url.queryParameters else {
@@ -38,6 +29,29 @@ final class URLExtensionsTests: XCTestCase {
         XCTAssertEqual(parameters["q"], "swifter swift")
         XCTAssertEqual(parameters["steve"], "jobs")
         XCTAssertEqual(parameters["empty"], nil)
+    }
+
+    func testOptionalStringInitializer() {
+        XCTAssertNil(URL(string: nil, relativeTo: nil))
+        XCTAssertNil(URL(string: nil))
+
+        let baseURL = URL(string: "https://www.example.com")
+        XCTAssertNotNil(baseURL)
+        XCTAssertNil(URL(string: nil, relativeTo: baseURL))
+
+        let string = "/index.html"
+        let optionalString: String? = string
+        XCTAssertEqual(URL(string: optionalString, relativeTo: baseURL), URL(string: string, relativeTo: baseURL))
+        XCTAssertEqual(URL(string: optionalString, relativeTo: baseURL)?.absoluteString, "https://www.example.com/index.html")
+    }
+
+    func testAppendingQueryParameters() {
+        XCTAssertEqual(url.appendingQueryParameters(params), queryUrl)
+    }
+
+    func testAppendQueryParameters() {
+        url.appendQueryParameters(params)
+        XCTAssertEqual(url, queryUrl)
     }
 
     func testValueForQueryKey() {


### PR DESCRIPTION
🚀

I often have an object loaded from a server that has optional paths, e.g.
```Swift
struct Food: Codable {
    imagePath: String?
}
```
With this extension users can simply call
```Swift
if let imageURL = URL(food.imagePath) { ... }
```
instead of
```Swift
if let imagePath = food.imagePath,
   let imageURL = URL(imagePath) { ... }
```

Alternatively I could have defined the property as `imagePath: URL?`, but I don't do this for decoded values because if the URL is invalid the entire decoding process fails as opposed to just returning `nil`, so this allows for smoother error handling.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
