### PR TITLE
Deprecated map(by:), compactMap(by:), filter(by:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Deprecated
 - **Sequence**:
-  - Marked `map(by:)`, `compactMap(by:)`, `filter(by:)` as deprecated because of KeyPaths as functions in Swift 5.2. [#862](https://github.com/SwifterSwift/SwifterSwift/pull/862) by [Roman Podymov](https://github.com/RomanPodymov).
+  - Marked `map(by:)`, `compactMap(by:)`, `filter(by:)` as deprecated in favor use of Key Path expressions as functions feature in Swift 5.2. [#862](https://github.com/SwifterSwift/SwifterSwift/pull/862) by [Roman Podymov](https://github.com/RomanPodymov).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Refactored `init(light:dark:)` to remove deployment target version restrictions. [#844](https://github.com/SwifterSwift/SwifterSwift/pull/844) by [VincentSit](https://github.com/vincentsit).
 
 ### Deprecated
+- **Sequence**:
+  - Marked `map(by:)`, `compactMap(by:)`, `filter(by:)` as deprecated because of KeyPaths as functions in Swift 5.2. [#862](https://github.com/SwifterSwift/SwifterSwift/pull/862) by [Roman Podymov](https://github.com/RomanPodymov).
 
 ### Removed
 

--- a/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
@@ -104,7 +104,7 @@ public extension Sequence {
     ///
     /// - Parameter keyPath: Boolean key path. If it's value is `true` the element will be added to result.
     /// - Returns: An array containing filtered elements.
-    @available(*, deprecated, message: "Use filter() with KeyPath instead.")
+    @available(*, deprecated, message: "Please use filter() with a key path instead.")
     func filter(by keyPath: KeyPath<Element, Bool>) -> [Element] {
         return filter { $0[keyPath: keyPath] }
     }

--- a/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
@@ -79,3 +79,33 @@ public extension Array {
     }
 
 }
+
+public extension Sequence {
+
+    /// SwifterSwift: Returns an array containing the results of mapping the given key path over the sequence’s elements.
+    ///
+    /// - Parameter keyPath: Key path to map.
+    /// - Returns: An array containing the results of mapping.
+    @available(*, deprecated, message: "Use map() with KeyPath instead.")
+    func map<T>(by keyPath: KeyPath<Element, T>) -> [T] {
+        return map { $0[keyPath: keyPath] }
+    }
+
+    /// SwifterSwift: Returns an array containing the non-nil results of mapping the given key path over the sequence’s elements.
+    ///
+    /// - Parameter keyPath: Key path to map.
+    /// - Returns: An array containing the non-nil results of mapping.
+    @available(*, deprecated, message: "Use compactMap() with KeyPath instead.")
+    func compactMap<T>(by keyPath: KeyPath<Element, T?>) -> [T] {
+        return compactMap { $0[keyPath: keyPath] }
+    }
+
+    /// SwifterSwift: Returns an array containing the results of filtering the sequence’s elements by a boolean key path.
+    ///
+    /// - Parameter keyPath: Boolean key path. If it's value is `true` the element will be added to result.
+    /// - Returns: An array containing filtered elements.
+    @available(*, deprecated, message: "Use filter() with KeyPath instead.")
+    func filter(by keyPath: KeyPath<Element, Bool>) -> [Element] {
+        return filter { $0[keyPath: keyPath] }
+    }
+}

--- a/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
@@ -95,7 +95,7 @@ public extension Sequence {
     ///
     /// - Parameter keyPath: Key path to map.
     /// - Returns: An array containing the non-nil results of mapping.
-    @available(*, deprecated, message: "Use compactMap() with KeyPath instead.")
+    @available(*, deprecated, message: "Please use compactMap() with a key path instead.")
     func compactMap<T>(by keyPath: KeyPath<Element, T?>) -> [T] {
         return compactMap { $0[keyPath: keyPath] }
     }

--- a/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
@@ -86,7 +86,7 @@ public extension Sequence {
     ///
     /// - Parameter keyPath: Key path to map.
     /// - Returns: An array containing the results of mapping.
-    @available(*, deprecated, message: "Use map() with KeyPath instead.")
+    @available(*, deprecated, message: "Please use map() with a key path instead.")
     func map<T>(by keyPath: KeyPath<Element, T>) -> [T] {
         return map { $0[keyPath: keyPath] }
     }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -249,30 +249,6 @@ public extension Sequence {
         return reduce(.zero) { $0 + $1[keyPath: keyPath] }
     }
 
-    /// SwifterSwift: Returns an array containing the results of mapping the given key path over the sequence’s elements.
-    ///
-    /// - Parameter keyPath: Key path to map.
-    /// - Returns: An array containing the results of mapping.
-    func map<T>(by keyPath: KeyPath<Element, T>) -> [T] {
-        return map { $0[keyPath: keyPath] }
-    }
-
-    /// SwifterSwift: Returns an array containing the non-nil results of mapping the given key path over the sequence’s elements.
-    ///
-    /// - Parameter keyPath: Key path to map.
-    /// - Returns: An array containing the non-nil results of mapping.
-    func compactMap<T>(by keyPath: KeyPath<Element, T?>) -> [T] {
-        return compactMap { $0[keyPath: keyPath] }
-    }
-
-    /// SwifterSwift: Returns an array containing the results of filtering the sequence’s elements by a boolean key path.
-    ///
-    /// - Parameter keyPath: Boolean key path. If it's value is `true` the element will be added to result.
-    /// - Returns: An array containing filtered elements.
-    func filter(by keyPath: KeyPath<Element, Bool>) -> [Element] {
-        return filter { $0[keyPath: keyPath] }
-    }
-
     /// SwifterSwift: Returns the first element of the sequence with having property by given key path equals to given `value`.
     ///
     /// - Parameters:

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -182,27 +182,6 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(people.sorted(by: \.surname, and: \.forename, and: \.age), expectedResult)
     }
 
-    func testMapByKeyPath() {
-        let array1 = [Person(name: "John", age: 30, location: Location(city: "Boston")), Person(name: "Jan", age: 22, location: Location(city: "Prague")), Person(name: "Roman", age: 26, location: Location(city: "Moscow"))]
-        XCTAssertEqual(array1.map(by: \.name), ["John", "Jan", "Roman"])
-
-        let array2 = [Person(name: "Daniel", age: 45, location: Location(city: "Pittsburgh")), Person(name: "Michael", age: nil, location: Location(city: "Dresden")), Person(name: "Pierre", age: 20, location: Location(city: "Paris"))]
-        XCTAssertEqual(array2.map(by: \.age), [45, nil, 20])
-    }
-
-    func testCompactMapByKeyPath() {
-        let array1 = [Person(name: "John", age: 30, location: Location(city: "Boston")), Person(name: "Jan", age: 22, location: nil), Person(name: "Roman", age: 26, location: Location(city: "Moscow"))]
-        XCTAssertEqual(array1.compactMap(by: \.location), [Location(city: "Boston"), Location(city: "Moscow")])
-
-        let array2 = [Person(name: "Daniel", age: 45, location: Location(city: "Pittsburgh")), Person(name: "Michael", age: nil, location: Location(city: "Dresden")), Person(name: "Pierre", age: 20, location: Location(city: "Paris"))]
-        XCTAssertEqual(array2.compactMap(by: \.age), [45, 20])
-    }
-
-    func testFilterByKeyPath() {
-        let array1 = [Person(name: "Iveta", age: 20, location: Location(city: "Prague"), isStudent: true), Person(name: "Victor", age: 44, location: Location(city: "Dallas"), isStudent: false), Person(name: "Lukasz", age: 62, location: nil), Person(name: "Anna", age: 18, location: Location(city: "Minsk"), isStudent: true)]
-        XCTAssertEqual(array1.filter(by: \.isStudent), [Person(name: "Iveta", age: 20, location: Location(city: "Prague"), isStudent: true), Person(name: "Anna", age: 18, location: Location(city: "Minsk"), isStudent: true)])
-    }
-
     func testFirstByKeyPath() {
         let array1 = [
             Person(name: "John", age: 30, location: Location(city: "Boston")),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
🚀
Hello.
Thank you for SwifterSwift.
In this pull request I fixed #861.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.