### PR TITLE
Added convenient wrapper to asyncAfter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 -**DispatchQueue**:
-- Added `asyncAfter(delay:qos:flags:execute work:)`  method to use it more conveniently without typing unnecessary `.now() + delay`. [#859](https://github.com/SwifterSwift/SwifterSwift/pull/859) by [VatoKo](https://github.com/VatoKo)
+- Added `asyncAfter(delay:qos:flags:execute:)` method to use it more conveniently without typing unnecessary `.now() + delay`. [#859](https://github.com/SwifterSwift/SwifterSwift/pull/859) by [VatoKo](https://github.com/VatoKo)
 - **RangeReplaceableCollection**:
   - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#826](https://github.com/SwifterSwift/SwifterSwift/pull/826) by [guykogus](https://github.com/guykogus)
 - **Sequence**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+-**DispatchQueue**:
+- Added `asyncAfter(delay:qos:flags:execute work:)`  method to use it more conveniently without typing unnecessary `.now() + delay`. [#859](https://github.com/SwifterSwift/SwifterSwift/pull/859) by [VatoKo](https://github.com/VatoKo)
 - **RangeReplaceableCollection**:
   - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#826](https://github.com/SwifterSwift/SwifterSwift/pull/826) by [guykogus](https://github.com/guykogus)
 - **Sequence**:

--- a/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
+++ b/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
@@ -41,6 +41,19 @@ public extension DispatchQueue {
 
         return DispatchQueue.getSpecific(key: key) != nil
     }
+    
+    /// SwifterSwift: Runs passed closure asynchronous after certain time interval
+    ///
+    /// - Parameter delay: The time inverval after which the closure will run.
+    /// - Parameter qos: Quality of service at which the work item should be executed.
+    /// - Parameter flags: Flags that control the execution environment of the work item.
+    /// - Parameter work: The closure to run after certain time interval.
+    func asyncAfter(delay: Double,
+                    qos: DispatchQoS = .unspecified,
+                    flags: DispatchWorkItemFlags = [],
+                    execute work: @escaping @convention(block) () -> Void) {
+        asyncAfter(deadline: .now() + delay, qos: qos, flags: flags, execute: work)
+    }
 
 }
 

--- a/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
+++ b/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
@@ -44,10 +44,11 @@ public extension DispatchQueue {
     
     /// SwifterSwift: Runs passed closure asynchronous after certain time interval
     ///
-    /// - Parameter delay: The time inverval after which the closure will run.
-    /// - Parameter qos: Quality of service at which the work item should be executed.
-    /// - Parameter flags: Flags that control the execution environment of the work item.
-    /// - Parameter work: The closure to run after certain time interval.
+    /// - Parameters:
+    ///   - delay: The time inverval after which the closure will run.
+    ///   - qos: Quality of service at which the work item should be executed.
+    ///   - flags: Flags that control the execution environment of the work item.
+    ///   - work: The closure to run after certain time interval.
     func asyncAfter(delay: Double,
                     qos: DispatchQoS = .unspecified,
                     flags: DispatchWorkItemFlags = [],

--- a/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
+++ b/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
@@ -51,7 +51,7 @@ public extension DispatchQueue {
     func asyncAfter(delay: Double,
                     qos: DispatchQoS = .unspecified,
                     flags: DispatchWorkItemFlags = [],
-                    execute work: @escaping @convention(block) () -> Void) {
+                    execute work: @escaping () -> Void) {
         asyncAfter(deadline: .now() + delay, qos: qos, flags: flags, execute: work)
     }
 

--- a/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
+++ b/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
@@ -51,6 +51,20 @@ final class DispatchQueueExtensionsTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
     }
+    
+    func testAsyncAfter() {
+        let delay: Double = 2
+        var codeExecuted = false
+        let codeShouldBeExecuted = expectation(description: "Executed")
+        
+        DispatchQueue.main.asyncAfter(delay: delay) {
+            codeExecuted = true
+            codeShouldBeExecuted.fulfill()
+        }
+        
+        waitForExpectations(timeout: delay, handler: nil)
+        XCTAssertTrue(codeExecuted)
+    }
 
 }
 

--- a/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
+++ b/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
@@ -63,7 +63,7 @@ final class DispatchQueueExtensionsTests: XCTestCase {
         }
         
         waitForExpectations(timeout: delay, handler: nil)
-        XCTAssertTrue(codeExecuted)
+        XCTAssert(codeExecuted)
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
