### PR TITLE
Added `last(where:equals:)` extension to Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#826](https://github.com/SwifterSwift/SwifterSwift/pull/826) by [guykogus](https://github.com/guykogus)
 - **Sequence**:
   - Added `first(where:equals:)` to find the first element of the sequence with having property by given key path equals to given value. [#836](https://github.com/SwifterSwift/SwifterSwift/pull/836) by [hamtiko](https://github.com/hamtiko)
+  - Added `last(where:equals:)` to find the last element of the sequence with having property by given key path equals to given value. [#838](https://github.com/SwifterSwift/SwifterSwift/pull/838) by [hamtiko](https://github.com/hamtiko)
 - **SKNode**:
   - `center`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight` to get anchor position or set position using anchor. [#835](https://github.com/SwifterSwift/SwifterSwift/pull/835) by [rypyak](https://github.com/rypyak)
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -282,6 +282,16 @@ public extension Sequence {
     func first<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
         return first { $0[keyPath: keyPath] == value }
     }
+
+    /// SwifterSwift: Returns the last element of the sequence with having property by given key path equals to given `value`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` of property for `Element` to compare.
+    ///   - value: The value to compare with `Element` property
+    /// - Returns: The last element of the collection that has property by given key path equals to given `value` or `nil` if there is no such element.
+    func last<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
+        return last { $0[keyPath: keyPath] == value }
+    }
 }
 
 public extension Sequence where Element: Equatable {

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -207,7 +207,7 @@ final class SequenceExtensionsTests: XCTestCase {
         let array1 = [
             Person(name: "John", age: 30, location: Location(city: "Boston")),
             Person(name: "Jan", age: 22, location: nil),
-            Person(name: "Roman", age: 26, location: Location(city: "Moscow"))
+            Person(name: "Roman", age: 30, location: Location(city: "Moscow"))
         ]
 
         let first30Age = array1.first(where: \.age, equals: 30)
@@ -215,6 +215,22 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(first30Age, array1.first)
 
         let missingPerson = array1.first(where: \.name, equals: "Tom")
+
+        XCTAssertNil(missingPerson)
+    }
+
+    func testLastByKeyPath() {
+        let array1 = [
+            Person(name: "John", age: 30, location: Location(city: "Boston")),
+            Person(name: "Jan", age: 22, location: nil),
+            Person(name: "Roman", age: 30, location: Location(city: "Moscow"))
+        ]
+
+        let last30Age = array1.last(where: \.age, equals: 30)
+
+        XCTAssertEqual(last30Age, array1.last)
+
+        let missingPerson = array1.last(where: \.name, equals: "Tom")
 
         XCTAssertNil(missingPerson)
     }


### PR DESCRIPTION
Adding `last(where:equals:)` extension to Sequence in addition to `first(where:equals:)`.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
