### PR TITLE
CoreAnimation: Make CAGradientLayer extension public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Removed
 
 ### Fixed
+- **CAGradientLayerExtensions.swift**:
+- CAGradientLayer extensions inaccessible through internal level protection. [#856](https://github.com/SwifterSwift/SwifterSwift/pull/856) by [Den Andreychuk](https://github.com/denandreychuk).
 
 ### Security
 

--- a/Sources/SwifterSwift/CoreAnimation/CAGradientLayerExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CAGradientLayerExtensions.swift
@@ -9,7 +9,7 @@
 #if !os(watchOS) && !os(Linux) && canImport(QuartzCore)
 import QuartzCore
 
-extension CAGradientLayer {
+public extension CAGradientLayer {
 
     /// SwifterSwift: Creates a CAGradientLayer with the specified colors, location, startPoint, endPoint, and type.
     /// - Parameter colors: An array of colors defining the color of each gradient stop


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
