### PR TITLE
UILabel extension to calculate text size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added new `+`, `+=`, `-` and `-=` operator extensions for tuple (width: CGFloat, height: CGFloat). [#841](https://github.com/SwifterSwift/SwifterSwift/pull/841) by [hamtiko](https://github.com/hamtiko)
 - **WKWebView**:
   - Added `loadURL(_:)` and `loadURLString(_:)` extensions for `WkWebView`. [#851](https://github.com/SwifterSwift/SwifterSwift/pull/851) by [hamtiko](https://github.com/hamtiko)
+  - **UILabel**:
+    - Added  `size(thatFitsAttributedString attributedString: NSAttributedString,
+     withConstraints size: CGSize) -> CGSize` to calculate and return the size that best fits an attributed string given specified constraints. [#853](https://github.com/SwifterSwift/SwifterSwift/pull/853) by [daliadanila](https://github.com/daliadanila)
 
 ### Changed
 - **NSAttributedStringExtensions.swift**:

--- a/Examples/Examples.playground/Pages/03-UIKitExtensions.xcplaygroundpage/Contents.swift
+++ b/Examples/Examples.playground/Pages/03-UIKitExtensions.xcplaygroundpage/Contents.swift
@@ -102,4 +102,32 @@ view.cornerRadius = 30
 // Add shadow to view
 view.addShadow(ofColor: .black, radius: 3, opacity: 0.5)
 
+//: UILabel extension
+
+let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+
+let attributes = [NSAttributedString.Key.foregroundColor: UIColor.red, NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 16) ]
+
+let attributedString = NSAttributedString(string: string, attributes: attributes)
+
+let label = UILabel()
+
+label.numberOfLines = 20
+
+label.attributedText = attributedString
+
+let singleLineSize = UILabel.size(thatFitsAttributedString: attributedString, withConstraints: CGSize(width: 100, height: CGFloat.greatestFiniteMagnitude))
+
+label.backgroundColor = UIColor.white
+
+label.frame = CGRect.init(x: 0, y: 0, width: singleLineSize.width, height: singleLineSize.height)
+
+let testView = UIView.init(frame: CGRect.init(x: 0, y: 0, width: 500, height: singleLineSize.height))
+
+testView.backgroundColor = UIColor.blue
+
+testView.addSubview(label)
+
+
 //: [Next](@next)
+//

--- a/Examples/Examples.playground/Pages/03-UIKitExtensions.xcplaygroundpage/Contents.swift
+++ b/Examples/Examples.playground/Pages/03-UIKitExtensions.xcplaygroundpage/Contents.swift
@@ -128,6 +128,5 @@ testView.backgroundColor = UIColor.blue
 
 testView.addSubview(label)
 
-
 //: [Next](@next)
 //

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -38,7 +38,6 @@ public extension UILabel {
     ///   - attributedString: The attributed string.
     ///   - size: The maximum dimensions used to calculate size.
     /// - Returns: The size that fits the attributed string within the specified constraints.
-    @available(iOS 10, *)
     static func size(thatFitsAttributedString attributedString: NSAttributedString,
                      withConstraints size: CGSize) -> CGSize {
 

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -38,7 +38,7 @@ public extension UILabel {
     ///   - attributedString: The attributed string.
     ///   - size: The maximum dimensions used to calculate size.
     /// - Returns: The size that fits the attributed string within the specified constraints.
-    
+    @available(iOS 10, *)
     static func size(thatFitsAttributedString attributedString: NSAttributedString,
                      withConstraints size: CGSize) -> CGSize {
         

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -11,7 +11,7 @@ import UIKit
 
 // MARK: - Properties
 public extension UILabel {
-    
+
     /// SwifterSwift: Required height for a label
     var requiredHeight: CGFloat {
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width, height: CGFloat.greatestFiniteMagnitude))
@@ -27,7 +27,7 @@ public extension UILabel {
 
 // MARK: - Methods
 public extension UILabel {
-    
+
     /// SwifterSwift:  Calculate and return the size that best fits an attributed string, given the specified constraints on size
     ///
     ///   let yourAttributedString = ...
@@ -41,34 +41,32 @@ public extension UILabel {
     @available(iOS 10, *)
     static func size(thatFitsAttributedString attributedString: NSAttributedString,
                      withConstraints size: CGSize) -> CGSize {
-        
+
         guard attributedString.length > 0 else { return CGSize.zero}
-        
+
         let framesetter = CTFramesetterCreateWithAttributedString(attributedString)
-        
+
         let calculatedSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,
-                                                                          CFRange(location: 0,length: attributedString.length),
+                                                                          CFRange(location: 0, length: attributedString.length),
                                                                           nil,
                                                                           size,
                                                                           nil)
-        
+
         return calculatedSize
-        
-        
-        
+
     }
 }
 
 // MARK: - Initializers
 
 public extension UILabel {
-    
+
     /// SwifterSwift: Initialize a UILabel with text
     convenience init(text: String?) {
         self.init()
         self.text = text
     }
-    
+
     /// SwifterSwift: Initialize a UILabel with a text and font style.
     ///
     /// - Parameters:

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -9,7 +9,6 @@
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
 
-
 // MARK: - Properties
 public extension UILabel {
     
@@ -29,6 +28,41 @@ public extension UILabel {
 // MARK: - Methods
 public extension UILabel {
     
+    /// SwifterSwift:  Calculate and return the size that best fits an attributed string, given the specified constraints on size and number of lines.
+    ///
+    ///   let yourAttributedString = ...
+    ///   let yourConstraintSize = ...
+    ///   let size = UILabel.size(thatFitsAttributedString: yourAttributedString, withConstraints: yourConstraintSize)
+    ///
+    /// - Parameters:
+    ///   - attributedString: The attributed string.
+    ///   - size: The maximum dimensions used to calculate size.
+    /// - Returns: The size that fits the attributed string within the specified constraints.
+    
+    static func size(thatFitsAttributedString attributedString: NSAttributedString,
+                     withConstraints size: CGSize) -> CGSize {
+        
+        guard attributedString.length > 0 else { return CGSize.zero}
+        
+        let framesetter = CTFramesetterCreateWithAttributedString(attributedString)
+        
+        let calculatedSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,
+                                                                          CFRange(location: 0,length: attributedString.length),
+                                                                          nil,
+                                                                          size,
+                                                                          nil)
+        
+        return calculatedSize
+        
+        
+        
+    }
+}
+
+// MARK: - Initializers
+
+public extension UILabel {
+    
     /// SwifterSwift: Initialize a UILabel with text
     convenience init(text: String?) {
         self.init()
@@ -44,36 +78,6 @@ public extension UILabel {
         self.init()
         font = UIFont.preferredFont(forTextStyle: style)
         self.text = text
-    }
-    
-    /// SwifterSwift:  Calculate and return the size that best fits an attributed string, given the specified constraints on size and number of lines.
-    ///
-    ///   let yourAttributedString = ...
-    ///   let yourConstraintSize = ...
-    ///   let size = UILabel.size(thatFitsAttributedString: yourAttributedString, withConstraints: yourConstraintSize)
-    ///
-    /// - Parameters:
-    ///   - attributedString The attributed string.
-    ///   - size The maximum dimensions used to calculate size.
-    /// - Returns: The size that fits the attributed string within the specified constraints.
-    
-    static func size(thatFitsAttributedString attributedString: NSAttributedString,
-                     withConstraints size: CGSize) -> CGSize {
-        
-        guard attributedString.length > 0 else { return CGSize.zero}
-        
-        let framesetter = CTFramesetterCreateWithAttributedString(attributedString)
-              
-        let calculatedSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,
-                                                                          CFRange(location: 0,length: attributedString.length),
-                                                                          nil,
-                                                                          size,
-                                                                          nil)
-        
-        return calculatedSize
-        
-        
-        
     }
 }
 

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -9,26 +9,10 @@
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
 
-// MARK: - Methods
+
+// MARK: - Properties
 public extension UILabel {
-
-    /// SwifterSwift: Initialize a UILabel with text
-    convenience init(text: String?) {
-        self.init()
-        self.text = text
-    }
-
-    /// SwifterSwift: Initialize a UILabel with a text and font style.
-    ///
-    /// - Parameters:
-    ///   - text: the label's text.
-    ///   - style: the text style of the label, used to determine which font should be used.
-    convenience init(text: String, style: UIFont.TextStyle) {
-        self.init()
-        font = UIFont.preferredFont(forTextStyle: style)
-        self.text = text
-    }
-
+    
     /// SwifterSwift: Required height for a label
     var requiredHeight: CGFloat {
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width, height: CGFloat.greatestFiniteMagnitude))
@@ -40,7 +24,28 @@ public extension UILabel {
         label.sizeToFit()
         return label.frame.height
     }
+}
 
+// MARK: - Methods
+public extension UILabel {
+    
+    /// SwifterSwift: Initialize a UILabel with text
+    convenience init(text: String?) {
+        self.init()
+        self.text = text
+    }
+    
+    /// SwifterSwift: Initialize a UILabel with a text and font style.
+    ///
+    /// - Parameters:
+    ///   - text: the label's text.
+    ///   - style: the text style of the label, used to determine which font should be used.
+    convenience init(text: String, style: UIFont.TextStyle) {
+        self.init()
+        font = UIFont.preferredFont(forTextStyle: style)
+        self.text = text
+    }
+    
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -46,6 +46,35 @@ public extension UILabel {
         self.text = text
     }
     
+    /// SwifterSwift:  Calculate and return the size that best fits an attributed string, given the specified constraints on size and number of lines.
+    ///
+    ///   let yourAttributedString = ...
+    ///   let yourConstraintSize = ...
+    ///   let size = UILabel.size(thatFitsAttributedString: yourAttributedString, withConstraints: yourConstraintSize)
+    ///
+    /// - Parameters:
+    ///   - attributedString The attributed string.
+    ///   - size The maximum dimensions used to calculate size.
+    /// - Returns: The size that fits the attributed string within the specified constraints.
+    
+    static func size(thatFitsAttributedString attributedString: NSAttributedString,
+                     withConstraints size: CGSize) -> CGSize {
+        
+        guard attributedString.length > 0 else { return CGSize.zero}
+        
+        let framesetter = CTFramesetterCreateWithAttributedString(attributedString)
+              
+        let calculatedSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter,
+                                                                          CFRange(location: 0,length: attributedString.length),
+                                                                          nil,
+                                                                          size,
+                                                                          nil)
+        
+        return calculatedSize
+        
+        
+        
+    }
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UILabelExtensions.swift
@@ -28,7 +28,7 @@ public extension UILabel {
 // MARK: - Methods
 public extension UILabel {
     
-    /// SwifterSwift:  Calculate and return the size that best fits an attributed string, given the specified constraints on size and number of lines.
+    /// SwifterSwift:  Calculate and return the size that best fits an attributed string, given the specified constraints on size
     ///
     ///   let yourAttributedString = ...
     ///   let yourConstraintSize = ...

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -47,8 +47,9 @@ final class UILabelExtensionsTests: XCTestCase {
         
         // Empty attributed string
         
-        XCTAssertTrue(CGSize.zero.equalTo(UILabel.size(thatFitsAttributedString: NSAttributedString.init(), withConstraints: CGSize(width: 10, height: CGFloat.greatestFiniteMagnitude))),
-                      "empty string should size to zero")
+        let zeroSize = UILabel.size(thatFitsAttributedString: NSAttributedString.init(), withConstraints: CGSize(width: 10, height: CGFloat.greatestFiniteMagnitude))
+        
+        XCTAssertTrue(CGSize.zero.equalTo(zeroSize), "empty string should size to zero")
         
         // Single line attributed string
         

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -43,7 +43,6 @@ final class UILabelExtensionsTests: XCTestCase {
         #endif
     }
 
-    @available(iOS 10, *)
     func testSizeThatFitsAttributedString() {
 
         // Empty attributed string

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -43,6 +43,39 @@ final class UILabelExtensionsTests: XCTestCase {
         #endif
     }
 
+    func testSizeThatFitsAttributedString() {
+        
+        // Empty attributed string
+        
+        XCTAssertTrue(CGSize.zero.equalTo(UILabel.size(thatFitsAttributedString: NSAttributedString.init(), withConstraints: CGSize(width: 10, height: CGFloat.greatestFiniteMagnitude))),
+                      "empty string should size to zero")
+        
+        // Single line attributed string
+        
+        let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+        
+        let attributes = [NSAttributedString.Key.foregroundColor: UIColor.red, NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 16) ]
+        
+        let attributedString = NSAttributedString(string: string, attributes: attributes)
+        
+        let label = UILabel()
+        
+        label.attributedText = attributedString
+        
+        let singleLineSize = UILabel.size(thatFitsAttributedString: attributedString, withConstraints: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
+        
+        let font = attributedString.attribute(NSAttributedString.Key.font, at: 0, effectiveRange: nil) as! UIFont
+        
+        XCTAssertLessThan(singleLineSize.height, font.pointSize * 2, "Label should size to less than two lines")
+        
+        
+        // Multi line attributed string
+        
+        let multipleLineSize = UILabel.size(thatFitsAttributedString: attributedString, withConstraints: CGSize(width: 90, height: CGFloat.greatestFiniteMagnitude))
+        
+        XCTAssertGreaterThan(multipleLineSize.height, font.pointSize, "Text should size to more than one line")
+        
+    }
 }
 
 #endif

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -43,6 +43,7 @@ final class UILabelExtensionsTests: XCTestCase {
         #endif
     }
 
+    @available(iOS 10, *)
     func testSizeThatFitsAttributedString() {
         
         // Empty attributed string

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -45,41 +45,40 @@ final class UILabelExtensionsTests: XCTestCase {
 
     @available(iOS 10, *)
     func testSizeThatFitsAttributedString() {
-        
+
         // Empty attributed string
-        
+
         let zeroSize = UILabel.size(thatFitsAttributedString: NSAttributedString.init(), withConstraints: CGSize(width: 10, height: CGFloat.greatestFiniteMagnitude))
-        
+
         XCTAssertTrue(CGSize.zero.equalTo(zeroSize), "empty string should size to zero")
-        
+
         // Single line attributed string
-        
+
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
-        
+
         let attributes = [NSAttributedString.Key.foregroundColor: UIColor.red, NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 16) ]
-        
+
         let attributedString = NSAttributedString(string: string, attributes: attributes)
-        
+
         let label = UILabel()
-        
+
         label.attributedText = attributedString
-        
+
         let singleLineSize = UILabel.size(thatFitsAttributedString: attributedString, withConstraints: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
-        
+
         guard let font = attributedString.attribute(NSAttributedString.Key.font, at: 0, effectiveRange: nil) as? UIFont else {
             XCTFail("Unable to find font in attributed string")
             return
         }
-        
+
         XCTAssertLessThan(singleLineSize.height, font.pointSize * 2, "Label should size to less than two lines")
-        
-        
+
         // Multi line attributed string
-        
+
         let multipleLineSize = UILabel.size(thatFitsAttributedString: attributedString, withConstraints: CGSize(width: 90, height: CGFloat.greatestFiniteMagnitude))
-        
+
         XCTAssertGreaterThan(multipleLineSize.height, font.pointSize, "Text should size to more than one line")
-        
+
     }
 }
 

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -29,7 +29,7 @@ final class UILabelExtensionsTests: XCTestCase {
         XCTAssertEqual(label.font, preferredFont)
     }
 
-    func testrequiredHeight() {
+    func testRequiredHeight() {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let label = UILabel(frame: frame)
         label.text = "Hello world"

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -66,7 +66,10 @@ final class UILabelExtensionsTests: XCTestCase {
         
         let singleLineSize = UILabel.size(thatFitsAttributedString: attributedString, withConstraints: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
         
-        let font = attributedString.attribute(NSAttributedString.Key.font, at: 0, effectiveRange: nil) as! UIFont
+        guard let font = attributedString.attribute(NSAttributedString.Key.font, at: 0, effectiveRange: nil) as? UIFont else {
+            XCTFail("Unable to find font in attributed string")
+            return
+        }
         
         XCTAssertLessThan(singleLineSize.height, font.pointSize * 2, "Label should size to less than two lines")
         


### PR DESCRIPTION
Added UILabel extension for calculating the size that best fits an attributed string #850 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
