### PR TITLE
Make `NSAttributedString.applying(attributes:)` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#826](https://github.com/SwifterSwift/SwifterSwift/pull/826) by [guykogus](https://github.com/guykogus)
 
 ### Changed
+- **NSAttributedStringExtensions.swift**:
+  - `applying(attributes:)` changed access modifier from `fileprivate` to `public`. [#832](https://github.com/SwifterSwift/SwifterSwift/pull/832) by [cHaLkdusT](https://github.com/cHaLkdusT)
 
 ### Deprecated
 

--- a/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSAttributedStringExtensions.swift
@@ -66,7 +66,7 @@ public extension NSAttributedString {
     ///
     /// - Parameter attributes: Dictionary of attributes
     /// - Returns: NSAttributedString with applied attributes
-    fileprivate func applying(attributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
+    func applying(attributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
         let copy = NSMutableAttributedString(attributedString: self)
         let range = (string as NSString).range(of: string)
         copy.addAttributes(attributes, range: range)

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -84,7 +84,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         ])
         attributes = out.attributes(at: 0, effectiveRange: nil)
         XCTAssertEqual(attributes.count, 2)
-        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue)) // swiftlint:disable:next force_cast
+        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue)) // swiftlint:disable:this force_cast
         XCTAssertEqual(attributes[.foregroundColor] as! Color, .red) // swiftlint:disable:next force_cast
         #endif
     }

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -82,12 +82,9 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
             .foregroundColor: Color.red
         ])
         attributes = out.attributes(at: 0, effectiveRange: nil)
-        let filteredAttributes = attributes.filter { (key, value) -> Bool in
-            return (key == NSAttributedString.Key.foregroundColor && (value as? Color) == .red) ||
-                (key == NSAttributedString.Key.strikethroughStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.single.rawValue)
-        }
-
-        XCTAssertEqual(filteredAttributes.count, 2)
+        XCTAssertEqual(attributes.count, 2)
+        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue as Int))
+        XCTAssertEqual(attributes[.foregroundColor] as! Color, .red)
         #endif
     }
 

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -85,7 +85,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         attributes = out.attributes(at: 0, effectiveRange: nil)
         XCTAssertEqual(attributes.count, 2)
         XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue)) // swiftlint:disable:this force_cast
-        XCTAssertEqual(attributes[.foregroundColor] as! Color, .red) // swiftlint:disable:next force_cast
+        XCTAssertEqual(attributes[.foregroundColor] as! Color, .red) // swiftlint:disable:this force_cast
         #endif
     }
 

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -73,11 +73,15 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
     func testApplying() {
         #if canImport(AppKit) || canImport(UIKit)
         let string = NSAttributedString(string: "Applying")
-        let out = string.applying(attributes: [
+        var out = string.applying(attributes: [:])
+        var attributes = out.attributes(at: 0, effectiveRange: nil)
+        XCTAssertTrue(attributes.isEmpty)
+
+        out = string.applying(attributes: [
             .strikethroughStyle: NSNumber(value: NSUnderlineStyle.single.rawValue as Int),
             .foregroundColor: Color.red
         ])
-        let attributes = out.attributes(at: 0, effectiveRange: nil)
+        attributes = out.attributes(at: 0, effectiveRange: nil)
         let filteredAttributes = attributes.filter { (key, value) -> Bool in
             return (key == NSAttributedString.Key.foregroundColor && (value as? Color) == .red) ||
                 (key == NSAttributedString.Key.strikethroughStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.single.rawValue)

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -75,7 +75,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         let string = NSAttributedString(string: "Applying")
         let out = string.applying(attributes: [
             .strikethroughStyle: NSNumber(value: NSUnderlineStyle.single.rawValue as Int),
-            .foregroundColor: UIColor.red
+            .foregroundColor: Color.red
         ])
         let attributes = out.attributes(at: 0, effectiveRange: nil)
         let filteredAttributes = attributes.filter { (key, value) -> Bool in

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -70,6 +70,23 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
     }
 
     // MARK: - Methods
+    func testApplying() {
+        #if canImport(AppKit) || canImport(UIKit)
+        let string = NSAttributedString(string: "Applying")
+        let out = string.applying(attributes: [
+            .strikethroughStyle: NSNumber(value: NSUnderlineStyle.single.rawValue as Int),
+            .foregroundColor: UIColor.red
+        ])
+        let attributes = out.attributes(at: 0, effectiveRange: nil)
+        let filteredAttributes = attributes.filter { (key, value) -> Bool in
+            return (key == NSAttributedString.Key.foregroundColor && (value as? Color) == .red) ||
+                (key == NSAttributedString.Key.strikethroughStyle && (value as? NSUnderlineStyle.RawValue) == NSUnderlineStyle.single.rawValue)
+        }
+
+        XCTAssertEqual(filteredAttributes.count, 2)
+        #endif
+    }
+
     func testColored() {
         #if canImport(AppKit) || canImport(UIKit)
         let string = NSAttributedString(string: "Colored")

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -83,7 +83,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         ])
         attributes = out.attributes(at: 0, effectiveRange: nil)
         XCTAssertEqual(attributes.count, 2)
-        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue as Int))
+        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue))
         XCTAssertEqual(attributes[.foregroundColor] as! Color, .red)
         #endif
     }

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -78,7 +78,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         XCTAssertTrue(attributes.isEmpty)
 
         out = string.applying(attributes: [
-            .strikethroughStyle: NSNumber(value: NSUnderlineStyle.single.rawValue as Int),
+            .strikethroughStyle: NSNumber(value: NSUnderlineStyle.single.rawValue),
             .foregroundColor: Color.red
         ])
         attributes = out.attributes(at: 0, effectiveRange: nil)

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -12,6 +12,7 @@ import XCTest
 #if canImport(Foundation)
 import Foundation
 
+// swiftlint:disable:next type_body_length
 final class NSAttributedStringExtensionsTests: XCTestCase {
 
     func testBolded() {
@@ -83,8 +84,8 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         ])
         attributes = out.attributes(at: 0, effectiveRange: nil)
         XCTAssertEqual(attributes.count, 2)
-        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue))
-        XCTAssertEqual(attributes[.foregroundColor] as! Color, .red)
+        XCTAssertEqual(attributes[.strikethroughStyle] as! NSNumber, NSNumber(value: NSUnderlineStyle.single.rawValue)) // swiftlint:disable:next force_cast
+        XCTAssertEqual(attributes[.foregroundColor] as! Color, .red) // swiftlint:disable:next force_cast
         #endif
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #831 
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
