### PR TITLE
Added string and dispatch queue extensions

### DIFF
--- a/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
+++ b/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
@@ -41,6 +41,19 @@ public extension DispatchQueue {
 
         return DispatchQueue.getSpecific(key: key) != nil
     }
+    
+    /// SwifterSwift: Runs passed closure asynchronous after certain time interval
+    ///
+    /// - Parameter delay: The time inverval after which the closure will run.
+    /// - Parameter qos: Quality of service at which the work item should be executed.
+    /// - Parameter flags: Flags that control the execution environment of the work item.
+    /// - Parameter work: The closure to run after certain time interval.
+    func asyncAfter(delay: Double,
+                    qos: DispatchQoS = .unspecified,
+                    flags: DispatchWorkItemFlags = [],
+                    execute work: @escaping @convention(block) () -> Void) {
+        asyncAfter(deadline: .now() + delay, qos: qos, flags: flags, execute: work)
+    }
 
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -957,6 +957,17 @@ public extension String {
         return range(of: pattern, options: .regularExpression, range: nil, locale: nil) != nil
     }
     #endif
+    
+    #if canImport(Foundation)
+    /// SwifterSwift: Overload Swift's 'contains' operator for matching regex pattern
+    ///
+    /// - Parameter lhs: String to check on regex pattern.
+    /// - Parameter rhs: Pattern to verify.
+    /// - Returns: true if string matches the pattern.
+    static func ~= (lhs: String, rhs: String) -> Bool {
+        return lhs.range(of: rhs, options: .regularExpression, range: nil, locale: nil) != nil
+    }
+    #endif
 
     /// SwifterSwift: Pad string to fit the length parameter size with another string in the start.
     ///

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -576,6 +576,16 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("notanemail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
         XCTAssertTrue("email@mail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
     }
+    
+    func testRegexMatchOperator() {
+        #if canImport(Foundation)
+        XCTAssertTrue("123" ~= "\\d{3}")
+        XCTAssertFalse("dasda" ~= "\\d{3}")
+        XCTAssertFalse("notanemail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+        XCTAssertTrue("email@mail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+        XCTAssertTrue("hat" ~= "[a-z]at")
+        #endif
+    }
 
     func testPadStart() {
         var str: String = "str"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've taken into account all the suggestions from my previous PR and made some changes.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
