### PR TITLE
Access/update RangeReplaceableCollection by index offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **RangeReplaceableCollection**:
+  - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#824](https://github.com/SwifterSwift/SwifterSwift/pull/824) by [guykogus](https://github.com/guykogus)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **RangeReplaceableCollection**:
-  - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#824](https://github.com/SwifterSwift/SwifterSwift/pull/824) by [guykogus](https://github.com/guykogus)
+  - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#826](https://github.com/SwifterSwift/SwifterSwift/pull/826) by [guykogus](https://github.com/guykogus)
 
 ### Changed
 

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -151,4 +151,32 @@ public extension RangeReplaceableCollection {
         var set = Set<E>()
         removeAll { !set.insert($0[keyPath: path]).inserted }
     }
+
+    /// SwifterSwift: Accesses the element at the specified position.
+    ///
+    /// - Parameter offset: The offset position of the element to access. `offset` must be a valid index offset of the collection that is not equal to the `endIndex` property.
+    subscript(offset: Int) -> Element {
+        get {
+            return self[index(startIndex, offsetBy: offset)]
+        }
+        set {
+            let offsetIndex = index(startIndex, offsetBy: offset)
+            replaceSubrange(offsetIndex..<index(after: offsetIndex), with: [newValue])
+        }
+    }
+
+    /// SwifterSwift: Accesses a contiguous subrange of the collection’s elements.
+    ///
+    /// - Parameter range: A range of the collection’s indices offsets. The bounds of the range must be valid indices of the collection.
+    subscript<R>(range: R) -> SubSequence where R: RangeExpression, R.Bound == Int {
+        get {
+            let indexRange = range.relative(to: 0..<count)
+            return self[index(startIndex, offsetBy: indexRange.lowerBound)..<index(startIndex, offsetBy: indexRange.upperBound)]
+        }
+        set {
+            let indexRange = range.relative(to: 0..<count)
+            replaceSubrange(index(startIndex, offsetBy: indexRange.lowerBound)..<index(startIndex, offsetBy: indexRange.upperBound), with: newValue)
+        }
+    }
+
 }

--- a/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
@@ -137,4 +137,47 @@ final class RangeReplaceableCollectionTests: XCTestCase {
         input.removeDuplicates(keyPath: \.location)
         XCTAssertEqual(input, expectedResult)
     }
+
+    func testIntSubscripts() {
+        var string = "Hello world!"
+        XCTAssertEqual(string[0], "H")
+        XCTAssertEqual(string[11], "!")
+
+        XCTAssertEqual(string[0..<5], "Hello")
+        XCTAssertEqual(string[6..<12], "world!")
+
+        XCTAssertEqual(string[0...4], "Hello")
+        XCTAssertEqual(string[6...11], "world!")
+
+        XCTAssertEqual(string[0...], "Hello world!")
+
+        XCTAssertEqual(string[...11], "Hello world!")
+
+        XCTAssertEqual(string[..<12], "Hello world!")
+
+        string[0] = "h"
+        XCTAssertEqual(string, "hello world!")
+        string[11] = "?"
+        XCTAssertEqual(string, "hello world?")
+
+        string[0..<5] = "Goodbye"
+        XCTAssertEqual(string, "Goodbye world?")
+        string[8..<14] = "planet!"
+        XCTAssertEqual(string, "Goodbye planet!")
+
+        string[0...6] = "Hello"
+        XCTAssertEqual(string, "Hello planet!")
+        string[6...12] = "world?"
+        XCTAssertEqual(string, "Hello world?")
+
+        string[5...] = "!"
+        XCTAssertEqual(string, "Hello!")
+
+        string[..<6] = "Hello Ferris"
+        XCTAssertEqual(string, "Hello Ferris")
+
+        string[...4] = "Save"
+        XCTAssertEqual(string, "Save Ferris")
+    }
+
 }


### PR DESCRIPTION
🚀
This is especially useful for `String`s.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
