### PR TITLE
CGSize: Added new `+`, `+=`, `-` and `-=` operator extensions for tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `last(where:equals:)` to find the last element of the sequence with having property by given key path equals to given value. [#838](https://github.com/SwifterSwift/SwifterSwift/pull/838) by [hamtiko](https://github.com/hamtiko)
 - **SKNode**:
   - `center`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight` to get anchor position or set position using anchor. [#835](https://github.com/SwifterSwift/SwifterSwift/pull/835) by [rypyak](https://github.com/rypyak)
+- **CGSize**:
+  - Added new `+`, `+=`, `-` and `-=` operator extensions for tuple (width: CGFloat, height: CGFloat). [#841](https://github.com/SwifterSwift/SwifterSwift/pull/841) by [hamtiko](https://github.com/hamtiko)
 
 ### Changed
 - **NSAttributedStringExtensions.swift**:

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -96,20 +96,6 @@ public extension CGSize {
         return CGSize(width: lhs.width + tuple.width, height: lhs.height + tuple.height)
     }
 
-    /// SwifterSwift: Add a tuple to CGSize.
-    ///
-    ///     let sizeA = CGSize(width: 5, height: 10)
-    ///     let result = (4, 5) + sizeA
-    ///     // result = CGSize(width: 9, height: 15)
-    ///
-    /// - Parameters:
-    ///   - scalar: tuple value.
-    ///   - rhs: CGSize to add to.
-    /// - Returns: The result comes from the addition of the given tuple and CGSize.
-    static func + (tuple: (width: CGFloat, height: CGFloat), rhs: CGSize) -> CGSize {
-        return CGSize(width: tuple.width + rhs.width, height: tuple.height + rhs.height)
-    }
-
     /// SwifterSwift: Add a CGSize to self.
     ///
     ///     var sizeA = CGSize(width: 5, height: 10)

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -82,9 +82,37 @@ public extension CGSize {
         return CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
     }
 
-    /// SwifterSwift: Add a CGSize to self.
+    /// SwifterSwift: Add a tuple to CGSize.
     ///
     ///     let sizeA = CGSize(width: 5, height: 10)
+    ///     let result = sizeA + (5, 4)
+    ///     // result = CGSize(width: 10, height: 14)
+    ///
+    /// - Parameters:
+    ///   - lhs: CGSize to add to.
+    ///   - tuple: tuple value.
+    /// - Returns: The result comes from the addition of the given CGSize and tuple.
+    static func + (lhs: CGSize, tuple: (width: CGFloat, height: CGFloat)) -> CGSize {
+        return CGSize(width: lhs.width + tuple.width, height: lhs.height + tuple.height)
+    }
+
+    /// SwifterSwift: Add a tuple to CGSize.
+    ///
+    ///     let sizeA = CGSize(width: 5, height: 10)
+    ///     let result = (4, 5) + sizeA
+    ///     // result = CGSize(width: 9, height: 15)
+    ///
+    /// - Parameters:
+    ///   - scalar: tuple value.
+    ///   - rhs: CGSize to add to.
+    /// - Returns: The result comes from the addition of the given tuple and CGSize.
+    static func + (tuple: (width: CGFloat, height: CGFloat), rhs: CGSize) -> CGSize {
+        return CGSize(width: tuple.width + rhs.width, height: tuple.height + rhs.height)
+    }
+
+    /// SwifterSwift: Add a CGSize to self.
+    ///
+    ///     var sizeA = CGSize(width: 5, height: 10)
     ///     let sizeB = CGSize(width: 3, height: 4)
     ///     sizeA += sizeB
     ///     // sizeA = CGPoint(width: 8, height: 14)
@@ -95,6 +123,20 @@ public extension CGSize {
     static func += (lhs: inout CGSize, rhs: CGSize) {
         lhs.width += rhs.width
         lhs.height += rhs.height
+    }
+
+    /// SwifterSwift: Add a tuple to self.
+    ///
+    ///     var sizeA = CGSize(width: 5, height: 10)
+    ///     sizeA += (3, 4)
+    ///     // result = CGSize(width: 8, height: 14)
+    ///
+    /// - Parameters:
+    ///   - lhs: self.
+    ///   - tuple: tuple value.
+    static func += (lhs: inout CGSize, tuple: (width: CGFloat, height: CGFloat)) {
+        lhs.width += tuple.width
+        lhs.height += tuple.height
     }
 
     /// SwifterSwift: Subtract two CGSize
@@ -112,9 +154,23 @@ public extension CGSize {
         return CGSize(width: lhs.width - rhs.width, height: lhs.height - rhs.height)
     }
 
-    /// SwifterSwift: Subtract a CGSize from self.
+    /// SwifterSwift: Subtract a tuple from CGSize.
     ///
     ///     let sizeA = CGSize(width: 5, height: 10)
+    ///     let result = sizeA - (3, 2)
+    ///     // result = CGSize(width: 2, height: 8)
+    ///
+    /// - Parameters:
+    ///   - lhs: CGSize to subtract from.
+    ///   - tuple: tuple value.
+    /// - Returns: The result comes from the subtract of the given CGSize and tuple.
+    static func - (lhs: CGSize, tuple: (width: CGFloat, heoght: CGFloat)) -> CGSize {
+        return CGSize(width: lhs.width - tuple.width, height: lhs.height - tuple.heoght)
+    }
+
+    /// SwifterSwift: Subtract a CGSize from self.
+    ///
+    ///     var sizeA = CGSize(width: 5, height: 10)
     ///     let sizeB = CGSize(width: 3, height: 4)
     ///     sizeA -= sizeB
     ///     // sizeA = CGPoint(width: 2, height: 6)
@@ -125,6 +181,20 @@ public extension CGSize {
     static func -= (lhs: inout CGSize, rhs: CGSize) {
         lhs.width -= rhs.width
         lhs.height -= rhs.height
+    }
+
+    /// SwifterSwift: Subtract a tuple from self.
+    ///
+    ///     var sizeA = CGSize(width: 5, height: 10)
+    ///     sizeA -= (2, 4)
+    ///     // result = CGSize(width: 3, height: 6)
+    ///
+    /// - Parameters:
+    ///   - lhs: self.
+    ///   - tuple: tuple value.
+    static func -= (lhs: inout CGSize, tuple: (width: CGFloat, height: CGFloat)) {
+        lhs.width -= tuple.width
+        lhs.height -= tuple.height
     }
 
     /// SwifterSwift: Multiply two CGSize
@@ -172,7 +242,7 @@ public extension CGSize {
 
     /// SwifterSwift: Multiply self with a CGSize.
     ///
-    ///     let sizeA = CGSize(width: 5, height: 10)
+    ///     var sizeA = CGSize(width: 5, height: 10)
     ///     let sizeB = CGSize(width: 3, height: 4)
     ///     sizeA *= sizeB
     ///     // result = CGSize(width: 15, height: 40)
@@ -187,7 +257,7 @@ public extension CGSize {
 
     /// SwifterSwift: Multiply self with a scalar.
     ///
-    ///     let sizeA = CGSize(width: 5, height: 10)
+    ///     var sizeA = CGSize(width: 5, height: 10)
     ///     sizeA *= 3
     ///     // result = CGSize(width: 15, height: 30)
     ///

--- a/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
@@ -62,9 +62,9 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(result.height, 14)
     }
 
-    func testAddTupleRight() {
-        let sizeA = CGSize(width: 5, height: 10)
-        let result = sizeA + (width: 4, height: 4)
+    func testAddTuple() {
+        let size = CGSize(width: 5, height: 10)
+        let result = size + (width: 4, height: 4)
         XCTAssertEqual(result.width, 9)
         XCTAssertEqual(result.height, 14)
     }
@@ -78,10 +78,10 @@ final class CGSizeExtensionsTests: XCTestCase {
     }
 
     func testAddEqualTuple() {
-        var sizeA = CGSize(width: 5, height: 10)
-        sizeA += (3, 0)
-        XCTAssertEqual(sizeA.width, 8)
-        XCTAssertEqual(sizeA.height, 10)
+        var size = CGSize(width: 5, height: 10)
+        size += (3, 0)
+        XCTAssertEqual(size.width, 8)
+        XCTAssertEqual(size.height, 10)
     }
 
     func testSubtract() {
@@ -93,8 +93,8 @@ final class CGSizeExtensionsTests: XCTestCase {
     }
 
     func testSubtractTuple() {
-        let sizeA = CGSize(width: 5, height: 10)
-        let result = sizeA - (2, 3)
+        let size = CGSize(width: 5, height: 10)
+        let result = size - (2, 3)
         XCTAssertEqual(result.width, 3)
         XCTAssertEqual(result.height, 7)
     }
@@ -107,11 +107,11 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(sizeA.height, 6)
     }
 
-    func testSubtractTupleEqual() {
-        var sizeA = CGSize(width: 5, height: 10)
-        sizeA -= (1, 4)
-        XCTAssertEqual(sizeA.width, 4)
-        XCTAssertEqual(sizeA.height, 6)
+    func testSubtractEqualTuple() {
+        var size = CGSize(width: 5, height: 10)
+        size -= (1, 4)
+        XCTAssertEqual(size.width, 4)
+        XCTAssertEqual(size.height, 6)
     }
 
     func testMultiplyCGSize() {

--- a/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
@@ -62,12 +62,33 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(result.height, 14)
     }
 
+    func testAddScalarRight() {
+        let sizeA = CGSize(width: 5, height: 10)
+        let result = sizeA + (width: 4, height: 4)
+        XCTAssertEqual(result.width, 9)
+        XCTAssertEqual(result.height, 14)
+    }
+
+    func testAddScalarLeft() {
+        let sizeA = CGSize(width: 5, height: 10)
+        let result = (5, 3) + sizeA
+        XCTAssertEqual(result.width, 10)
+        XCTAssertEqual(result.height, 13)
+    }
+
     func testAddEqual() {
         var sizeA = CGSize(width: 5, height: 10)
         let sizeB = CGSize(width: 3, height: 4)
         sizeA += sizeB
         XCTAssertEqual(sizeA.width, 8)
         XCTAssertEqual(sizeA.height, 14)
+    }
+
+    func testAddEqualScalar() {
+        var sizeA = CGSize(width: 5, height: 10)
+        sizeA += (3, 0)
+        XCTAssertEqual(sizeA.width, 8)
+        XCTAssertEqual(sizeA.height, 10)
     }
 
     func testSubtract() {
@@ -78,11 +99,25 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(result.height, 6)
     }
 
+    func testSubtractScalar() {
+        let sizeA = CGSize(width: 5, height: 10)
+        let result = sizeA - (2, 3)
+        XCTAssertEqual(result.width, 3)
+        XCTAssertEqual(result.height, 7)
+    }
+
     func testSubtractEqual() {
         var sizeA = CGSize(width: 5, height: 10)
         let sizeB = CGSize(width: 3, height: 4)
         sizeA -= sizeB
         XCTAssertEqual(sizeA.width, 2)
+        XCTAssertEqual(sizeA.height, 6)
+    }
+
+    func testSubtractScalarEqual() {
+        var sizeA = CGSize(width: 5, height: 10)
+        sizeA -= (1, 4)
+        XCTAssertEqual(sizeA.width, 4)
         XCTAssertEqual(sizeA.height, 6)
     }
 

--- a/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGSizeExtensionsTests.swift
@@ -62,18 +62,11 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(result.height, 14)
     }
 
-    func testAddScalarRight() {
+    func testAddTupleRight() {
         let sizeA = CGSize(width: 5, height: 10)
         let result = sizeA + (width: 4, height: 4)
         XCTAssertEqual(result.width, 9)
         XCTAssertEqual(result.height, 14)
-    }
-
-    func testAddScalarLeft() {
-        let sizeA = CGSize(width: 5, height: 10)
-        let result = (5, 3) + sizeA
-        XCTAssertEqual(result.width, 10)
-        XCTAssertEqual(result.height, 13)
     }
 
     func testAddEqual() {
@@ -84,7 +77,7 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(sizeA.height, 14)
     }
 
-    func testAddEqualScalar() {
+    func testAddEqualTuple() {
         var sizeA = CGSize(width: 5, height: 10)
         sizeA += (3, 0)
         XCTAssertEqual(sizeA.width, 8)
@@ -99,7 +92,7 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(result.height, 6)
     }
 
-    func testSubtractScalar() {
+    func testSubtractTuple() {
         let sizeA = CGSize(width: 5, height: 10)
         let result = sizeA - (2, 3)
         XCTAssertEqual(result.width, 3)
@@ -114,7 +107,7 @@ final class CGSizeExtensionsTests: XCTestCase {
         XCTAssertEqual(sizeA.height, 6)
     }
 
-    func testSubtractScalarEqual() {
+    func testSubtractTupleEqual() {
         var sizeA = CGSize(width: 5, height: 10)
         sizeA -= (1, 4)
         XCTAssertEqual(sizeA.width, 4)


### PR DESCRIPTION
Added new `+`, `+=`, `-` and `-=` operator extensions for scalar.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
