### PR TITLE
Make CATransform3D Swifty

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,3 +39,9 @@ disabled_rules:
 
 excluded:
   - vendor # Folder created by bundle install command that we run on CI
+
+identifier_name:
+  excluded:
+    - x
+    - y
+    - z

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,7 +3,7 @@ custom_rules:
     included: ".*\\.swift"
     excluded: ".*Tests\\.swift"
     name: "Missing SwifterSwift: prefix"
-    regex: "///\\s(?!SwifterSwift:\\s)\\w+[^\\n]*$"
+    regex: "\\n\\n(\\s*///\\s(?!SwifterSwift:\\s)\\w+[^\\n]*$)"
     match_kinds:
       - doccomment
     message: "Doc string should always start with the SwifterSwift: prefix"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **CATransform3D**:
+  - `identity`, `isIdentity`, `init(translationX:y:z:)`, `init(scaleX:y:z:)`, `init(rotationAngle:x:y:z:)`, `translatedBy(x:y:z:)`, `scaledBy(x:y:z:)`, `rotated(by:x:y:z:)`, `inverted()`, `concatenating(_:)`, `translateBy(x:y:z:)`, `scaleBy(x:y:z:)`, `rotate(by:x:y:z:)`, `invert()`, `concatenate(_:)`, `isAffine` and `affineTransform()`. Also conforms to `Codable` and `Equatable`. [#819](https://github.com/SwifterSwift/SwifterSwift/pull/819) by [guykogus](https://github.com/guykogus)
+- **CGAffineTransform**:
+  - `transform3D()`. [#819](https://github.com/SwifterSwift/SwifterSwift/pull/819) by [guykogus](https://github.com/guykogus)
 - **NotificationCenter**:
   - `observeOnce(forName:object:queue:using:)` for observing a single posting of a notification. [#812](https://github.com/SwifterSwift/SwifterSwift/pull/812) by [guykogus](https://github.com/guykogus)
 - **Optional**:

--- a/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
@@ -23,6 +23,7 @@ extension CATransform3D: Equatable {
     /// - Parameters:
     ///   - lhs: A value to compare.
     ///   - rhs: Another value to compare.
+    @inlinable
     public static func == (lhs: CATransform3D, rhs: CATransform3D) -> Bool {
         CATransform3DEqualToTransform(lhs, rhs)
     }
@@ -35,6 +36,7 @@ extension CATransform3D: Equatable {
 public extension CATransform3D {
 
     /// SwifterSwift: The identity transform: [1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 1].
+    @inlinable
     static var identity: CATransform3D { CATransform3DIdentity }
 
 }
@@ -48,6 +50,7 @@ extension CATransform3D: Codable {
     ///
     /// This initializer throws an error if reading from the decoder fails, or if the data read is corrupted or otherwise invalid.
     /// - Parameter decoder: The decoder to read data from.
+    @inlinable
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         self.init(m11: try container.decode(CGFloat.self),
@@ -74,6 +77,7 @@ extension CATransform3D: Codable {
     ///
     /// This function throws an error if any values are invalid for the given encoder’s format.
     /// - Parameter encoder: The encoder to write data to.
+    @inlinable
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
         try container.encode(m11)
@@ -106,6 +110,7 @@ public extension CATransform3D {
     ///   - tx: x-axis translation
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
+    @inlinable
     init(translationX tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DMakeTranslation(tx, ty, tz)
     }
@@ -115,6 +120,7 @@ public extension CATransform3D {
     ///   - sx: x-axis scale
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
+    @inlinable
     init(scaleX sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DMakeScale(sx, sy, sz)
     }
@@ -127,6 +133,7 @@ public extension CATransform3D {
     ///   - x: x position of the vector
     ///   - y: y position of the vector
     ///   - z: z position of the vector
+    @inlinable
     init(rotationAngle angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DMakeRotation(angle, x, y, z)
     }
@@ -137,6 +144,7 @@ public extension CATransform3D {
 public extension CATransform3D {
 
     /// SwifterSwift: Returns `true` if the receiver is the identity transform.
+    @inlinable
     var isIdentity: Bool { CATransform3DIsIdentity(self) }
 
 }
@@ -150,6 +158,7 @@ public extension CATransform3D {
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
     /// - Returns: The translated matrix.
+    @inlinable
     func translatedBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
         CATransform3DTranslate(self, tx, ty, tz)
     }
@@ -160,6 +169,7 @@ public extension CATransform3D {
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
     /// - Returns: The scaled matrix.
+    @inlinable
     func scaledBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
         CATransform3DScale(self, sx, sy, sz)
     }
@@ -173,6 +183,7 @@ public extension CATransform3D {
     ///   - y: y position of the vector
     ///   - z: z position of the vector
     /// - Returns: The rotated matrix.
+    @inlinable
     func rotated(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
         CATransform3DRotate(self, angle, x, y, z)
     }
@@ -181,6 +192,7 @@ public extension CATransform3D {
     ///
     /// Returns the original matrix if the receiver has no inverse.
     /// - Returns: The inverted matrix of the receiver.
+    @inlinable
     func inverted() -> CATransform3D {
         CATransform3DInvert(self)
     }
@@ -188,6 +200,7 @@ public extension CATransform3D {
     /// SwifterSwift: Concatenate `transform` to the receiver.
     /// - Parameter t2: The transform to concatenate on to the receiver
     /// - Returns: The concatenated matrix.
+    @inlinable
     func concatenating(_ t2: CATransform3D) -> CATransform3D { // swiftlint:disable:this identifier_name
         CATransform3DConcat(self, t2)
     }
@@ -197,6 +210,7 @@ public extension CATransform3D {
     ///   - tx: x-axis translation
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
+    @inlinable
     mutating func translateBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DTranslate(self, tx, ty, tz)
     }
@@ -206,6 +220,7 @@ public extension CATransform3D {
     ///   - sx: x-axis scale
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
+    @inlinable
     mutating func scaleBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DScale(self, sx, sy, sz)
     }
@@ -218,6 +233,7 @@ public extension CATransform3D {
     ///   - x: x position of the vector
     ///   - y: y position of the vector
     ///   - z: z position of the vector
+    @inlinable
     mutating func rotate(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DRotate(self, angle, x, y, z)
     }
@@ -225,12 +241,14 @@ public extension CATransform3D {
     /// SwifterSwift: Invert the receiver.
     ///
     /// Returns the original matrix if the receiver has no inverse.
+    @inlinable
     mutating func invert() {
         self = CATransform3DInvert(self)
     }
 
     /// SwifterSwift: Concatenate `transform` to the receiver.
     /// - Parameter t2: The transform to concatenate on to the receiver
+    @inlinable
     mutating func concatenate(_ t2: CATransform3D) { // swiftlint:disable:this identifier_name
         self = CATransform3DConcat(self, t2)
     }
@@ -245,11 +263,13 @@ import CoreGraphics
 public extension CATransform3D {
 
     /// SwifterSwift: Returns true if the receiver can be represented exactly by an affine transform.
+    @inlinable
     var isAffine: Bool { CATransform3DIsAffine(self) }
 
     /// SwifterSwift: Returns the affine transform represented by the receiver.
     ///
     /// If the receiver can not be represented exactly by an affine transform the returned value is undefined.
+    @inlinable
     func affineTransform() -> CGAffineTransform {
         CATransform3DGetAffineTransform(self)
     }

--- a/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
@@ -111,7 +111,7 @@ public extension CATransform3D {
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
     @inlinable
-    init(translationX tx: CGFloat, y ty: CGFloat, z tz: CGFloat) {
+    init(translationX tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DMakeTranslation(tx, ty, tz)
     }
 
@@ -121,7 +121,7 @@ public extension CATransform3D {
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
     @inlinable
-    init(scaleX sx: CGFloat, y sy: CGFloat, z sz: CGFloat) {
+    init(scaleX sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DMakeScale(sx, sy, sz)
     }
 
@@ -159,7 +159,7 @@ public extension CATransform3D {
     ///   - tz: z-axis translation
     /// - Returns: The translated matrix.
     @inlinable
-    func translatedBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) -> CATransform3D {
+    func translatedBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
         CATransform3DTranslate(self, tx, ty, tz)
     }
 
@@ -170,7 +170,7 @@ public extension CATransform3D {
     ///   - sz: z-axis scale
     /// - Returns: The scaled matrix.
     @inlinable
-    func scaledBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) -> CATransform3D {
+    func scaledBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
         CATransform3DScale(self, sx, sy, sz)
     }
 
@@ -211,7 +211,7 @@ public extension CATransform3D {
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
     @inlinable
-    mutating func translateBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) {
+    mutating func translateBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DTranslate(self, tx, ty, tz)
     }
 
@@ -221,7 +221,7 @@ public extension CATransform3D {
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
     @inlinable
-    mutating func scaleBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) {
+    mutating func scaleBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
         self = CATransform3DScale(self, sx, sy, sz)
     }
 

--- a/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
@@ -111,7 +111,7 @@ public extension CATransform3D {
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
     @inlinable
-    init(translationX tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
+    init(translationX tx: CGFloat, y ty: CGFloat, z tz: CGFloat) {
         self = CATransform3DMakeTranslation(tx, ty, tz)
     }
 
@@ -121,7 +121,7 @@ public extension CATransform3D {
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
     @inlinable
-    init(scaleX sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
+    init(scaleX sx: CGFloat, y sy: CGFloat, z sz: CGFloat) {
         self = CATransform3DMakeScale(sx, sy, sz)
     }
 
@@ -134,7 +134,7 @@ public extension CATransform3D {
     ///   - y: y position of the vector
     ///   - z: z position of the vector
     @inlinable
-    init(rotationAngle angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
+    init(rotationAngle angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) {
         self = CATransform3DMakeRotation(angle, x, y, z)
     }
 
@@ -159,7 +159,7 @@ public extension CATransform3D {
     ///   - tz: z-axis translation
     /// - Returns: The translated matrix.
     @inlinable
-    func translatedBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+    func translatedBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) -> CATransform3D {
         CATransform3DTranslate(self, tx, ty, tz)
     }
 
@@ -170,7 +170,7 @@ public extension CATransform3D {
     ///   - sz: z-axis scale
     /// - Returns: The scaled matrix.
     @inlinable
-    func scaledBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+    func scaledBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) -> CATransform3D {
         CATransform3DScale(self, sx, sy, sz)
     }
 
@@ -184,7 +184,7 @@ public extension CATransform3D {
     ///   - z: z position of the vector
     /// - Returns: The rotated matrix.
     @inlinable
-    func rotated(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+    func rotated(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) -> CATransform3D {
         CATransform3DRotate(self, angle, x, y, z)
     }
 
@@ -211,7 +211,7 @@ public extension CATransform3D {
     ///   - ty: y-axis translation
     ///   - tz: z-axis translation
     @inlinable
-    mutating func translateBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
+    mutating func translateBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) {
         self = CATransform3DTranslate(self, tx, ty, tz)
     }
 
@@ -221,7 +221,7 @@ public extension CATransform3D {
     ///   - sy: y-axis scale
     ///   - sz: z-axis scale
     @inlinable
-    mutating func scaleBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
+    mutating func scaleBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) {
         self = CATransform3DScale(self, sx, sy, sz)
     }
 
@@ -234,7 +234,7 @@ public extension CATransform3D {
     ///   - y: y position of the vector
     ///   - z: z position of the vector
     @inlinable
-    mutating func rotate(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
+    mutating func rotate(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) {
         self = CATransform3DRotate(self, angle, x, y, z)
     }
 

--- a/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
@@ -1,0 +1,197 @@
+//
+//  CATransform3DExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 19/3/20.
+//  Copyright © 2020 SwifterSwift
+//
+
+#if canImport(QuartzCore)
+
+import QuartzCore
+
+// MARK: - Properties
+public extension CATransform3D {
+
+    /// SwifterSwift: The identity transform: [1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 1].
+    static var identity: CATransform3D { CATransform3DIdentity }
+
+    /// SwifterSwift: Returns `true` if the receiver is the identity transform.
+    var isIdentity: Bool { CATransform3DIsIdentity(self) }
+
+}
+
+// MARK: - Initializers
+public extension CATransform3D {
+
+    /// SwifterSwift: Returns a transform that translates by `(tx, ty, tz)`.
+    /// - Parameters:
+    ///   - tx: x-axis translation
+    ///   - ty: y-axis translation
+    ///   - tz: z-axis translation
+    init(translation tx: CGFloat, _ ty: CGFloat, _ tz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DMakeTranslation(tx, ty, tz)
+    }
+
+    /// SwifterSwift: Returns a transform that scales by `(sx, sy, sz)`.
+    /// - Parameters:
+    ///   - sx: x-axis scale
+    ///   - sy: y-axis scale
+    ///   - sz: z-axis scale
+    init(scale sx: CGFloat, _ sy: CGFloat, _ sz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DMakeScale(sx, sy, sz)
+    }
+
+    /// SwifterSwift: Returns a transform that rotates by `angle` radians about the vector `(x, y, z)`.
+    ///
+    /// If the vector has zero length the behavior is undefined.
+    /// - Parameters:
+    ///   - angle: The angle of rotation
+    ///   - x: x position of the vector
+    ///   - y: y position of the vector
+    ///   - z: z position of the vector
+    init(rotation angle: CGFloat, _ x: CGFloat, _ y: CGFloat, _ z: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DMakeRotation(angle, x, y, z)
+    }
+
+}
+
+// MARK: - Methods
+public extension CATransform3D {
+
+    /// SwifterSwift: Translate the receiver by `(tx, ty, tz)`.
+    /// - Parameters:
+    ///   - tx: x-axis translation
+    ///   - ty: y-axis translation
+    ///   - tz: z-axis translation
+    /// - Returns: The translated matrix.
+    func translated(tx: CGFloat, ty: CGFloat, tz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DTranslate(self, tx, ty, tz)
+    }
+
+    /// SwifterSwift: Scale the receiver by `(sx, sy, sz)`.
+    /// - Parameters:
+    ///   - sx: x-axis scale
+    ///   - sy: y-axis scale
+    ///   - sz: z-axis scale
+    /// - Returns: The scaled matrix.
+    func scaled(sx: CGFloat, sy: CGFloat, sz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DScale(self, sx, sy, sz)
+    }
+
+    /// SwifterSwift: Rotate the receiver by `angle` radians about the vector `(x, y, z)`.
+    ///
+    /// If the vector has zero length the behavior is undefined.
+    /// - Parameters:
+    ///   - angle: The angle of rotation
+    ///   - x: x position of the vector
+    ///   - y: y position of the vector
+    ///   - z: z position of the vector
+    /// - Returns: The rotated matrix.
+    func rotated(angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DRotate(self, angle, x, y, z)
+    }
+
+    /// SwifterSwift: Concatenate `transform` to the receiver.
+    /// - Parameter transform: The transform to concatenate on to the receiver
+    /// - Returns: The concatenated matrix.
+    func concatenated(transform: CATransform3D) -> CATransform3D {
+        CATransform3DConcat(self, transform)
+    }
+
+    /// SwifterSwift: Invert the receiver.
+    ///
+    /// Returns the original matrix if the receiver has no inverse.
+    /// - Returns: The inverted matrix of the receiver.
+    func inverted() -> CATransform3D {
+        CATransform3DInvert(self)
+    }
+
+    /// SwifterSwift: Translate the receiver by `(tx, ty, tz)`.
+    /// - Parameters:
+    ///   - tx: x-axis translation
+    ///   - ty: y-axis translation
+    ///   - tz: z-axis translation
+    mutating func translate(tx: CGFloat, ty: CGFloat, tz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DTranslate(self, tx, ty, tz)
+    }
+
+    /// SwifterSwift: Scale the receiver by `(sx, sy, sz)`.
+    /// - Parameters:
+    ///   - sx: x-axis scale
+    ///   - sy: y-axis scale
+    ///   - sz: z-axis scale
+    mutating func scale(sx: CGFloat, sy: CGFloat, sz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DScale(self, sx, sy, sz)
+    }
+
+    /// SwifterSwift: Rotate the receiver by `angle` radians about the vector `(x, y, z)`.
+    ///
+    /// If the vector has zero length the behavior is undefined.
+    /// - Parameters:
+    ///   - angle: The angle of rotation
+    ///   - x: x position of the vector
+    ///   - y: y position of the vector
+    ///   - z: z position of the vector
+    mutating func rotate(angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DRotate(self, angle, x, y, z)
+    }
+
+    /// SwifterSwift: Concatenate `transform` to the receiver.
+    /// - Parameter transform: The transform to concatenate on to the receiver
+    mutating func concatenate(transform: CATransform3D) {
+        self = CATransform3DConcat(self, transform)
+    }
+
+    /// SwifterSwift: Invert the receiver.
+    ///
+    /// Returns the original matrix if the receiver has no inverse.
+    mutating func invert() {
+        self = CATransform3DInvert(self)
+    }
+
+}
+
+// MARK: - Equatable
+extension CATransform3D: Equatable {
+
+    // swiftlint:disable missing_swifterswift_prefix
+
+    /// Returns a Boolean value indicating whether two values are equal.
+    ///
+    /// Equality is the inverse of inequality. For any values `a` and `b`,
+    /// `a == b` implies that `a != b` is `false`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
+    public static func == (lhs: CATransform3D, rhs: CATransform3D) -> Bool {
+        CATransform3DEqualToTransform(lhs, rhs)
+    }
+
+    // swiftlint:disable missing_swifterswift_prefix
+
+}
+
+#if canImport(CoreGraphics)
+
+import CoreGraphics
+
+// MARK: - CGAffineTransform
+public extension CATransform3D {
+
+    /// SwifterSwift: Returns true if the receiver can be represented exactly by an affine transform.
+    var isAffine: Bool { CATransform3DIsAffine(self) }
+
+    /// SwifterSwift: Returns the affine transform represented by the receiver.
+    ///
+    /// If the receiver can not be represented exactly by an affine transform the returned value is undefined.
+    func affineTransform() -> CGAffineTransform {
+        CATransform3DGetAffineTransform(self)
+    }
+
+}
+
+#endif
+
+#endif

--- a/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
@@ -10,148 +10,6 @@
 
 import QuartzCore
 
-// MARK: - Properties
-public extension CATransform3D {
-
-    /// SwifterSwift: The identity transform: [1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 1].
-    static var identity: CATransform3D { CATransform3DIdentity }
-
-    /// SwifterSwift: Returns `true` if the receiver is the identity transform.
-    var isIdentity: Bool { CATransform3DIsIdentity(self) }
-
-}
-
-// MARK: - Initializers
-public extension CATransform3D {
-
-    /// SwifterSwift: Returns a transform that translates by `(tx, ty, tz)`.
-    /// - Parameters:
-    ///   - tx: x-axis translation
-    ///   - ty: y-axis translation
-    ///   - tz: z-axis translation
-    init(translation tx: CGFloat, _ ty: CGFloat, _ tz: CGFloat) { // swiftlint:disable:this identifier_name
-        self = CATransform3DMakeTranslation(tx, ty, tz)
-    }
-
-    /// SwifterSwift: Returns a transform that scales by `(sx, sy, sz)`.
-    /// - Parameters:
-    ///   - sx: x-axis scale
-    ///   - sy: y-axis scale
-    ///   - sz: z-axis scale
-    init(scale sx: CGFloat, _ sy: CGFloat, _ sz: CGFloat) { // swiftlint:disable:this identifier_name
-        self = CATransform3DMakeScale(sx, sy, sz)
-    }
-
-    /// SwifterSwift: Returns a transform that rotates by `angle` radians about the vector `(x, y, z)`.
-    ///
-    /// If the vector has zero length the behavior is undefined.
-    /// - Parameters:
-    ///   - angle: The angle of rotation
-    ///   - x: x position of the vector
-    ///   - y: y position of the vector
-    ///   - z: z position of the vector
-    init(rotation angle: CGFloat, _ x: CGFloat, _ y: CGFloat, _ z: CGFloat) { // swiftlint:disable:this identifier_name
-        self = CATransform3DMakeRotation(angle, x, y, z)
-    }
-
-}
-
-// MARK: - Methods
-public extension CATransform3D {
-
-    /// SwifterSwift: Translate the receiver by `(tx, ty, tz)`.
-    /// - Parameters:
-    ///   - tx: x-axis translation
-    ///   - ty: y-axis translation
-    ///   - tz: z-axis translation
-    /// - Returns: The translated matrix.
-    func translated(tx: CGFloat, ty: CGFloat, tz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
-        CATransform3DTranslate(self, tx, ty, tz)
-    }
-
-    /// SwifterSwift: Scale the receiver by `(sx, sy, sz)`.
-    /// - Parameters:
-    ///   - sx: x-axis scale
-    ///   - sy: y-axis scale
-    ///   - sz: z-axis scale
-    /// - Returns: The scaled matrix.
-    func scaled(sx: CGFloat, sy: CGFloat, sz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
-        CATransform3DScale(self, sx, sy, sz)
-    }
-
-    /// SwifterSwift: Rotate the receiver by `angle` radians about the vector `(x, y, z)`.
-    ///
-    /// If the vector has zero length the behavior is undefined.
-    /// - Parameters:
-    ///   - angle: The angle of rotation
-    ///   - x: x position of the vector
-    ///   - y: y position of the vector
-    ///   - z: z position of the vector
-    /// - Returns: The rotated matrix.
-    func rotated(angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
-        CATransform3DRotate(self, angle, x, y, z)
-    }
-
-    /// SwifterSwift: Concatenate `transform` to the receiver.
-    /// - Parameter transform: The transform to concatenate on to the receiver
-    /// - Returns: The concatenated matrix.
-    func concatenated(transform: CATransform3D) -> CATransform3D {
-        CATransform3DConcat(self, transform)
-    }
-
-    /// SwifterSwift: Invert the receiver.
-    ///
-    /// Returns the original matrix if the receiver has no inverse.
-    /// - Returns: The inverted matrix of the receiver.
-    func inverted() -> CATransform3D {
-        CATransform3DInvert(self)
-    }
-
-    /// SwifterSwift: Translate the receiver by `(tx, ty, tz)`.
-    /// - Parameters:
-    ///   - tx: x-axis translation
-    ///   - ty: y-axis translation
-    ///   - tz: z-axis translation
-    mutating func translate(tx: CGFloat, ty: CGFloat, tz: CGFloat) { // swiftlint:disable:this identifier_name
-        self = CATransform3DTranslate(self, tx, ty, tz)
-    }
-
-    /// SwifterSwift: Scale the receiver by `(sx, sy, sz)`.
-    /// - Parameters:
-    ///   - sx: x-axis scale
-    ///   - sy: y-axis scale
-    ///   - sz: z-axis scale
-    mutating func scale(sx: CGFloat, sy: CGFloat, sz: CGFloat) { // swiftlint:disable:this identifier_name
-        self = CATransform3DScale(self, sx, sy, sz)
-    }
-
-    /// SwifterSwift: Rotate the receiver by `angle` radians about the vector `(x, y, z)`.
-    ///
-    /// If the vector has zero length the behavior is undefined.
-    /// - Parameters:
-    ///   - angle: The angle of rotation
-    ///   - x: x position of the vector
-    ///   - y: y position of the vector
-    ///   - z: z position of the vector
-    mutating func rotate(angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
-        self = CATransform3DRotate(self, angle, x, y, z)
-    }
-
-    /// SwifterSwift: Concatenate `transform` to the receiver.
-    /// - Parameter transform: The transform to concatenate on to the receiver
-    mutating func concatenate(transform: CATransform3D) {
-        self = CATransform3DConcat(self, transform)
-    }
-
-    /// SwifterSwift: Invert the receiver.
-    ///
-    /// Returns the original matrix if the receiver has no inverse.
-    mutating func invert() {
-        self = CATransform3DInvert(self)
-    }
-
-}
-
 // MARK: - Equatable
 extension CATransform3D: Equatable {
 
@@ -170,6 +28,212 @@ extension CATransform3D: Equatable {
     }
 
     // swiftlint:disable missing_swifterswift_prefix
+
+}
+
+// MARK: - Static Properties
+public extension CATransform3D {
+
+    /// SwifterSwift: The identity transform: [1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 1].
+    static var identity: CATransform3D { CATransform3DIdentity }
+
+}
+
+// MARK: - Codable
+extension CATransform3D: Codable {
+
+    // swiftlint:disable missing_swifterswift_prefix
+
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or if the data read is corrupted or otherwise invalid.
+    /// - Parameter decoder: The decoder to read data from.
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.init(m11: try container.decode(CGFloat.self),
+                  m12: try container.decode(CGFloat.self),
+                  m13: try container.decode(CGFloat.self),
+                  m14: try container.decode(CGFloat.self),
+                  m21: try container.decode(CGFloat.self),
+                  m22: try container.decode(CGFloat.self),
+                  m23: try container.decode(CGFloat.self),
+                  m24: try container.decode(CGFloat.self),
+                  m31: try container.decode(CGFloat.self),
+                  m32: try container.decode(CGFloat.self),
+                  m33: try container.decode(CGFloat.self),
+                  m34: try container.decode(CGFloat.self),
+                  m41: try container.decode(CGFloat.self),
+                  m42: try container.decode(CGFloat.self),
+                  m43: try container.decode(CGFloat.self),
+                  m44: try container.decode(CGFloat.self))
+    }
+
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, encoder will encode an empty keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given encoder’s format.
+    /// - Parameter encoder: The encoder to write data to.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(m11)
+        try container.encode(m12)
+        try container.encode(m13)
+        try container.encode(m14)
+        try container.encode(m21)
+        try container.encode(m22)
+        try container.encode(m23)
+        try container.encode(m24)
+        try container.encode(m31)
+        try container.encode(m32)
+        try container.encode(m33)
+        try container.encode(m34)
+        try container.encode(m41)
+        try container.encode(m42)
+        try container.encode(m43)
+        try container.encode(m44)
+    }
+
+    // swiftlint:enable missing_swifterswift_prefix
+
+}
+
+// MARK: - Initializers
+public extension CATransform3D {
+
+    /// SwifterSwift: Returns a transform that translates by `(tx, ty, tz)`.
+    /// - Parameters:
+    ///   - tx: x-axis translation
+    ///   - ty: y-axis translation
+    ///   - tz: z-axis translation
+    init(translationX tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DMakeTranslation(tx, ty, tz)
+    }
+
+    /// SwifterSwift: Returns a transform that scales by `(sx, sy, sz)`.
+    /// - Parameters:
+    ///   - sx: x-axis scale
+    ///   - sy: y-axis scale
+    ///   - sz: z-axis scale
+    init(scaleX sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DMakeScale(sx, sy, sz)
+    }
+
+    /// SwifterSwift: Returns a transform that rotates by `angle` radians about the vector `(x, y, z)`.
+    ///
+    /// If the vector has zero length the behavior is undefined.
+    /// - Parameters:
+    ///   - angle: The angle of rotation
+    ///   - x: x position of the vector
+    ///   - y: y position of the vector
+    ///   - z: z position of the vector
+    init(rotationAngle angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DMakeRotation(angle, x, y, z)
+    }
+
+}
+
+// MARK: - Properties
+public extension CATransform3D {
+
+    /// SwifterSwift: Returns `true` if the receiver is the identity transform.
+    var isIdentity: Bool { CATransform3DIsIdentity(self) }
+
+}
+
+// MARK: - Methods
+public extension CATransform3D {
+
+    /// SwifterSwift: Translate the receiver by `(tx, ty, tz)`.
+    /// - Parameters:
+    ///   - tx: x-axis translation
+    ///   - ty: y-axis translation
+    ///   - tz: z-axis translation
+    /// - Returns: The translated matrix.
+    func translatedBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DTranslate(self, tx, ty, tz)
+    }
+
+    /// SwifterSwift: Scale the receiver by `(sx, sy, sz)`.
+    /// - Parameters:
+    ///   - sx: x-axis scale
+    ///   - sy: y-axis scale
+    ///   - sz: z-axis scale
+    /// - Returns: The scaled matrix.
+    func scaledBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DScale(self, sx, sy, sz)
+    }
+
+    /// SwifterSwift: Rotate the receiver by `angle` radians about the vector `(x, y, z)`.
+    ///
+    /// If the vector has zero length the behavior is undefined.
+    /// - Parameters:
+    ///   - angle: The angle of rotation
+    ///   - x: x position of the vector
+    ///   - y: y position of the vector
+    ///   - z: z position of the vector
+    /// - Returns: The rotated matrix.
+    func rotated(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DRotate(self, angle, x, y, z)
+    }
+
+    /// SwifterSwift: Invert the receiver.
+    ///
+    /// Returns the original matrix if the receiver has no inverse.
+    /// - Returns: The inverted matrix of the receiver.
+    func inverted() -> CATransform3D {
+        CATransform3DInvert(self)
+    }
+
+    /// SwifterSwift: Concatenate `transform` to the receiver.
+    /// - Parameter t2: The transform to concatenate on to the receiver
+    /// - Returns: The concatenated matrix.
+    func concatenating(_ t2: CATransform3D) -> CATransform3D { // swiftlint:disable:this identifier_name
+        CATransform3DConcat(self, t2)
+    }
+
+    /// SwifterSwift: Translate the receiver by `(tx, ty, tz)`.
+    /// - Parameters:
+    ///   - tx: x-axis translation
+    ///   - ty: y-axis translation
+    ///   - tz: z-axis translation
+    mutating func translateBy(x tx: CGFloat, y ty: CGFloat, z tz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DTranslate(self, tx, ty, tz)
+    }
+
+    /// SwifterSwift: Scale the receiver by `(sx, sy, sz)`.
+    /// - Parameters:
+    ///   - sx: x-axis scale
+    ///   - sy: y-axis scale
+    ///   - sz: z-axis scale
+    mutating func scaleBy(x sx: CGFloat, y sy: CGFloat, z sz: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DScale(self, sx, sy, sz)
+    }
+
+    /// SwifterSwift: Rotate the receiver by `angle` radians about the vector `(x, y, z)`.
+    ///
+    /// If the vector has zero length the behavior is undefined.
+    /// - Parameters:
+    ///   - angle: The angle of rotation
+    ///   - x: x position of the vector
+    ///   - y: y position of the vector
+    ///   - z: z position of the vector
+    mutating func rotate(by angle: CGFloat, x: CGFloat, y: CGFloat, z: CGFloat) { // swiftlint:disable:this identifier_name
+        self = CATransform3DRotate(self, angle, x, y, z)
+    }
+
+    /// SwifterSwift: Invert the receiver.
+    ///
+    /// Returns the original matrix if the receiver has no inverse.
+    mutating func invert() {
+        self = CATransform3DInvert(self)
+    }
+
+    /// SwifterSwift: Concatenate `transform` to the receiver.
+    /// - Parameter t2: The transform to concatenate on to the receiver
+    mutating func concatenate(_ t2: CATransform3D) { // swiftlint:disable:this identifier_name
+        self = CATransform3DConcat(self, t2)
+    }
 
 }
 

--- a/Sources/SwifterSwift/CoreGraphics/CGAffineTransformExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGAffineTransformExtensions.swift
@@ -17,6 +17,7 @@ import QuartzCore
 public extension CGAffineTransform {
 
     /// SwifterSwift: Returns a transform with the same effect as the receiver.
+    @inlinable
     func transform3D() -> CATransform3D { CATransform3DMakeAffineTransform(self) }
 
 }

--- a/Sources/SwifterSwift/CoreGraphics/CGAffineTransformExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGAffineTransformExtensions.swift
@@ -1,0 +1,26 @@
+//
+//  CGAffineTransformExtensions.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 19/3/20.
+//  Copyright © 2020 SwifterSwift
+//
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+#if canImport(QuartzCore)
+
+import QuartzCore
+
+// MARK: - Methods
+public extension CGAffineTransform {
+
+    /// SwifterSwift: Returns a transform with the same effect as the receiver.
+    func transform3D() -> CATransform3D { CATransform3DMakeAffineTransform(self) }
+
+}
+
+#endif
+
+#endif

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -600,7 +600,7 @@ public extension String {
         guard index >= 0 && index < count else { return nil }
         return self[self.index(startIndex, offsetBy: index)]
     }
-    
+
     /// SwifterSwift: Safely subscript string within a given range.
     ///
     ///        "Hello World!"[safe: 6..<11] -> "World"

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -203,7 +203,6 @@ public extension UIView {
         }
     }
 
-    // swiftlint:disable identifier_name
     /// SwifterSwift: x origin of view.
     var x: CGFloat {
         get {
@@ -213,9 +212,7 @@ public extension UIView {
             frame.origin.x = newValue
         }
     }
-    // swiftlint:enable identifier_name
 
-    // swiftlint:disable identifier_name
     /// SwifterSwift: y origin of view.
     var y: CGFloat {
         get {
@@ -225,7 +222,6 @@ public extension UIView {
             frame.origin.y = newValue
         }
     }
-    // swiftlint:enable identifier_name
 
 }
 

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -578,6 +578,23 @@
 		D9F36CF623521F440057258F /* MKMapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F36CF523521F440057258F /* MKMapViewTests.swift */; };
 		E5E5EB3A2350EED400B04C42 /* CAGradientLayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */; };
 		E5E5EB3D2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */; };
+		F854D2A52423AE92003A08A9 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */; };
+		F854D2AE2423DF54003A08A9 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */; };
+		F854D2B02423DF5A003A08A9 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */; };
+		F854D2B52423E19B003A08A9 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */; };
+		F854D2B62423E1F0003A08A9 /* CAGradientLayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */; };
+		F854D2B72423E1F1003A08A9 /* CAGradientLayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */; };
+		F854D2B82423E1FE003A08A9 /* CAGradientLayerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */; };
+		F854D2B92423E1FE003A08A9 /* CAGradientLayerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */; };
+		F854D2BB2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2BA2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift */; };
+		F854D2BC2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2BA2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift */; };
+		F854D2BD2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2BA2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift */; };
+		F854D2BF2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2BE2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift */; };
+		F854D2C02423EBD0003A08A9 /* CATransform3DExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2BE2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift */; };
+		F854D2C12423EBD0003A08A9 /* CATransform3DExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2BE2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift */; };
+		F854D2C32423ECEF003A08A9 /* CATransform3DExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A62423AF22003A08A9 /* CATransform3DExtensions.swift */; };
+		F854D2C42423ECF0003A08A9 /* CATransform3DExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A62423AF22003A08A9 /* CATransform3DExtensions.swift */; };
+		F854D2C52423ECF0003A08A9 /* CATransform3DExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A62423AF22003A08A9 /* CATransform3DExtensions.swift */; };
 		F87AA5D5241257E3005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
 		F87AA5D624125808005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
 		F87AA5D724125808005F5B28 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */; };
@@ -834,6 +851,10 @@
 		D9F36CF523521F440057258F /* MKMapViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKMapViewTests.swift; sourceTree = "<group>"; };
 		E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensions.swift; sourceTree = "<group>"; };
 		E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensionsTests.swift; sourceTree = "<group>"; };
+		F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensions.swift; sourceTree = "<group>"; };
+		F854D2A62423AF22003A08A9 /* CATransform3DExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CATransform3DExtensions.swift; sourceTree = "<group>"; };
+		F854D2BA2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
+		F854D2BE2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CATransform3DExtensionsTests.swift; sourceTree = "<group>"; };
 		F87AA5D4241257E3005F5B28 /* NotificationCenterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensions.swift; sourceTree = "<group>"; };
 		F87AA5D924125C19005F5B28 /* NotificationCenterExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensionsTests.swift; sourceTree = "<group>"; };
 		F8A710E823BF3EF100112DAD /* EdgeInsetsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetsExtensions.swift; sourceTree = "<group>"; };
@@ -1006,19 +1027,19 @@
 		07898B941F27904200558C97 /* SwifterSwift */ = {
 			isa = PBXGroup;
 			children = (
-				664CB981217243BA00FC87B4 /* Dispatch */,
-				752AC79E20BC974700659E76 /* SpriteKit */,
-				9D806A3F2258B91F008E500A /* SceneKit */,
-				748B191823B4F4B10030FABB /* StoreKit */,
-				784C752D2051BD01001C48DD /* MapKit */,
-				0726D7751F7C19880028CAB5 /* Shared */,
-				077BA0871F6BE73000D9C4AC /* SwiftStdlib */,
-				07B7F1651F5EB41600E6F910 /* Foundation */,
-				07B7F1791F5EB41600E6F910 /* UIKit */,
+				07B7F15C1F5EB41600E6F910 /* AppKit */,
+				E5E5EB382350EE9A00B04C42 /* CoreAnimation */,
 				07D8960D1F5ED85400FC894D /* CoreGraphics */,
 				07D8960C1F5ED84400FC894D /* CoreLocation */,
-				E5E5EB382350EE9A00B04C42 /* CoreAnimation */,
-				07B7F15C1F5EB41600E6F910 /* AppKit */,
+				664CB981217243BA00FC87B4 /* Dispatch */,
+				07B7F1651F5EB41600E6F910 /* Foundation */,
+				784C752D2051BD01001C48DD /* MapKit */,
+				9D806A3F2258B91F008E500A /* SceneKit */,
+				0726D7751F7C19880028CAB5 /* Shared */,
+				752AC79E20BC974700659E76 /* SpriteKit */,
+				748B191823B4F4B10030FABB /* StoreKit */,
+				077BA0871F6BE73000D9C4AC /* SwiftStdlib */,
+				07B7F1791F5EB41600E6F910 /* UIKit */,
 			);
 			path = SwifterSwift;
 			sourceTree = "<group>";
@@ -1104,9 +1125,9 @@
 				07C50CF91F5EB03200F46E5A /* FoundationTests */,
 				784C75322051BDCA001C48DD /* MapKitTests */,
 				CAC5EBBE2125270A00AB27EC /* ResourcesTests */,
+				9D806A452258B99D008E500A /* SceneKitTests */,
 				D86A98EE1F7E50C90084EDCD /* SharedTests */,
 				752AC7A120BC977700659E76 /* SpriteKitTests */,
-				9D806A452258B99D008E500A /* SceneKitTests */,
 				748B191B23B4F4DA0030FABB /* StoreKitTests */,
 				077BA0931F6BE93000D9C4AC /* SwiftStdlibTests */,
 				07C50D0D1F5EB03200F46E5A /* UIKitTests */,
@@ -1194,6 +1215,7 @@
 		07D8960D1F5ED85400FC894D /* CoreGraphics */ = {
 			isa = PBXGroup;
 			children = (
+				F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */,
 				07B7F15D1F5EB41600E6F910 /* CGColorExtensions.swift */,
 				07B7F15E1F5EB41600E6F910 /* CGFloatExtensions.swift */,
 				07B7F15F1F5EB41600E6F910 /* CGPointExtensions.swift */,
@@ -1207,6 +1229,7 @@
 		07D8960E1F5ED89A00FC894D /* CoreGraphicsTests */ = {
 			isa = PBXGroup;
 			children = (
+				F854D2BA2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift */,
 				07C50D251F5EB03200F46E5A /* CGFloatExtensionsTests.swift */,
 				07C50D261F5EB03200F46E5A /* CGPointExtensionsTests.swift */,
 				07C50D271F5EB03200F46E5A /* CGSizeExtensionsTests.swift */,
@@ -1370,6 +1393,7 @@
 			isa = PBXGroup;
 			children = (
 				E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */,
+				F854D2A62423AF22003A08A9 /* CATransform3DExtensions.swift */,
 			);
 			path = CoreAnimation;
 			sourceTree = "<group>";
@@ -1378,6 +1402,7 @@
 			isa = PBXGroup;
 			children = (
 				E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */,
+				F854D2BE2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift */,
 			);
 			path = CoreAnimationTests;
 			sourceTree = "<group>";
@@ -1825,6 +1850,7 @@
 				A94AA78720280F9100E229A5 /* FileManagerExtensions.swift in Sources */,
 				07A1C447224FFDE4003272E4 /* UIApplicationExtensions.swift in Sources */,
 				90693551208B4F9400407C4D /* UIGestureRecognizerExtensions.swift in Sources */,
+				F854D2C32423ECEF003A08A9 /* CATransform3DExtensions.swift in Sources */,
 				0726D7771F7C199E0028CAB5 /* ColorExtensions.swift in Sources */,
 				B2A0DAC02336DA87002B0BC5 /* MutableCollectionExtensions.swift in Sources */,
 				07B7F2181F5EB43C00E6F910 /* SignedIntegerExtensions.swift in Sources */,
@@ -1851,6 +1877,7 @@
 				07B7F2111F5EB43C00E6F910 /* DictionaryExtensions.swift in Sources */,
 				076AEC891FDB48580077D153 /* UIDatePickerExtensions.swift in Sources */,
 				9D806A6A2258DC3E008E500A /* SCNShape.swift in Sources */,
+				F854D2A52423AE92003A08A9 /* CGAffineTransformExtensions.swift in Sources */,
 				07B7F2301F5EB45100E6F910 /* CGPointExtensions.swift in Sources */,
 				664CB96D2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */,
 				07B7F1951F5EB42000E6F910 /* UICollectionViewExtensions.swift in Sources */,
@@ -1944,6 +1971,7 @@
 				07B7F2381F5EB45200E6F910 /* CLLocationExtensions.swift in Sources */,
 				07B7F1FC1F5EB43C00E6F910 /* CollectionExtensions.swift in Sources */,
 				74932D1623B8CEB800A56D81 /* SKProductExtensions.swift in Sources */,
+				F854D2B62423E1F0003A08A9 /* CAGradientLayerExtensions.swift in Sources */,
 				07B7F2031F5EB43C00E6F910 /* IntExtensions.swift in Sources */,
 				9D806A702258DE23008E500A /* SCNCylinderExtensions.swift in Sources */,
 				07B7F1FF1F5EB43C00E6F910 /* DictionaryExtensions.swift in Sources */,
@@ -1985,6 +2013,7 @@
 				9D806A372258AE09008E500A /* UIBezierPathExtensions.swift in Sources */,
 				077BA08B1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				07A1C448224FFE16003272E4 /* UIApplicationExtensions.swift in Sources */,
+				F854D2C42423ECF0003A08A9 /* CATransform3DExtensions.swift in Sources */,
 				B29527AE20F99F9900E1F75D /* RandomAccessCollectionExtensions.swift in Sources */,
 				9D4914841F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
 				F87AA5D624125808005F5B28 /* NotificationCenterExtensions.swift in Sources */,
@@ -1994,6 +2023,7 @@
 				07B7F2051F5EB43C00E6F910 /* OptionalExtensions.swift in Sources */,
 				074EAF1C1F7BA68B00C74636 /* UIFontExtensions.swift in Sources */,
 				07B7F1A81F5EB42000E6F910 /* UIAlertControllerExtensions.swift in Sources */,
+				F854D2AE2423DF54003A08A9 /* CGAffineTransformExtensions.swift in Sources */,
 				07B7F2341F5EB45200E6F910 /* CGColorExtensions.swift in Sources */,
 				70269A2C1FB478D100C6C2D0 /* CalendarExtensions.swift in Sources */,
 				07B7F2041F5EB43C00E6F910 /* LocaleExtensions.swift in Sources */,
@@ -2018,6 +2048,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07B7F1F51F5EB43B00E6F910 /* SignedNumericExtensions.swift in Sources */,
+				F854D2B52423E19B003A08A9 /* CGAffineTransformExtensions.swift in Sources */,
 				1875A8FB20BDE50D00A6D258 /* SKNodeExtensions.swift in Sources */,
 				0726D77B1F7C24840028CAB5 /* ColorExtensions.swift in Sources */,
 				07B7F1F41F5EB43B00E6F910 /* SignedIntegerExtensions.swift in Sources */,
@@ -2144,9 +2175,12 @@
 				07B7F2241F5EB44600E6F910 /* CLLocationExtensions.swift in Sources */,
 				1875A8FA20BDE50D00A6D258 /* SKNodeExtensions.swift in Sources */,
 				9D806A682258D75A008E500A /* SCNBoxExtensions.swift in Sources */,
+				F854D2C52423ECF0003A08A9 /* CATransform3DExtensions.swift in Sources */,
+				F854D2B02423DF5A003A08A9 /* CGAffineTransformExtensions.swift in Sources */,
 				278CA08D1F9A9232004918BD /* NSImageExtensions.swift in Sources */,
 				F8A710EC23BF3F7400112DAD /* EdgeInsetsExtensions.swift in Sources */,
 				74932D1523B8CEB700A56D81 /* SKProductExtensions.swift in Sources */,
+				F854D2B72423E1F1003A08A9 /* CAGradientLayerExtensions.swift in Sources */,
 				9D806A4E2258CFF8008E500A /* SCNSphereExtensions.swift in Sources */,
 				07B7F1E21F5EB43B00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				07B7F1E51F5EB43B00E6F910 /* URLExtensions.swift in Sources */,
@@ -2181,6 +2215,7 @@
 				07C50D321F5EB04700F46E5A /* UILabelExtensionsTests.swift in Sources */,
 				9D806A3D2258AED2008E500A /* UIBezierPathExtensionsTests.swift in Sources */,
 				07C50D621F5EB05000F46E5A /* OptionalExtensionsTests.swift in Sources */,
+				F854D2BB2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift in Sources */,
 				07C50D601F5EB05000F46E5A /* IntExtensionsTests.swift in Sources */,
 				07C50D631F5EB05000F46E5A /* StringExtensionsTests.swift in Sources */,
 				9D806A8B2258F892008E500A /* SCNGeometryExtensionsTests.swift in Sources */,
@@ -2250,6 +2285,7 @@
 				07C50D8F1F5EB06000F46E5A /* CLLocationExtensionsTests.swift in Sources */,
 				9D806A972258FD81008E500A /* SCNCylinderExtensionsTests.swift in Sources */,
 				07C50D8D1F5EB06000F46E5A /* CGPointExtensionsTests.swift in Sources */,
+				F854D2BF2423EBD0003A08A9 /* CATransform3DExtensionsTests.swift in Sources */,
 				C7E027C92360958B00F1061E /* KeyedDecodingContainerExtensionsTests.swift in Sources */,
 				B29527B220F9A04900E1F75D /* RandomAccessCollectionExtensionsTests.swift in Sources */,
 				07C50D3F1F5EB04700F46E5A /* UIViewControllerExtensionsTests.swift in Sources */,
@@ -2291,6 +2327,7 @@
 				752AC7A620BCA04100659E76 /* SpriteKitTests.swift in Sources */,
 				07C50D441F5EB04700F46E5A /* UICollectionViewExtensionsTests.swift in Sources */,
 				07C50D521F5EB04700F46E5A /* UITableViewExtensionsTests.swift in Sources */,
+				F854D2C02423EBD0003A08A9 /* CATransform3DExtensionsTests.swift in Sources */,
 				078916DB2076077000AC0665 /* FloatingPointExtensionsTests.swift in Sources */,
 				F8C1AE75225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
 				07C50D4E1F5EB04700F46E5A /* UISliderExtensionsTests.swift in Sources */,
@@ -2311,6 +2348,7 @@
 				748B192023B4F4FA0030FABB /* SKProductTests.swift in Sources */,
 				2141A353235F37C100218109 /* TestHelpers.swift in Sources */,
 				07C50D6D1F5EB05100F46E5A /* FloatExtensionsTests.swift in Sources */,
+				F854D2B82423E1FE003A08A9 /* CAGradientLayerExtensionsTests.swift in Sources */,
 				07C50D4D1F5EB04700F46E5A /* UISegmentedControlExtensionsTests.swift in Sources */,
 				07C50D891F5EB06000F46E5A /* CGSizeExtensionsTests.swift in Sources */,
 				9D806A982258FD81008E500A /* SCNCylinderExtensionsTests.swift in Sources */,
@@ -2355,6 +2393,7 @@
 				07C50D411F5EB04700F46E5A /* UIAlertControllerExtensionsTests.swift in Sources */,
 				B2A0DAC62336DCE5002B0BC5 /* MutableCollectionTests.swift in Sources */,
 				664CB98B21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */,
+				F854D2BC2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift in Sources */,
 				07C50D6C1F5EB05100F46E5A /* DoubleExtensionsTests.swift in Sources */,
 				9D806A482258B9BB008E500A /* SCNVector3ExtensionsTests.swift in Sources */,
 				07C50D6B1F5EB05100F46E5A /* DictionaryExtensionsTests.swift in Sources */,
@@ -2379,6 +2418,7 @@
 				664CB97D21718B1D00FC87B4 /* BinaryFloatingPointExtensionsTests.swift in Sources */,
 				0782A5B423DA98C100E562C0 /* CLLocationArrayExtensionsTests.swift in Sources */,
 				07C50D7E1F5EB05100F46E5A /* OptionalExtensionsTests.swift in Sources */,
+				F854D2C12423EBD0003A08A9 /* CATransform3DExtensionsTests.swift in Sources */,
 				2141A354235F37C200218109 /* TestHelpers.swift in Sources */,
 				5C88FBEC234CC1280065A942 /* NSColorExtensionsTests.swift in Sources */,
 				9D9784E61FCAE6DD00D988E7 /* StringProtocolExtensionsTests.swift in Sources */,
@@ -2389,6 +2429,7 @@
 				078916E020760DA700AC0665 /* SignedIntegerExtensionsTests.swift in Sources */,
 				F87AA5DC24125C19005F5B28 /* NotificationCenterExtensionsTests.swift in Sources */,
 				07C50D861F5EB05800F46E5A /* NSViewExtensionsTests.swift in Sources */,
+				F854D2B92423E1FE003A08A9 /* CAGradientLayerExtensionsTests.swift in Sources */,
 				07C50D851F5EB05800F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07C50D7C1F5EB05100F46E5A /* IntExtensionsTests.swift in Sources */,
 				F8C1AE76225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift in Sources */,
@@ -2405,6 +2446,7 @@
 				664CB98C21724A9100FC87B4 /* DispatchQueueExtensionsTests.swift in Sources */,
 				18C8E5E52074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				9D806A492258B9BB008E500A /* SCNVector3ExtensionsTests.swift in Sources */,
+				F854D2BD2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift in Sources */,
 				278CA0911F9A9679004918BD /* NSImageExtensionsTests.swift in Sources */,
 				182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */,
 				077BA0A01F6BEA4A00D9C4AC /* URLRequestExtensionsTests.swift in Sources */,

--- a/Tests/CoreAnimationTests/CAGradientLayerExtensionsTests.swift
+++ b/Tests/CoreAnimationTests/CAGradientLayerExtensionsTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class CAGradientLayerExtensionsTests: XCTestCase {
 
     func testInitWithGradientAttributes() {
-        let colors: [UIColor] = [.red, .blue, .orange, .yellow]
+        let colors: [Color] = [.red, .blue, .orange, .yellow]
         let locations: [CGFloat]? = [0, 0.3, 0.6, 1]
         let startPoint = CGPoint(x: 0.0, y: 0.5)
         let endPoint = CGPoint(x: 1.0, y: 0.5)

--- a/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
+++ b/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
@@ -1,0 +1,150 @@
+//
+//  CATransform3DExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 19/3/20.
+//  Copyright © 2020 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if canImport(QuartzCore)
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+
+// swiftlint:disable identifier_name
+
+final class CATransform3DExtensionsTests: XCTestCase {
+
+    let x = CGFloat(5)
+    let y = CGFloat(10)
+    let z = CGFloat(20)
+    let angle = CGFloat.pi / 3
+
+    var translation: CATransform3D { CATransform3DMakeTranslation(x, y, z) }
+    var scale: CATransform3D { CATransform3DMakeScale(x, y, z) }
+    var rotation: CATransform3D { CATransform3DMakeRotation(angle, x, y, z) }
+
+    func testIdentity() {
+        XCTAssertEqual(CATransform3D.identity, CATransform3DIdentity)
+        XCTAssertNotEqual(translation, CATransform3D.identity)
+        XCTAssertNotEqual(scale, CATransform3D.identity)
+        XCTAssertNotEqual(rotation, CATransform3D.identity)
+    }
+
+    func testIsIdentity() {
+        XCTAssert(CATransform3DIdentity.isIdentity)
+        XCTAssertFalse(translation.isIdentity)
+        XCTAssertFalse(scale.isIdentity)
+        XCTAssertFalse(rotation.isIdentity)
+    }
+
+    func testInitTranslation() {
+        XCTAssertEqual(CATransform3D(translation: x, y, z), translation)
+    }
+
+    func testInitScale() {
+        XCTAssertEqual(CATransform3D(scale: x, y, z), scale)
+    }
+
+    func testInitRotation() {
+        XCTAssertEqual(CATransform3D(rotation: angle, x, y, z), rotation)
+    }
+
+    func testTranslated() {
+        XCTAssertEqual(CATransform3DIdentity.translated(tx: x, ty: y, tz: z), translation)
+    }
+
+    func testScaled() {
+        XCTAssertEqual(CATransform3DIdentity.scaled(sx: x, sy: y, sz: z), scale)
+    }
+
+    func testRotated() {
+        XCTAssertEqual(CATransform3DIdentity.rotated(angle: angle, x: x, y: y, z: z), rotation)
+    }
+
+    func testConcatenated() {
+        XCTAssertEqual(CATransform3DIdentity.concatenated(transform: translation), translation)
+        XCTAssertEqual(CATransform3DIdentity.concatenated(transform: scale), scale)
+        XCTAssertEqual(CATransform3DIdentity.concatenated(transform: rotation), rotation)
+    }
+
+    func testInverted() {
+        XCTAssertEqual(CATransform3DIdentity, CATransform3DIdentity.inverted())
+        XCTAssertEqual(translation.inverted(), CATransform3DInvert(translation))
+        XCTAssertEqual(scale.inverted(), CATransform3DInvert(scale))
+        XCTAssertEqual(rotation.inverted(), CATransform3DInvert(rotation))
+    }
+
+    func testTranslate() {
+        var transform = CATransform3DIdentity
+        transform.translate(tx: x, ty: y, tz: z)
+        XCTAssertEqual(transform, translation)
+    }
+
+    func testScale() {
+        var transform = CATransform3DIdentity
+        transform.scale(sx: x, sy: y, sz: z)
+        XCTAssertEqual(transform, scale)
+    }
+
+    func testRotate() {
+        var transform = CATransform3DIdentity
+        transform.rotate(angle: angle, x: x, y: y, z: z)
+        XCTAssertEqual(transform, rotation)
+    }
+
+    func testConcatenate() {
+        var transform = CATransform3DIdentity
+        transform.concatenate(transform: translation)
+        XCTAssertEqual(transform, translation)
+
+        transform = CATransform3DIdentity
+        transform.concatenate(transform: scale)
+        XCTAssertEqual(transform, scale)
+
+        transform = CATransform3DIdentity
+        transform.concatenate(transform: rotation)
+        XCTAssertEqual(transform, rotation)
+    }
+
+    func testInvert() {
+        var transform = CATransform3DIdentity
+        transform.invert()
+        XCTAssertEqual(transform, CATransform3DIdentity)
+
+        transform = translation
+        transform.invert()
+        XCTAssertEqual(transform, CATransform3DInvert(translation))
+
+        transform = scale
+        transform.invert()
+        XCTAssertEqual(transform, CATransform3DInvert(scale))
+
+        transform = rotation
+        transform.invert()
+        XCTAssertEqual(transform, CATransform3DInvert(rotation))
+    }
+
+    #if canImport(CoreGraphics)
+
+    func testIsAffine() {
+        XCTAssert(CATransform3DIdentity.isAffine)
+        XCTAssertFalse(CATransform3DMakeTranslation(0, 0, 1).isAffine)
+    }
+
+    func testAffineTransform() {
+        XCTAssertEqual(CATransform3DIdentity.affineTransform(), CGAffineTransform.identity)
+        XCTAssertEqual(CATransform3DMakeTranslation(x, y, 1).affineTransform(), CGAffineTransform(translationX: x, y: y))
+    }
+
+    #endif
+
+}
+
+// swiftlint:enable identifier_name
+
+#endif

--- a/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
+++ b/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
@@ -35,6 +35,49 @@ final class CATransform3DExtensionsTests: XCTestCase {
         XCTAssertNotEqual(rotation, CATransform3D.identity)
     }
 
+    func testCodable() {
+        let transform = translation.concatenating(scale).concatenating(rotation)
+
+        let encoder = JSONEncoder()
+        var data: Data?
+        XCTAssertNoThrow(data = try encoder.encode(transform))
+        XCTAssert(data?.isEmpty == false)
+
+        let decoder = JSONDecoder()
+        var decodedTransform: CATransform3D?
+        XCTAssertNoThrow(decodedTransform = try decoder.decode(CATransform3D.self, from: data!))
+
+        let accuracy = CGFloat(0.000001)
+        XCTAssertEqual(transform.m11, decodedTransform!.m11, accuracy: accuracy)
+        XCTAssertEqual(transform.m12, decodedTransform!.m12, accuracy: accuracy)
+        XCTAssertEqual(transform.m13, decodedTransform!.m13, accuracy: accuracy)
+        XCTAssertEqual(transform.m14, decodedTransform!.m14, accuracy: accuracy)
+        XCTAssertEqual(transform.m21, decodedTransform!.m21, accuracy: accuracy)
+        XCTAssertEqual(transform.m22, decodedTransform!.m22, accuracy: accuracy)
+        XCTAssertEqual(transform.m23, decodedTransform!.m23, accuracy: accuracy)
+        XCTAssertEqual(transform.m24, decodedTransform!.m24, accuracy: accuracy)
+        XCTAssertEqual(transform.m31, decodedTransform!.m31, accuracy: accuracy)
+        XCTAssertEqual(transform.m32, decodedTransform!.m32, accuracy: accuracy)
+        XCTAssertEqual(transform.m33, decodedTransform!.m33, accuracy: accuracy)
+        XCTAssertEqual(transform.m34, decodedTransform!.m34, accuracy: accuracy)
+        XCTAssertEqual(transform.m41, decodedTransform!.m41, accuracy: accuracy)
+        XCTAssertEqual(transform.m42, decodedTransform!.m42, accuracy: accuracy)
+        XCTAssertEqual(transform.m43, decodedTransform!.m43, accuracy: accuracy)
+        XCTAssertEqual(transform.m44, decodedTransform!.m44, accuracy: accuracy)
+    }
+
+    func testInitTranslation() {
+        XCTAssertEqual(CATransform3D(translationX: x, y: y, z: z), translation)
+    }
+
+    func testInitScale() {
+        XCTAssertEqual(CATransform3D(scaleX: x, y: y, z: z), scale)
+    }
+
+    func testInitRotation() {
+        XCTAssertEqual(CATransform3D(rotationAngle: angle, x: x, y: y, z: z), rotation)
+    }
+
     func testIsIdentity() {
         XCTAssert(CATransform3DIdentity.isIdentity)
         XCTAssertFalse(translation.isIdentity)
@@ -42,34 +85,16 @@ final class CATransform3DExtensionsTests: XCTestCase {
         XCTAssertFalse(rotation.isIdentity)
     }
 
-    func testInitTranslation() {
-        XCTAssertEqual(CATransform3D(translation: x, y, z), translation)
-    }
-
-    func testInitScale() {
-        XCTAssertEqual(CATransform3D(scale: x, y, z), scale)
-    }
-
-    func testInitRotation() {
-        XCTAssertEqual(CATransform3D(rotation: angle, x, y, z), rotation)
-    }
-
     func testTranslated() {
-        XCTAssertEqual(CATransform3DIdentity.translated(tx: x, ty: y, tz: z), translation)
+        XCTAssertEqual(CATransform3DIdentity.translatedBy(x: x, y: y, z: z), translation)
     }
 
     func testScaled() {
-        XCTAssertEqual(CATransform3DIdentity.scaled(sx: x, sy: y, sz: z), scale)
+        XCTAssertEqual(CATransform3DIdentity.scaledBy(x: x, y: y, z: z), scale)
     }
 
     func testRotated() {
-        XCTAssertEqual(CATransform3DIdentity.rotated(angle: angle, x: x, y: y, z: z), rotation)
-    }
-
-    func testConcatenated() {
-        XCTAssertEqual(CATransform3DIdentity.concatenated(transform: translation), translation)
-        XCTAssertEqual(CATransform3DIdentity.concatenated(transform: scale), scale)
-        XCTAssertEqual(CATransform3DIdentity.concatenated(transform: rotation), rotation)
+        XCTAssertEqual(CATransform3DIdentity.rotated(by: angle, x: x, y: y, z: z), rotation)
     }
 
     func testInverted() {
@@ -79,35 +104,27 @@ final class CATransform3DExtensionsTests: XCTestCase {
         XCTAssertEqual(rotation.inverted(), CATransform3DInvert(rotation))
     }
 
+    func testConcatenated() {
+        XCTAssertEqual(CATransform3DIdentity.concatenating(translation), translation)
+        XCTAssertEqual(CATransform3DIdentity.concatenating(scale), scale)
+        XCTAssertEqual(CATransform3DIdentity.concatenating(rotation), rotation)
+    }
+
     func testTranslate() {
         var transform = CATransform3DIdentity
-        transform.translate(tx: x, ty: y, tz: z)
+        transform.translateBy(x: x, y: y, z: z)
         XCTAssertEqual(transform, translation)
     }
 
     func testScale() {
         var transform = CATransform3DIdentity
-        transform.scale(sx: x, sy: y, sz: z)
+        transform.scaleBy(x: x, y: y, z: z)
         XCTAssertEqual(transform, scale)
     }
 
     func testRotate() {
         var transform = CATransform3DIdentity
-        transform.rotate(angle: angle, x: x, y: y, z: z)
-        XCTAssertEqual(transform, rotation)
-    }
-
-    func testConcatenate() {
-        var transform = CATransform3DIdentity
-        transform.concatenate(transform: translation)
-        XCTAssertEqual(transform, translation)
-
-        transform = CATransform3DIdentity
-        transform.concatenate(transform: scale)
-        XCTAssertEqual(transform, scale)
-
-        transform = CATransform3DIdentity
-        transform.concatenate(transform: rotation)
+        transform.rotate(by: angle, x: x, y: y, z: z)
         XCTAssertEqual(transform, rotation)
     }
 
@@ -127,6 +144,20 @@ final class CATransform3DExtensionsTests: XCTestCase {
         transform = rotation
         transform.invert()
         XCTAssertEqual(transform, CATransform3DInvert(rotation))
+    }
+
+    func testConcatenate() {
+        var transform = CATransform3DIdentity
+        transform.concatenate(translation)
+        XCTAssertEqual(transform, translation)
+
+        transform = CATransform3DIdentity
+        transform.concatenate(scale)
+        XCTAssertEqual(transform, scale)
+
+        transform = CATransform3DIdentity
+        transform.concatenate(rotation)
+        XCTAssertEqual(transform, rotation)
     }
 
     #if canImport(CoreGraphics)

--- a/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
+++ b/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
@@ -15,8 +15,6 @@ import XCTest
 import CoreGraphics
 #endif
 
-// swiftlint:disable identifier_name
-
 final class CATransform3DExtensionsTests: XCTestCase {
 
     let x = CGFloat(5)
@@ -175,7 +173,5 @@ final class CATransform3DExtensionsTests: XCTestCase {
     #endif
 
 }
-
-// swiftlint:enable identifier_name
 
 #endif

--- a/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
@@ -12,6 +12,10 @@ import XCTest
 #if canImport(CoreGraphics)
 import CoreGraphics
 
+#if canImport(QuartzCore)
+import QuartzCore
+#endif
+
 final class CGAffineTransformExtensionsTests: XCTestCase {
 
     #if canImport(QuartzCore)

--- a/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
@@ -1,0 +1,42 @@
+//
+//  CGAffineTransformExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 19/3/20.
+//  Copyright © 2020 SwifterSwift
+//
+
+import XCTest
+@testable import SwifterSwift
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+final class CGAffineTransformExtensionsTests: XCTestCase {
+
+    #if canImport(QuartzCore)
+    func testTransform3D() {
+        let identityAffineTransform = CGAffineTransform.identity
+        let identityTransform = CATransform3DIdentity
+        XCTAssertEqual(identityAffineTransform.transform3D(), identityTransform)
+
+        // swiftlint:disable identifier_name
+        let x = CGFloat(5)
+        let y = CGFloat(10)
+        // swiftlint:enable identifier_name
+
+        XCTAssertEqual(identityAffineTransform.translatedBy(x: x, y: y).transform3D(),
+                       identityTransform.translated(tx: x, ty: y, tz: 0))
+
+        XCTAssertEqual(identityAffineTransform.scaledBy(x: x, y: y).transform3D(),
+                       identityTransform.scaled(sx: x, sy: y, sz: 1))
+
+        let angle = CGFloat.pi / 3
+        XCTAssertEqual(identityAffineTransform.rotated(by: angle).transform3D(),
+                       identityTransform.rotated(angle: angle, x: 0, y: 0, z: 1))
+    }
+    #endif
+
+}
+
+#endif

--- a/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
@@ -16,24 +16,17 @@ final class CGAffineTransformExtensionsTests: XCTestCase {
 
     #if canImport(QuartzCore)
     func testTransform3D() {
-        let identityAffineTransform = CGAffineTransform.identity
-        let identityTransform = CATransform3DIdentity
-        XCTAssertEqual(identityAffineTransform.transform3D(), identityTransform)
+        XCTAssertEqual(CGAffineTransform.identity.transform3D(), CATransform3DIdentity)
 
         // swiftlint:disable identifier_name
         let x = CGFloat(5)
         let y = CGFloat(10)
         // swiftlint:enable identifier_name
-
-        XCTAssertEqual(identityAffineTransform.translatedBy(x: x, y: y).transform3D(),
-                       identityTransform.translated(tx: x, ty: y, tz: 0))
-
-        XCTAssertEqual(identityAffineTransform.scaledBy(x: x, y: y).transform3D(),
-                       identityTransform.scaled(sx: x, sy: y, sz: 1))
-
         let angle = CGFloat.pi / 3
-        XCTAssertEqual(identityAffineTransform.rotated(by: angle).transform3D(),
-                       identityTransform.rotated(angle: angle, x: 0, y: 0, z: 1))
+
+        XCTAssertEqual(CGAffineTransform(translationX: x, y: y).transform3D(), CATransform3DMakeTranslation(x, y, 0))
+        XCTAssertEqual(CGAffineTransform(scaleX: x, y: y).transform3D(), CATransform3DMakeScale(x, y, 1))
+        XCTAssertEqual(CGAffineTransform(rotationAngle: angle).transform3D(), CATransform3DMakeRotation(angle, 0, 0, 1))
     }
     #endif
 

--- a/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGAffineTransformExtensionsTests.swift
@@ -22,10 +22,8 @@ final class CGAffineTransformExtensionsTests: XCTestCase {
     func testTransform3D() {
         XCTAssertEqual(CGAffineTransform.identity.transform3D(), CATransform3DIdentity)
 
-        // swiftlint:disable identifier_name
         let x = CGFloat(5)
         let y = CGFloat(10)
-        // swiftlint:enable identifier_name
         let angle = CGFloat.pi / 3
 
         XCTAssertEqual(CGAffineTransform(translationX: x, y: y).transform3D(), CATransform3DMakeTranslation(x, y, 0))


### PR DESCRIPTION
🚀
CATransform only had the old Objective-C-style functions. It now gets the same treatment as `CGAffineTransform`, plus `mutating` functions to go with it.

Also added in a little fix for `CAGradientLayerExtensionsTests`, which wasn't included in all the tests.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
