### PR TITLE
Refactored init(light:dark:) to remove deployment target version restrictions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Changed
 - **NSAttributedStringExtensions.swift**:
   - `applying(attributes:)` changed access modifier from `fileprivate` to `public`. [#832](https://github.com/SwifterSwift/SwifterSwift/pull/832) by [cHaLkdusT](https://github.com/cHaLkdusT)
+- **Color**:
+  - Refactored `init(light:dark:)` to remove deployment target version restrictions. [#844](https://github.com/SwifterSwift/SwifterSwift/pull/844) by [VincentSit](https://github.com/vincentsit).
 
 ### Deprecated
 

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -17,9 +17,13 @@ public extension UIColor {
     /// - Parameters:
     ///     - light: Color to use in light/unspecified mode.
     ///     - dark: Color to use in dark mode.
-    @available(iOS 13.0, tvOS 13.0, *)
-    convenience init(light: UIColor, dark: UIColor) {
-        self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
+    convenience init(light: UIColor, dark: UIColor?) {
+        if #available(iOS 13.0, tvOS 13.0, *),
+            let dark = dark {
+            self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
+        } else {
+            self.init(cgColor: light.cgColor)
+        }
     }
     #endif
 

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -17,9 +17,8 @@ public extension UIColor {
     /// - Parameters:
     ///     - light: Color to use in light/unspecified mode.
     ///     - dark: Color to use in dark mode.
-    convenience init(light: UIColor, dark: UIColor?) {
-        if #available(iOS 13.0, tvOS 13.0, *),
-            let dark = dark {
+    convenience init(light: UIColor, dark: UIColor) {
+        if #available(iOS 13.0, tvOS 13.0, *) {
             self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
         } else {
             self.init(cgColor: light.cgColor)

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -15,13 +15,17 @@ import UIKit
 final class UIColorExtensionsTests: XCTestCase {
 
     #if !os(watchOS)
-    @available(iOS 13.0, tvOS 13.0, *)
     func testInitLightDark() {
         let lightModeColor = UIColor.red
         let darkModeColor = UIColor.blue
         let color = UIColor(light: lightModeColor, dark: darkModeColor)
-        XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
-        XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), darkModeColor)
+
+        if #available(iOS 13.0, tvOS 13.0, *) {
+            XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
+            XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), darkModeColor)
+        } else {
+            XCTAssertEqual(color, lightModeColor)
+        }
     }
     #endif
 

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -19,16 +19,12 @@ final class UIColorExtensionsTests: XCTestCase {
         let lightModeColor = UIColor.red
         let darkModeColor = UIColor.blue
         let color = UIColor(light: lightModeColor, dark: darkModeColor)
-        let color2 = UIColor(light: lightModeColor, dark: nil)
 
         if #available(iOS 13.0, tvOS 13.0, *) {
             XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
             XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), darkModeColor)
-            XCTAssertEqual(color2.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
-            XCTAssertEqual(color2.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), nil)
         } else {
             XCTAssertEqual(color, lightModeColor)
-            XCTAssertEqual(color2, lightModeColor)
         }
     }
     #endif

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -19,10 +19,13 @@ final class UIColorExtensionsTests: XCTestCase {
         let lightModeColor = UIColor.red
         let darkModeColor = UIColor.blue
         let color = UIColor(light: lightModeColor, dark: darkModeColor)
+        let color2 = UIColor(light: lightModeColor, dark: nil)
 
         if #available(iOS 13.0, tvOS 13.0, *) {
             XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
             XCTAssertEqual(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), darkModeColor)
+            XCTAssertEqual(color2.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)), lightModeColor)
+            XCTAssertEqual(color2.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), nil)
         } else {
             XCTAssertEqual(color, lightModeColor)
         }

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -28,6 +28,7 @@ final class UIColorExtensionsTests: XCTestCase {
             XCTAssertEqual(color2.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)), nil)
         } else {
             XCTAssertEqual(color, lightModeColor)
+            XCTAssertEqual(color2, lightModeColor)
         }
     }
     #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

See the earlier [discussion][link1] about the reason for creating this PR.

For `NSColor`, since `init (cgColor:)` returns an optional value, it may cause a break change. We may need further discussion.

[link1]:https://github.com/SwifterSwift/SwifterSwift/pull/722#issuecomment-629224728
