### PR TITLE
Clean up code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,16 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `applying(attributes:)` changed access modifier from `fileprivate` to `public`. [#832](https://github.com/SwifterSwift/SwifterSwift/pull/832) by [cHaLkdusT](https://github.com/cHaLkdusT)
 - **Color**:
   - Refactored `init(light:dark:)` to remove deployment target version restrictions. [#844](https://github.com/SwifterSwift/SwifterSwift/pull/844) by [VincentSit](https://github.com/vincentsit).
+- **CAGradientLayer**:
+  - In `init(colors:locations:startPoint:endPoint:type:)` added default values to `startPoint` and `endPoint`. [#864](https://github.com/SwifterSwift/SwifterSwift/pull/864) by [guykogus](https://github.com/guykogus)
 
 ### Deprecated
 - **Sequence**:
   - Marked `map(by:)`, `compactMap(by:)`, `filter(by:)` as deprecated in favor use of Key Path expressions as functions feature in Swift 5.2. [#862](https://github.com/SwifterSwift/SwifterSwift/pull/862) by [Roman Podymov](https://github.com/RomanPodymov).
 
 ### Removed
+- **UIDatePicker**
+  - Disabled `textColor` when compiling for target `macCatalyst` as it will crash. [#864](https://github.com/SwifterSwift/SwifterSwift/pull/864) by [guykogus](https://github.com/guykogus)
 
 ### Fixed
 - **CAGradientLayerExtensions.swift**:

--- a/Sources/SwifterSwift/AppKit/NSImageExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSImageExtensions.swift
@@ -14,22 +14,22 @@ public extension NSImage {
 
     /// SwifterSwift: NSImage scaled to maximum size with respect to aspect ratio
     ///
-    /// - Parameter toMaxSize: maximum size
+    /// - Parameter maxSize: maximum size
     /// - Returns: scaled NSImage
-    func scaled(toMaxSize: NSSize) -> NSImage {
-        var ratio: Float = 0.0
-        let imageWidth = Float(size.width)
-        let imageHeight = Float(size.height)
-        let maxWidth = Float(toMaxSize.width)
-        let maxHeight = Float(toMaxSize.height)
+    func scaled(toMaxSize maxSize: NSSize) -> NSImage {
+        let imageWidth = size.width
+        let imageHeight = size.height
+
+        guard imageHeight > 0 else { return self }
 
         // Get ratio (landscape or portrait)
+        let ratio: CGFloat
         if imageWidth > imageHeight {
             // Landscape
-            ratio = maxWidth / imageWidth
+            ratio = maxSize.width / imageWidth
         } else {
             // Portrait
-            ratio = maxHeight / imageHeight
+            ratio = maxSize.height / imageHeight
         }
 
         // Calculate new size based on the ratio
@@ -37,17 +37,13 @@ public extension NSImage {
         let newHeight = imageHeight * ratio
 
         // Create a new NSSize object with the newly calculated size
-        let newSize = NSSize(width: Int(newWidth), height: Int(newHeight))
+        let newSize = NSSize(width: newWidth.rounded(.down), height: newHeight.rounded(.down))
 
         // Cast the NSImage to a CGImage
-        var imageRect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        let imageRef = cgImage(forProposedRect: &imageRect, context: nil, hints: nil)
+        var imageRect = CGRect(origin: .zero, size: size)
+        guard let imageRef = cgImage(forProposedRect: &imageRect, context: nil, hints: nil) else { return self }
 
-        // Create NSImage from the CGImage using the new size
-        let imageWithNewSize = NSImage(cgImage: imageRef!, size: newSize)
-
-        // Return the new image
-        return imageWithNewSize
+        return NSImage(cgImage: imageRef, size: newSize)
     }
 
     /// SwifterSwift: Write NSImage to url.

--- a/Sources/SwifterSwift/AppKit/NSViewExtensions.swift
+++ b/Sources/SwifterSwift/AppKit/NSViewExtensions.swift
@@ -46,7 +46,7 @@ public extension NSView {
         set {
             wantsLayer = true
             layer?.masksToBounds = true
-            layer?.cornerRadius = abs(CGFloat(Int(newValue * 100)) / 100)
+            layer?.cornerRadius = newValue.magnitude
         }
     }
 

--- a/Sources/SwifterSwift/CoreAnimation/CAGradientLayerExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CAGradientLayerExtensions.swift
@@ -22,7 +22,11 @@ public extension CAGradientLayer {
     /// - Parameter startPoint: start point corresponds to the first gradient stop (I.e. [0,0] is the bottom-corner of the layer, [1,1] is the top-right corner.)
     /// - Parameter endPoint: end point corresponds to the last gradient stop
     /// - Parameter type: The kind of gradient that will be drawn. Currently, the only allowed values are `axial' (the default value), `radial', and `conic'.
-    convenience init(colors: [Color], locations: [CGFloat]? = nil, startPoint: CGPoint, endPoint: CGPoint, type: CAGradientLayerType = .axial) {
+    convenience init(colors: [Color],
+                     locations: [CGFloat]? = nil,
+                     startPoint: CGPoint = CGPoint(x: 0.5, y: 0),
+                     endPoint: CGPoint = CGPoint(x: 0.5, y: 1),
+                     type: CAGradientLayerType = .axial) {
         self.init()
         self.colors =  colors.map { $0.cgColor }
         self.locations = locations?.map { NSNumber(value: Double($0)) }

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -14,7 +14,8 @@ public extension CGSize {
 
     /// SwifterSwift: Returns the aspect ratio.
     var aspectRatio: CGFloat {
-        return height == 0 ? 0 : width / height
+        guard height != 0 else { return 0 }
+        return width / height
     }
 
     /// SwifterSwift: Returns width or height, whichever is the bigger value.

--- a/Sources/SwifterSwift/CoreLocation/CLLocationArrayExtensions.swift
+++ b/Sources/SwifterSwift/CoreLocation/CLLocationArrayExtensions.swift
@@ -19,9 +19,9 @@ public extension Array where Element: CLLocation {
     @available(tvOS 10.0, macOS 10.12, watchOS 3.0, *)
     func distance(unitLength unit: UnitLength) -> Measurement<UnitLength> {
         guard count > 1 else {
-          return Measurement(value: 0.0, unit: unit)
+            return Measurement(value: 0.0, unit: unit)
         }
-        var distance = 0.0
+        var distance: CLLocationDistance = 0.0
         for idx in 0..<count-1 {
             distance += self[idx].distance(from: self[idx + 1])
         }

--- a/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
+++ b/Sources/SwifterSwift/Dispatch/DispatchQueueExtensions.swift
@@ -41,7 +41,7 @@ public extension DispatchQueue {
 
         return DispatchQueue.getSpecific(key: key) != nil
     }
-    
+
     /// SwifterSwift: Runs passed closure asynchronous after certain time interval
     ///
     /// - Parameters:

--- a/Sources/SwifterSwift/Foundation/URLExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLExtensions.swift
@@ -59,9 +59,7 @@ public extension URL {
     /// - Returns: URL with appending given query parameters.
     func appendingQueryParameters(_ parameters: [String: String]) -> URL {
         var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true)!
-        var items = urlComponents.queryItems ?? []
-        items += parameters.map({ URLQueryItem(name: $0, value: $1) })
-        urlComponents.queryItems = items
+        urlComponents.queryItems = (urlComponents.queryItems ?? []) + parameters.map { URLQueryItem(name: $0, value: $1) }
         return urlComponents.url!
     }
 

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -43,11 +43,11 @@ public extension Color {
     ///     UIColor.blue.rgbComponents.blue -> 255
     ///
     var rgbComponents: (red: Int, green: Int, blue: Int) {
-        var components: [CGFloat] {
-            let comps = cgColor.components!
-            if comps.count == 4 { return comps }
+        let components: [CGFloat] = {
+            let comps: [CGFloat] = cgColor.components!
+            guard comps.count != 4 else { return comps }
             return [comps[0], comps[0], comps[0], comps[1]]
-        }
+        }()
         let red = components[0]
         let green = components[1]
         let blue = components[2]
@@ -63,11 +63,11 @@ public extension Color {
     ///     UIColor.blue.rgbComponents.blue -> 1.0
     ///
     var cgFloatComponents: (red: CGFloat, green: CGFloat, blue: CGFloat) {
-        var components: [CGFloat] {
-            let comps = cgColor.components!
-            if comps.count == 4 { return comps }
+        let components: [CGFloat] = {
+            let comps: [CGFloat] = cgColor.components!
+            guard comps.count != 4 else { return comps }
             return [comps[0], comps[0], comps[0], comps[1]]
-        }
+        }()
         let red = components[0]
         let green = components[1]
         let blue = components[2]
@@ -91,9 +91,9 @@ public extension Color {
     /// SwifterSwift: Hexadecimal value string (read-only).
     var hexString: String {
         let components: [Int] = {
-            let comps = cgColor.components!
-            let components = comps.count == 4 ? comps : [comps[0], comps[0], comps[0], comps[1]]
-            return components.map { Int($0 * 255.0) }
+            let comps = cgColor.components!.map { Int($0 * 255.0) }
+            guard comps.count != 4 else { return comps }
+            return [comps[0], comps[0], comps[0], comps[1]]
         }()
         return String(format: "#%02X%02X%02X", components[0], components[1], components[2])
     }
@@ -109,9 +109,9 @@ public extension Color {
     /// SwifterSwift: Short hexadecimal value string, or full hexadecimal string if not possible (read-only).
     var shortHexOrHexString: String {
         let components: [Int] = {
-            let comps = cgColor.components!
-            let components = comps.count == 4 ? comps : [comps[0], comps[0], comps[0], comps[1]]
-            return components.map { Int($0 * 255.0) }
+            let comps = cgColor.components!.map { Int($0 * 255.0) }
+            guard comps.count != 4 else { return comps }
+            return [comps[0], comps[0], comps[0], comps[1]]
         }()
         let hexString = String(format: "#%02X%02X%02X", components[0], components[1], components[2])
         let string = hexString.replacingOccurrences(of: "#", with: "")
@@ -134,15 +134,16 @@ public extension Color {
 
     /// SwifterSwift: Get UInt representation of a Color (read-only).
     var uInt: UInt {
-        let comps: [CGFloat] = {
-            let comps = cgColor.components!
-            return comps.count == 4 ? comps : [comps[0], comps[0], comps[0], comps[1]]
+        let components: [CGFloat] = {
+            let comps: [CGFloat] = cgColor.components!
+            guard comps.count != 4 else { return comps }
+            return [comps[0], comps[0], comps[0], comps[1]]
         }()
 
         var colorAsUInt32: UInt32 = 0
-        colorAsUInt32 += UInt32(comps[0] * 255.0) << 16
-        colorAsUInt32 += UInt32(comps[1] * 255.0) << 8
-        colorAsUInt32 += UInt32(comps[2] * 255.0)
+        colorAsUInt32 += UInt32(components[0] * 255.0) << 16
+        colorAsUInt32 += UInt32(components[1] * 255.0) << 8
+        colorAsUInt32 += UInt32(components[2] * 255.0)
 
         return UInt(colorAsUInt32)
     }
@@ -196,13 +197,15 @@ public extension Color {
         guard level2 > 0 else { return color1 }
 
         let components1: [CGFloat] = {
-            let comps = color1.cgColor.components!
-            return comps.count == 4 ? comps : [comps[0], comps[0], comps[0], comps[1]]
+            let comps: [CGFloat] = color1.cgColor.components!
+            guard comps.count != 4 else { return comps }
+            return [comps[0], comps[0], comps[0], comps[1]]
         }()
 
         let components2: [CGFloat] = {
-            let comps = color2.cgColor.components!
-            return comps.count == 4 ? comps : [comps[0], comps[0], comps[0], comps[1]]
+            let comps: [CGFloat] = color2.cgColor.components!
+            guard comps.count != 4 else { return comps }
+            return [comps[0], comps[0], comps[0], comps[1]]
         }()
 
         let red1 = components1[0]

--- a/Sources/SwifterSwift/SpriteKit/SKNodeExtensions.swift
+++ b/Sources/SwifterSwift/SpriteKit/SKNodeExtensions.swift
@@ -17,7 +17,9 @@ public extension SKNode {
     ///         mySKNode.descendants() -> [childNodeOne, childNodeTwo]
     ///
     func descendants() -> [SKNode] {
-        return children + children.reduce(into: [SKNode]()) { $0 += $1.descendants() }
+        var children = self.children
+        children.append(contentsOf: children.reduce(into: [SKNode]()) { $0.append(contentsOf: $1.descendants()) })
+        return children
     }
 
     /// SwifterSwift: The center anchor of the node in its parent's coordinate system.

--- a/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
@@ -22,10 +22,8 @@ public extension Collection {
     ///
     /// - Parameter each: closure to run for each element.
     func forEachInParallel(_ each: (Self.Element) -> Void) {
-        let indicesArray = Array(indices)
-        DispatchQueue.concurrentPerform(iterations: indicesArray.count) { (index) in
-            let elementIndex = indicesArray[index]
-            each(self[elementIndex])
+        DispatchQueue.concurrentPerform(iterations: count) {
+            each(self[index(startIndex, offsetBy: $0)])
         }
     }
     #endif

--- a/Sources/SwifterSwift/SwiftStdlib/IntExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/IntExtensions.swift
@@ -138,12 +138,10 @@ public extension Int {
         for (index, romanChar) in romanValues.enumerated() {
             let arabicValue = arabicValues[index]
             let div = startingValue / arabicValue
-            if div > 0 {
-                for _ in 0..<div {
-                    romanValue += romanChar
-                }
-                startingValue -= arabicValue * div
+            for _ in 0..<div {
+                romanValue.append(romanChar)
             }
+            startingValue -= arabicValue * div
         }
         return romanValue
     }
@@ -204,6 +202,6 @@ prefix operator ±
 /// - Returns: tuple of plus-minus operation (example: ± 2 -> (2, -2)).
 public prefix func ± (int: Int) -> (Int, Int) {
     // http://nshipster.com/swift-operators/
-    return 0 ± int
+    return (int, -int)
 }
 // swiftlint:enable identifier_name

--- a/Sources/SwifterSwift/SwiftStdlib/MutableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/MutableCollectionExtensions.swift
@@ -64,12 +64,8 @@ public extension MutableCollection {
     /// - Parameter value: The new value of the field
     /// - Parameter keyPath: The actual field of the element
     mutating func assignToAll<Value>(value: Value, by keyPath: WritableKeyPath<Element, Value>) {
-        guard !isEmpty else { return }
-
-        var idx = startIndex
-        while idx != endIndex {
+        for idx in indices {
             self[idx][keyPath: keyPath] = value
-            idx = index(after: idx)
         }
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -957,7 +957,7 @@ public extension String {
         return range(of: pattern, options: .regularExpression, range: nil, locale: nil) != nil
     }
     #endif
-    
+
     #if canImport(Foundation)
     /// SwifterSwift: Overload Swift's 'contains' operator for matching regex pattern
     ///

--- a/Sources/SwifterSwift/SwiftStdlib/StringProtocolExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringProtocolExtensions.swift
@@ -19,23 +19,11 @@ public extension StringProtocol {
     ///     - Parameter options: Options for the comparison.
     /// - Returns: The longest common suffix of the receiver and the given String
     func commonSuffix<T: StringProtocol>(with aString: T, options: String.CompareOptions = []) -> String {
-        guard !isEmpty && !aString.isEmpty else { return "" }
-
-        var idx = endIndex
-        var strIdx = aString.endIndex
-
-        repeat {
-            formIndex(before: &idx)
-            aString.formIndex(before: &strIdx)
-
-            guard String(self[idx]).compare(String(aString[strIdx]), options: options) == .orderedSame else {
-                formIndex(after: &idx)
-                break
-            }
-
-        } while idx > startIndex && strIdx > aString.startIndex
-
-        return String(self[idx...])
+        return String(zip(reversed(), aString.reversed())
+            .lazy
+            .prefix(while: { (lhs: Character, rhs: Character) in String(lhs).compare(String(rhs), options: options) == .orderedSame })
+            .map { (lhs: Character, _: Character) in lhs }
+            .reversed())
     }
 
 }

--- a/Sources/SwifterSwift/UIKit/UIDatePickerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIDatePickerExtensions.swift
@@ -12,6 +12,7 @@ import UIKit
 // MARK: - Properties
 public extension UIDatePicker {
 
+    #if !targetEnvironment(macCatalyst)
     /// SwifterSwift: Text color of UIDatePicker.
     var textColor: UIColor? {
         set {
@@ -21,6 +22,7 @@ public extension UIDatePicker {
             return value(forKeyPath: "textColor") as? UIColor
         }
     }
+    #endif
 
 }
 

--- a/Tests/AppKitTests/NSImageExtensionsTests.swift
+++ b/Tests/AppKitTests/NSImageExtensionsTests.swift
@@ -21,6 +21,7 @@ final class NSImageExtensionsTests: XCTestCase {
         let scaledImage = image?.scaled(toMaxSize: NSSize(width: 150, height: 150))
         XCTAssertNotNil(scaledImage)
         XCTAssertEqual(scaledImage?.size.width, 150)
+        XCTAssertEqual(scaledImage?.size.height, 34)
     }
 
 }

--- a/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
+++ b/Tests/CoreAnimationTests/CATransform3DExtensionsTests.swift
@@ -39,7 +39,7 @@ final class CATransform3DExtensionsTests: XCTestCase {
         let encoder = JSONEncoder()
         var data: Data?
         XCTAssertNoThrow(data = try encoder.encode(transform))
-        XCTAssert(data?.isEmpty == false)
+        XCTAssertEqual(data?.isEmpty, false)
 
         let decoder = JSONDecoder()
         var decodedTransform: CATransform3D?

--- a/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
+++ b/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
@@ -19,7 +19,7 @@ final class DispatchQueueExtensionsTests: XCTestCase {
         let group = DispatchGroup()
 
         DispatchQueue.main.async(group: group) {
-            XCTAssertTrue(DispatchQueue.isMainQueue)
+            XCTAssert(DispatchQueue.isMainQueue)
         }
         DispatchQueue.global().async(group: group) {
             XCTAssertFalse(DispatchQueue.isMainQueue)
@@ -38,10 +38,10 @@ final class DispatchQueueExtensionsTests: XCTestCase {
         let queue = DispatchQueue.global()
 
         queue.async(group: group) {
-            XCTAssertTrue(DispatchQueue.isCurrent(queue))
+            XCTAssert(DispatchQueue.isCurrent(queue))
         }
         DispatchQueue.main.async(group: group) {
-            XCTAssertTrue(DispatchQueue.isCurrent(DispatchQueue.main))
+            XCTAssert(DispatchQueue.isCurrent(DispatchQueue.main))
             XCTAssertFalse(DispatchQueue.isCurrent(queue))
         }
 

--- a/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
+++ b/Tests/DispatchTests/DispatchQueueExtensionsTests.swift
@@ -29,7 +29,7 @@ final class DispatchQueueExtensionsTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testIsCurrent() {
@@ -49,21 +49,18 @@ final class DispatchQueueExtensionsTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
-    
+
     func testAsyncAfter() {
-        let delay: Double = 2
-        var codeExecuted = false
+        let delay = TimeInterval(2)
         let codeShouldBeExecuted = expectation(description: "Executed")
-        
+
         DispatchQueue.main.asyncAfter(delay: delay) {
-            codeExecuted = true
             codeShouldBeExecuted.fulfill()
         }
-        
-        waitForExpectations(timeout: delay, handler: nil)
-        XCTAssert(codeExecuted)
+
+        waitForExpectations(timeout: delay + 1)
     }
 
 }

--- a/Tests/FoundationTests/CalendarExtensionTest.swift
+++ b/Tests/FoundationTests/CalendarExtensionTest.swift
@@ -26,10 +26,10 @@ class CalendarExtensionTests: XCTestCase {
         let shortMonthsDateComponents = shortMonths.map { DateComponents(year: 2015, month: $0) }
         let longMonthDates = longMonthsDateComponents.compactMap { calendar.date(from: $0) }
         let shortMonthDates = shortMonthsDateComponents.compactMap { calendar.date(from: $0) }
-        longMonthDates.forEach { XCTAssert(calendar.numberOfDaysInMonth(for: $0) == 31) }
-        shortMonthDates.forEach { XCTAssert(calendar.numberOfDaysInMonth(for: $0) == 30) }
-        XCTAssert(calendar.numberOfDaysInMonth(for: febDate) == 28)
-        XCTAssert(calendar.numberOfDaysInMonth(for: leapYearDate) == 29)
+        longMonthDates.forEach { XCTAssertEqual(calendar.numberOfDaysInMonth(for: $0), 31) }
+        shortMonthDates.forEach { XCTAssertEqual(calendar.numberOfDaysInMonth(for: $0), 30) }
+        XCTAssertEqual(calendar.numberOfDaysInMonth(for: febDate), 28)
+        XCTAssertEqual(calendar.numberOfDaysInMonth(for: leapYearDate), 29)
     }
 
 }

--- a/Tests/FoundationTests/FileManagerExtensionsTests.swift
+++ b/Tests/FoundationTests/FileManagerExtensionsTests.swift
@@ -32,8 +32,8 @@ final class FileManagerExtensionsTests: XCTestCase {
             // Check contents
             if let dict = json {
                 if let string = dict["title"] as? String, let itemId = dict["id"] as? Int {
-                    XCTAssert(string == "Test")
-                    XCTAssert(itemId == 1)
+                    XCTAssertEqual(string, "Test")
+                    XCTAssertEqual(itemId, 1)
                 } else {
                     XCTFail("Does not contain the correct content.")
                 }
@@ -62,8 +62,8 @@ final class FileManagerExtensionsTests: XCTestCase {
             // Check contents
             if let dict = json {
                 if let string = dict["title"] as? String, let itemId = dict["id"] as? Int {
-                    XCTAssert(string == "Test")
-                    XCTAssert(itemId == 1)
+                    XCTAssertEqual(string, "Test")
+                    XCTAssertEqual(itemId, 1)
                 } else {
                     XCTFail("Does not contain the correct content.")
                 }

--- a/Tests/FoundationTests/LocaleExtensionsTests.swift
+++ b/Tests/FoundationTests/LocaleExtensionsTests.swift
@@ -21,7 +21,7 @@ final class LocaleExtensionsTests: XCTestCase {
 
     func testIs12HourTimeFormat() {
         let twelveHourLocale = Locale(identifier: "en")
-        XCTAssertTrue(twelveHourLocale.is12HourTimeFormat)
+        XCTAssert(twelveHourLocale.is12HourTimeFormat)
 
         let twentyFourLocale = Locale(identifier: "ru")
         XCTAssertFalse(twentyFourLocale.is12HourTimeFormat)

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -76,7 +76,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         let string = NSAttributedString(string: "Applying")
         var out = string.applying(attributes: [:])
         var attributes = out.attributes(at: 0, effectiveRange: nil)
-        XCTAssertTrue(attributes.isEmpty)
+        XCTAssert(attributes.isEmpty)
 
         out = string.applying(attributes: [
             .strikethroughStyle: NSNumber(value: NSUnderlineStyle.single.rawValue),
@@ -162,7 +162,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         let attrTestString = stringToTest.applying(attributes: attributes, toRangesMatching: pattern)
 
         let attrAtBeginning = attrTestString.attributes(at: 0, effectiveRange: nil)
-        XCTAssert(attrAtBeginning.count == 1)
+        XCTAssertEqual(attrAtBeginning.count, 1)
 
         var passed = false
         // iterate through each range of attributes

--- a/Tests/FoundationTests/NSPredicateExtensionsTests.swift
+++ b/Tests/FoundationTests/NSPredicateExtensionsTests.swift
@@ -17,7 +17,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
     func testNot() {
         let predicate = NSPredicate(value: true)
         let notPredicate = predicate.not
-        XCTAssert(notPredicate.compoundPredicateType == .not)
+        XCTAssertEqual(notPredicate.compoundPredicateType, .not)
 
         #if os(Linux)
         XCTAssertEqual(notPredicate.subpredicates, [predicate])
@@ -32,7 +32,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
         let predicate1 = NSPredicate(value: true)
         let predicate2 = NSPredicate(value: false)
         let andPredicate = predicate1.and(predicate2)
-        XCTAssert(andPredicate.compoundPredicateType == .and)
+        XCTAssertEqual(andPredicate.compoundPredicateType, .and)
 
         #if os(Linux)
         XCTAssertEqual(andPredicate.subpredicates, [predicate1, predicate2])
@@ -47,7 +47,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
         let predicate1 = NSPredicate(value: true)
         let predicate2 = NSPredicate(value: false)
         let orPredicate = predicate1.or(predicate2)
-        XCTAssert(orPredicate.compoundPredicateType == .or)
+        XCTAssertEqual(orPredicate.compoundPredicateType, .or)
 
         #if os(Linux)
         XCTAssertEqual(orPredicate.subpredicates, [predicate1, predicate2])
@@ -61,7 +61,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
     func testOperatorNot() {
         let predicate = NSPredicate(value: false)
         let notPredicate = !predicate
-        XCTAssert(notPredicate.compoundPredicateType == .not)
+        XCTAssertEqual(notPredicate.compoundPredicateType, .not)
 
         #if os(Linux)
         XCTAssertEqual(notPredicate.subpredicates, [predicate])
@@ -76,7 +76,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
         let predicate1 = NSPredicate(value: false)
         let predicate2 = NSPredicate(value: true)
         let andPredicate = predicate1 + predicate2
-        XCTAssert(andPredicate.compoundPredicateType == .and)
+        XCTAssertEqual(andPredicate.compoundPredicateType, .and)
 
         #if os(Linux)
         XCTAssertEqual(andPredicate.subpredicates, [predicate1, predicate2])
@@ -91,7 +91,7 @@ final class NSPredicateExtensionsTests: XCTestCase {
         let predicate1 = NSPredicate(value: true)
         let predicate2 = NSPredicate(value: false)
         let orPredicate = predicate1 | predicate2
-        XCTAssert(orPredicate.compoundPredicateType == .or)
+        XCTAssertEqual(orPredicate.compoundPredicateType, .or)
 
         #if os(Linux)
         XCTAssertEqual(orPredicate.subpredicates, [predicate1, predicate2])

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -28,7 +28,7 @@ final class URLExtensionsTests: XCTestCase {
         XCTAssertEqual(parameters.count, 2)
         XCTAssertEqual(parameters["q"], "swifter swift")
         XCTAssertEqual(parameters["steve"], "jobs")
-        XCTAssertEqual(parameters["empty"], nil)
+        XCTAssertNil(parameters["empty"])
     }
 
     func testOptionalStringInitializer() {
@@ -62,8 +62,8 @@ final class URLExtensionsTests: XCTestCase {
         let otherResult = url.queryValue(for: "other")
 
         XCTAssertEqual(codeResult, "12345")
-        XCTAssertEqual(emtpyResult, nil)
-        XCTAssertEqual(otherResult, nil)
+        XCTAssertNil(emtpyResult)
+        XCTAssertNil(otherResult)
     }
 
     func testDeletingAllPathComponents() {

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -94,12 +94,12 @@ final class ColorExtensionsTests: XCTestCase {
     // MARK: - Test properties
     func testHsbaComponents() {
         var color = Color(hex: 0x00FF00, transparency: 1.0)!
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (120/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.hue, 120.0 / 360.0, accuracy: 0.001)
         XCTAssertEqual(color.hsbaComponents.saturation, 1.0)
         XCTAssertEqual(color.hsbaComponents.brightness, 1.0)
 
         color = Color(hex: 0x0000FF, transparency: 1.0)!
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (240/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.hue, 240.0 / 360.0, accuracy: 0.001)
         XCTAssertEqual(color.hsbaComponents.saturation, 1.0)
         XCTAssertEqual(color.hsbaComponents.brightness, 1.0)
 
@@ -114,17 +114,17 @@ final class ColorExtensionsTests: XCTestCase {
         XCTAssertEqual(color.hsbaComponents.brightness, 1.0)
 
         color = Color(hex: 0x123456, transparency: 1.0)!
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (210/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.hue, 210.0 / 360.0, accuracy: 0.001)
         XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 79)
         XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 34)
 
         color = Color(hex: 0xFCA864, transparency: 1.0)!
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (27/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.hue, 27.0 / 360.0, accuracy: 0.001)
         XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 60)
         XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 99)
 
         color = Color(hex: 0x1F2D3C, transparency: 1.0)!
-        XCTAssertEqual(CGFloat(round(1000 * color.hsbaComponents.hue) / 1000), CGFloat(round(1000 * (211/360)) / 1000))
+        XCTAssertEqual(color.hsbaComponents.hue, 211.0 / 360.0, accuracy: 0.001)
         XCTAssertEqual((color.hsbaComponents.saturation * 100).rounded(), 48)
         XCTAssertEqual((color.hsbaComponents.brightness * 100).rounded(), 24)
     }

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -14,8 +14,21 @@ final class CollectionExtensionsTests: XCTestCase {
     let collection = [1, 2, 3, 4, 5]
 
     func testForEachInParallel() {
-        collection.forEachInParallel { item in
-            XCTAssert(collection.contains(item))
+        let expectation = XCTestExpectation(description: "forEachInParallel")
+
+        var count = 0
+        let countQueue = DispatchQueue.global()
+        collection.forEachInParallel {
+            XCTAssert(collection.contains($0))
+            countQueue.async {
+                count += 1
+                if count == self.collection.count {
+                    expectation.fulfill()
+                }
+            }
+        }
+        if count != collection.count {
+            wait(for: [expectation], timeout: 0.5)
         }
     }
 

--- a/Tests/SwiftStdlibTests/ComparableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ComparableExtensionsTests.swift
@@ -14,12 +14,12 @@ final class ComparableExtensionsTests: XCTestCase {
 
     func testIsBetween() {
         XCTAssertFalse(1.isBetween(5...7), "number range")
-        XCTAssertTrue(7.isBetween(6...12), "number range")
-        XCTAssertTrue(0.32.isBetween(0.31...0.33), "float range")
-        XCTAssertTrue("c".isBetween("a"..."d"), "string range")
+        XCTAssert(7.isBetween(6...12), "number range")
+        XCTAssert(0.32.isBetween(0.31...0.33), "float range")
+        XCTAssert("c".isBetween("a"..."d"), "string range")
 
         let date = Date()
-        XCTAssertTrue(date.isBetween(date...date.addingTimeInterval(1000)), "date range")
+        XCTAssert(date.isBetween(date...date.addingTimeInterval(1000)), "date range")
     }
 
     func testClamped() {

--- a/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DictionaryExtensionsTests.swift
@@ -21,7 +21,7 @@ final class DictionaryExtensionsTests: XCTestCase {
     func testRemoveAll() {
         var dict: [String: String] = ["key1": "value1", "key2": "value2", "key3": "value3"]
         dict.removeAll(keys: ["key1", "key2"])
-        XCTAssertTrue(dict.keys.contains("key3"))
+        XCTAssert(dict.keys.contains("key3"))
         XCTAssertFalse(dict.keys.contains("key1"))
         XCTAssertFalse(dict.keys.contains("key2"))
     }
@@ -30,7 +30,7 @@ final class DictionaryExtensionsTests: XCTestCase {
         var emptyDict = [String: String]()
         XCTAssertNil(emptyDict.removeValueForRandomKey())
 
-        var dict = ["key1": "value1", "key2": "value2", "key3": "value3"]
+        var dict: [String: String] = ["key1": "value1", "key2": "value2", "key3": "value3"]
         let elements = dict.count
         let removedElement = dict.removeValueForRandomKey()
         XCTAssertEqual(elements - 1, dict.count)
@@ -67,8 +67,8 @@ final class DictionaryExtensionsTests: XCTestCase {
     func testKeysForValue() {
         let dict = ["key1": "value1", "key2": "value1", "key3": "value2"]
         let result = dict.keys(forValue: "value1")
-        XCTAssertTrue(result.contains("key1"))
-        XCTAssertTrue(result.contains("key2"))
+        XCTAssert(result.contains("key1"))
+        XCTAssert(result.contains("key2"))
         XCTAssertFalse(result.contains("key3"))
     }
 
@@ -81,7 +81,7 @@ final class DictionaryExtensionsTests: XCTestCase {
     func testSubscriptKeypath() {
         var json = ["key": ["key1": ["key2": "value"]]]
 
-        XCTAssertEqual(json[path: []] as? String, nil)
+        XCTAssertNil(json[path: []] as? String)
         XCTAssertEqual(json[path: ["key", "key1"]] as? [String: String], ["key2": "value"])
         XCTAssertEqual(json[path: ["key", "key1", "key2"]] as? String, "value")
         json[path: ["key", "key1", "key2"]] = "newValue"
@@ -92,14 +92,14 @@ final class DictionaryExtensionsTests: XCTestCase {
         let dict: [String: String] = ["key1": "value1"]
         let dict2: [String: String] = ["key2": "value2"]
         let result = dict + dict2
-        XCTAssertTrue(result.keys.contains("key1"))
-        XCTAssertTrue(result.keys.contains("key2"))
+        XCTAssert(result.keys.contains("key1"))
+        XCTAssert(result.keys.contains("key2"))
     }
 
     func testOperatorMinus() {
         let dict: [String: String] = ["key1": "value1", "key2": "value2", "key3": "value3"]
         let result = dict-["key1", "key2"]
-        XCTAssertTrue(result.keys.contains("key3"))
+        XCTAssert(result.keys.contains("key3"))
         XCTAssertFalse(result.keys.contains("key1"))
         XCTAssertFalse(result.keys.contains("key2"))
     }
@@ -108,14 +108,14 @@ final class DictionaryExtensionsTests: XCTestCase {
         var dict: [String: String] = ["key1": "value1"]
         let dict2: [String: String] = ["key2": "value2"]
         dict += dict2
-        XCTAssertTrue(dict.keys.contains("key1"))
-        XCTAssertTrue(dict.keys.contains("key2"))
+        XCTAssert(dict.keys.contains("key1"))
+        XCTAssert(dict.keys.contains("key2"))
     }
 
     func testOperatorRemoveKeys() {
         var dict: [String: String] = ["key1": "value1", "key2": "value2", "key3": "value3"]
         dict-=["key1", "key2"]
-        XCTAssertTrue(dict.keys.contains("key3"))
+        XCTAssert(dict.keys.contains("key3"))
         XCTAssertFalse(dict.keys.contains("key1"))
         XCTAssertFalse(dict.keys.contains("key2"))
     }

--- a/Tests/SwiftStdlibTests/IntExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/IntExtensionsTests.swift
@@ -75,12 +75,12 @@ final class IntExtensionsTests: XCTestCase {
 
     func testIsPrime() {
         // Prime number
-        XCTAssertTrue(2.isPrime())
-        XCTAssertTrue(3.isPrime())
-        XCTAssertTrue(7.isPrime())
-        XCTAssertTrue(19.isPrime())
-        XCTAssertTrue(577.isPrime())
-        XCTAssertTrue(1999.isPrime())
+        XCTAssert(2.isPrime())
+        XCTAssert(3.isPrime())
+        XCTAssert(7.isPrime())
+        XCTAssert(19.isPrime())
+        XCTAssert(577.isPrime())
+        XCTAssert(1999.isPrime())
 
         // Composite number
         XCTAssertFalse(4.isPrime())
@@ -97,13 +97,14 @@ final class IntExtensionsTests: XCTestCase {
 
     func testRomanNumeral() {
         XCTAssertEqual(10.romanNumeral(), "X")
+        XCTAssertEqual(2784.romanNumeral(), "MMDCCLXXXIV")
         XCTAssertNil((-1).romanNumeral())
     }
 
     func testRoundToNearest() {
-        XCTAssert(12.roundToNearest(5) == 10)
-        XCTAssert(63.roundToNearest(25) == 75)
-        XCTAssert(42.roundToNearest(0) == 42)
+        XCTAssertEqual(12.roundToNearest(5), 10)
+        XCTAssertEqual(63.roundToNearest(25), 75)
+        XCTAssertEqual(42.roundToNearest(0), 42)
     }
 
     func testOperators() {

--- a/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/KeyedDecodingContainerExtensionsTests.swift
@@ -32,7 +32,7 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let isPlayingAndIsFullScreenAsInt = #"{"isPlaying": 1, "isFullScreen": 0}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsInt)
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
-        XCTAssertTrue(video.isPlaying)
+        XCTAssert(video.isPlaying)
         XCTAssertEqual(video.isFullScreen, false)
     }
 
@@ -40,7 +40,7 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let isPlayingAndIsFullScreenAsString = #"{"isPlaying": "true", "isFullScreen": "false"}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsString)
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
-        XCTAssertTrue(video.isPlaying)
+        XCTAssert(video.isPlaying)
         XCTAssertEqual(video.isFullScreen, false)
     }
 
@@ -48,7 +48,7 @@ final class KeyedDecodingContainerTests: XCTestCase {
         let isPlayingAndIsFullScreenAsBool = #"{"isPlaying": true, "isFullScreen": false}"#
         let data = mockJsonData(from: isPlayingAndIsFullScreenAsBool)
         let video = try! JSONDecoder().decode(Video.self, from: data) // swiftlint:disable:this force_try
-        XCTAssertTrue(video.isPlaying)
+        XCTAssert(video.isPlaying)
         XCTAssertEqual(video.isFullScreen, false)
     }
 

--- a/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/OptionalExtensionsTests.swift
@@ -58,9 +58,9 @@ final class OptionalExtensionsTests: XCTestCase {
         parameters[key1] ??= parameter1
         parameters[key2] ??= parameter2
 
-        XCTAssert(parameters[key1] == nil)
-        XCTAssertFalse(parameters[key1] != parameter1)
-        XCTAssert(parameters[key2] == parameter2)
+        XCTAssertNil(parameters[key1])
+        XCTAssertEqual(parameters[key1], parameter1)
+        XCTAssertEqual(parameters[key2], parameter2)
     }
 
     func testConditionalAssignment() {
@@ -74,7 +74,7 @@ final class OptionalExtensionsTests: XCTestCase {
 
         var text3: String?
         text3 ?= nil
-        XCTAssertEqual(text3, nil)
+        XCTAssertNil(text3)
 
         var text4: String? = "text4"
         text4 ?= nil
@@ -83,10 +83,10 @@ final class OptionalExtensionsTests: XCTestCase {
 
     func testIsNilOrEmpty() {
         let nilArray: [String]? = nil
-        XCTAssertTrue(nilArray.isNilOrEmpty)
+        XCTAssert(nilArray.isNilOrEmpty)
 
         let emptyArray: [String]? = []
-        XCTAssertTrue(emptyArray.isNilOrEmpty)
+        XCTAssert(emptyArray.isNilOrEmpty)
 
         let intArray: [Int]? = [1]
         XCTAssertFalse(intArray.isNilOrEmpty)

--- a/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/SwiftStdlibTests/RangeReplaceableCollectionTests.swift
@@ -15,9 +15,9 @@ final class RangeReplaceableCollectionTests: XCTestCase {
         var array = [1, 2, 3]
         let newArray = [Int](expression: array.removeLast(), count: array.count)
         XCTAssertEqual(newArray, [3, 2, 1])
-        XCTAssertTrue(array.isEmpty)
+        XCTAssert(array.isEmpty)
         let empty = [Int](expression: 1, count: 0)
-        XCTAssertTrue(empty.isEmpty)
+        XCTAssert(empty.isEmpty)
 
     }
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -268,7 +268,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("8.23".float(locale: Locale(identifier: "en_US_POSIX")))
         XCTAssertEqual("8.23".float(locale: Locale(identifier: "en_US_POSIX")), Float(8.23))
 
-        #if os(Linux) || targetEnvironment(macCatalyst)
+        #if os(Linux)
         XCTAssertEqual("8s".float(), 8)
         #else
         XCTAssertNil("8s".float())
@@ -282,7 +282,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("8.23".double(locale: Locale(identifier: "en_US_POSIX")))
         XCTAssertEqual("8.23".double(locale: Locale(identifier: "en_US_POSIX")), 8.23)
 
-        #if os(Linux) || targetEnvironment(macCatalyst)
+        #if os(Linux)
         XCTAssertEqual("8s".double(), 8)
         #else
         XCTAssertNil("8s".double())
@@ -297,11 +297,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNotNil("8.23".cgFloat(locale: Locale(identifier: "en_US_POSIX")))
         XCTAssertEqual("8.23".cgFloat(locale: Locale(identifier: "en_US_POSIX")), CGFloat(8.23))
 
-        #if targetEnvironment(macCatalyst)
-        XCTAssertEqual("8s".cgFloat(), 8)
-        #else
         XCTAssertNil("8s".cgFloat())
-        #endif
         #endif
     }
 
@@ -573,21 +569,21 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testMatches() {
-        XCTAssertTrue("123".matches(pattern: "\\d{3}"))
+        XCTAssert("123".matches(pattern: "\\d{3}"))
         XCTAssertFalse("dasda".matches(pattern: "\\d{3}"))
         XCTAssertFalse("notanemail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
-        XCTAssertTrue("email@mail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
+        XCTAssert("email@mail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
     }
     
     #if canImport(Foundation)
     func testRegexMatchOperator() {
-        XCTAssertTrue("123" ~= "\\d{3}")
+        XCTAssert("123" ~= "\\d{3}")
         XCTAssertFalse("dasda" ~= "\\d{3}")
         XCTAssertFalse("notanemail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
-        XCTAssertTrue("email@mail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
-        XCTAssertTrue("hat" ~= "[a-z]at")
+        XCTAssert("email@mail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+        XCTAssert("hat" ~= "[a-z]at")
         XCTAssertFalse("" ~= "[a-z]at")
-        XCTAssertTrue("" ~= "[a-z]*")
+        XCTAssert("" ~= "[a-z]*")
         XCTAssertFalse("" ~= "[0-9]+")
     }
     #endif
@@ -666,7 +662,7 @@ final class StringExtensionsTests: XCTestCase {
         #if os(iOS) || os(tvOS)
         let strCorrect = "Hello, World!"
 
-        XCTAssertTrue(strCorrect.isSpelledCorrectly)
+        XCTAssert(strCorrect.isSpelledCorrectly)
 
         let strNonCorrect = "Helol, Wrold!"
         XCTAssertFalse(strNonCorrect.isSpelledCorrectly)

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -574,7 +574,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("notanemail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
         XCTAssert("email@mail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
     }
-    
+
     #if canImport(Foundation)
     func testRegexMatchOperator() {
         XCTAssert("123" ~= "\\d{3}")

--- a/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
@@ -21,7 +21,7 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
 
         XCTAssertNotNil(discardedResult)
 
-        XCTAssert(alertController.actions.count == 1)
+        XCTAssertEqual(alertController.actions.count, 1)
 
         let action = alertController.actions.first
 
@@ -40,7 +40,7 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
 
         alertController.addTextField(text: "TextField", placeholder: "PlaceHolder", editingChangedTarget: self, editingChangedSelector: selector)
 
-        XCTAssert(alertController.textFields?.count == 1)
+        XCTAssertEqual(alertController.textFields?.count, 1)
 
         let textField = alertController.textFields?.first
 
@@ -60,7 +60,7 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
         XCTAssertEqual(alertController.message, "Message")
         XCTAssertEqual(alertController.view.tintColor, .blue)
 
-        XCTAssert(alertController.actions.count == 1)
+        XCTAssertEqual(alertController.actions.count, 1)
 
         let defaultAction = alertController.actions.first
 
@@ -81,7 +81,7 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
         XCTAssertEqual(alertController.message, error.localizedDescription)
         XCTAssertEqual(alertController.view.tintColor, .red)
 
-        XCTAssert(alertController.actions.count == 1)
+        XCTAssertEqual(alertController.actions.count, 1)
 
         let defaultAction = alertController.actions.first
 

--- a/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UICollectionViewExtensionsTests.swift
@@ -133,8 +133,8 @@ final class UICollectionViewExtensionsTests: XCTestCase {
         XCTAssertFalse(emptyCollectionView.isValidIndexPath(zeroIndexPath))
 
         XCTAssertFalse(collectionView.isValidIndexPath(negativeIndexPath))
-        XCTAssertTrue(collectionView.isValidIndexPath(zeroIndexPath))
-        XCTAssertTrue(collectionView.isValidIndexPath(validIndexPath))
+        XCTAssert(collectionView.isValidIndexPath(zeroIndexPath))
+        XCTAssert(collectionView.isValidIndexPath(validIndexPath))
         XCTAssertFalse(collectionView.isValidIndexPath(invalidIndexPath))
     }
 }

--- a/Tests/UIKitTests/UIDatePickerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIDatePickerExtensionsTests.swift
@@ -14,6 +14,7 @@ import UIKit
 
 final class UIDatePickerExtensionsTests: XCTestCase {
 
+    #if !targetEnvironment(macCatalyst)
     func testTextColor() {
         let datePicker = UIDatePicker()
         if let color = datePicker.textColor {
@@ -29,6 +30,7 @@ final class UIDatePickerExtensionsTests: XCTestCase {
         datePicker.textColor = nil
         XCTAssertNil(datePicker.textColor)
     }
+    #endif
 
 }
 

--- a/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIGestureRecognizerExtensionsTests.swift
@@ -19,25 +19,25 @@ final class UIGestureRecognizerExtensionsTests: XCTestCase {
         let tap = UITapGestureRecognizer()
 
         // First Baseline Assertion
-        XCTAssert(view.gestureRecognizers == nil)
-        XCTAssert(tap.view == nil)
+        XCTAssertNil(view.gestureRecognizers)
+        XCTAssertNil(tap.view)
 
         view.addGestureRecognizer(tap)
 
         // Verify change
-        XCTAssertFalse(view.gestureRecognizers == nil)
-        XCTAssertFalse(tap.view == nil)
+        XCTAssertNotNil(view.gestureRecognizers)
+        XCTAssertNotNil(tap.view)
 
         // Second Baseline Assertion
-        XCTAssertFalse((view.gestureRecognizers?.count ?? 0) == 0)
+        XCTAssertNotEqual(view.gestureRecognizers?.count, 0)
         XCTAssertFalse(view.gestureRecognizers?.isEmpty ?? true)
 
         tap.removeFromView()
 
         // Verify change
-        XCTAssert((view.gestureRecognizers?.count ?? 1) == 0)
+        XCTAssertEqual(view.gestureRecognizers?.count, 0)
         XCTAssert(view.gestureRecognizers?.isEmpty ?? false)
-        XCTAssert(tap.view == nil)
+        XCTAssertNil(tap.view)
     }
 
 }

--- a/Tests/UIKitTests/UIImageViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageViewExtensionsTests.swift
@@ -41,7 +41,7 @@ final class UIImageViewExtensionsTests: XCTestCase {
         }
         XCTAssertEqual(failImageView.contentMode, .center)
         XCTAssertNil(failImageView.image)
-        waitForExpectations(timeout: 15, handler: nil)
+        waitForExpectations(timeout: 15)
     }
 
     func testBlur() {

--- a/Tests/UIKitTests/UILabelExtensionsTests.swift
+++ b/Tests/UIKitTests/UILabelExtensionsTests.swift
@@ -35,7 +35,7 @@ final class UILabelExtensionsTests: XCTestCase {
         label.text = "Hello world"
 
         #if os(iOS)
-        XCTAssert(label.requiredHeight > 20)
+        XCTAssert(label.requiredHeight >= 20)
         XCTAssert(label.requiredHeight < 25)
         #else
         XCTAssert(label.requiredHeight > 0)

--- a/Tests/UIKitTests/UINavigationControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UINavigationControllerExtensionsTests.swift
@@ -23,7 +23,7 @@ final class UINavigationControllerExtensionsTests: XCTestCase {
         let exp = expectation(description: "pushCallback")
 
         navigationController.pushViewController(vcToPush) {
-            XCTAssert(navigationController.viewControllers.count == 1)
+            XCTAssertEqual(navigationController.viewControllers.count, 1)
             XCTAssertEqual(navigationController.topViewController, vcToPush)
             exp.fulfill()
         }
@@ -35,11 +35,11 @@ final class UINavigationControllerExtensionsTests: XCTestCase {
         let navigationController = UINavigationController(rootViewController: rootVC)
         let vcToPush = UIViewController()
         navigationController.pushViewController(vcToPush, animated: false)
-        XCTAssert(navigationController.viewControllers.count == 2)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
 
         let exp = expectation(description: "pushCallback")
         navigationController.popViewController(animated: false) {
-            XCTAssert(navigationController.viewControllers.count == 1)
+            XCTAssertEqual(navigationController.viewControllers.count, 1)
             XCTAssertEqual(navigationController.topViewController, rootVC)
             exp.fulfill()
         }

--- a/Tests/UIKitTests/UINavigationControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UINavigationControllerExtensionsTests.swift
@@ -27,7 +27,7 @@ final class UINavigationControllerExtensionsTests: XCTestCase {
             XCTAssertEqual(navigationController.topViewController, vcToPush)
             exp.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
     }
 
     func testPopViewController() {
@@ -43,7 +43,7 @@ final class UINavigationControllerExtensionsTests: XCTestCase {
             XCTAssertEqual(navigationController.topViewController, rootVC)
             exp.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
     }
 
     func testMakeTransparent() {

--- a/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
+++ b/Tests/UIKitTests/UIRefreshControlExntesionsTests.swift
@@ -21,7 +21,7 @@ final class UIRefreshControlExtensionTests: XCTestCase {
         tableView.addSubview(refreshControl)
         refreshControl.beginRefreshing(in: tableView, animated: true)
 
-        XCTAssertTrue(refreshControl.isRefreshing)
+        XCTAssert(refreshControl.isRefreshing)
         XCTAssertEqual(tableView.contentOffset.y, -refreshControl.frame.height)
 
         let anotherTableview = UITableView()
@@ -29,7 +29,7 @@ final class UIRefreshControlExtensionTests: XCTestCase {
         anotherTableview.refreshControl = UIRefreshControl()
         anotherTableview.refreshControl?.beginRefreshing(in: anotherTableview, animated: true, sendAction: true)
 
-        XCTAssertTrue(anotherTableview.refreshControl!.isRefreshing)
+        XCTAssert(anotherTableview.refreshControl!.isRefreshing)
         XCTAssertEqual(anotherTableview.contentOffset.y, -anotherTableview.refreshControl!.frame.height)
     }
 

--- a/Tests/UIKitTests/UISearchBarExtensionsTests.swift
+++ b/Tests/UIKitTests/UISearchBarExtensionsTests.swift
@@ -16,7 +16,7 @@ final class UISearchBarExtensionsTests: XCTestCase {
 
     func testSearchBar() {
         let searchBar = UISearchBar()
-        XCTAssert(searchBar.textField?.text?.isEmpty != false)
+        XCTAssertNotEqual(searchBar.textField?.text?.isEmpty, false)
 
         let frame = CGRect(x: 0, y: 0, width: 100, height: 30)
         let aSearchBar = UISearchBar(frame: frame)

--- a/Tests/UIKitTests/UISliderExtensionsTests.swift
+++ b/Tests/UIKitTests/UISliderExtensionsTests.swift
@@ -23,7 +23,7 @@ final class UISliderExtensionsTests: XCTestCase {
             XCTAssertEqual(slider.value, 90.0)
             exp.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
     }
 
     func testSetValue() {
@@ -50,7 +50,7 @@ final class UISliderExtensionsTests: XCTestCase {
             exp.fulfill()
         }
         XCTAssertEqual(slider.value, 50.0)
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 3)
     }
 
 }

--- a/Tests/UIKitTests/UIStackViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIStackViewExtensionsTests.swift
@@ -21,8 +21,8 @@ final class UIStackViewExtensionsTest: XCTestCase {
         var stack = UIStackView(arrangedSubviews: [view1, view2], axis: .horizontal)
 
         XCTAssertEqual(stack.arrangedSubviews.count, 2)
-        XCTAssertTrue(stack.arrangedSubviews[0] === view1)
-        XCTAssertTrue(stack.arrangedSubviews[1] === view2)
+        XCTAssert(stack.arrangedSubviews[0] === view1)
+        XCTAssert(stack.arrangedSubviews[1] === view2)
 
         XCTAssertEqual(stack.axis, .horizontal)
         XCTAssertEqual(stack.alignment, .fill)

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -55,7 +55,7 @@ final class UITableViewExtensionsTests: XCTestCase {
             XCTAssert(true)
             exp.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
     }
 
     func testRemoveTableFooterView() {

--- a/Tests/UIKitTests/UITableViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UITableViewExtensionsTests.swift
@@ -105,7 +105,7 @@ final class UITableViewExtensionsTests: XCTestCase {
 
     func testIsValidIndexPath() {
         let validIndexPath = IndexPath(row: 0, section: 0)
-        XCTAssertTrue(tableView.isValidIndexPath(validIndexPath))
+        XCTAssert(tableView.isValidIndexPath(validIndexPath))
 
         let invalidIndexPath = IndexPath(row: 10, section: 0)
         XCTAssertFalse(tableView.isValidIndexPath(invalidIndexPath))

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -55,7 +55,7 @@ final class UIViewExtensionsTests: XCTestCase {
         let txtView = UITextField(frame: CGRect.zero)
         window.addSubview(txtView)
         txtView.becomeFirstResponder()
-        XCTAssertTrue(txtView.firstResponder() === txtView)
+        XCTAssert(txtView.firstResponder() === txtView)
 
         // When a subview is firstResponder
         let superView = UIView()
@@ -63,10 +63,10 @@ final class UIViewExtensionsTests: XCTestCase {
         let subView = UITextField(frame: CGRect.zero)
         superView.addSubview(subView)
         subView.becomeFirstResponder()
-        XCTAssertTrue(superView.firstResponder() === subView)
+        XCTAssert(superView.firstResponder() === subView)
 
         // When you have to find recursively
-        XCTAssertTrue(window.firstResponder() === subView)
+        XCTAssert(window.firstResponder() === subView)
 
     }
 

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -229,7 +229,7 @@ final class UIViewExtensionsTests: XCTestCase {
         }
 
         XCTAssertEqual(view2.alpha, 1)
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testFadeOut() {
@@ -249,7 +249,7 @@ final class UIViewExtensionsTests: XCTestCase {
             fadeOutExpectation.fulfill()
         }
         XCTAssertEqual(view2.alpha, 0)
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testRotateByAngle() {
@@ -272,7 +272,7 @@ final class UIViewExtensionsTests: XCTestCase {
             rotateExpectation.fulfill()
         }
         XCTAssertEqual(view3.transform, transform3)
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testRotateToAngle() {
@@ -295,7 +295,7 @@ final class UIViewExtensionsTests: XCTestCase {
             rotateExpectation.fulfill()
         }
         XCTAssertEqual(view3.transform, transform3)
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testScale() {

--- a/Tests/UIKitTests/UIWindowExtensionsTests.swift
+++ b/Tests/UIKitTests/UIWindowExtensionsTests.swift
@@ -36,7 +36,7 @@ final class UIWindowExtensionsTests: XCTestCase {
             XCTAssertEqual(window.rootViewController!, viewController)
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
     }
 
 }

--- a/Tests/WebKitTests/WKWebViewExtensionsTests.swift
+++ b/Tests/WebKitTests/WKWebViewExtensionsTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import WebKit
 
 final class WKWebViewExtensionsTests: XCTestCase {
+    private let timeout = TimeInterval(10)
 
     var webView: WKWebView!
 
@@ -28,7 +29,7 @@ final class WKWebViewExtensionsTests: XCTestCase {
 
         XCTAssertNotNil(navigation)
 
-        wait(for: [successExpectation], timeout: 3)
+        wait(for: [successExpectation], timeout: timeout)
     }
 
     func testLoadURLString() {
@@ -39,7 +40,7 @@ final class WKWebViewExtensionsTests: XCTestCase {
 
         XCTAssertNotNil(navigation)
 
-        wait(for: [successExpectation], timeout: 3)
+        wait(for: [successExpectation], timeout: timeout)
     }
 
     func testLoadInvalidURLString() {
@@ -57,7 +58,7 @@ final class WKWebViewExtensionsTests: XCTestCase {
 
         XCTAssertNotNil(navigation)
 
-        wait(for: [failureExpectation], timeout: 3)
+        wait(for: [failureExpectation], timeout: timeout)
     }
 
 }


### PR DESCRIPTION
🚀

I've been playing around with compile time optimisation lately. Using the `OTHER_SWIFT_FLAGS` `-Xfrontend -warn-long-expression-type-checking=200 -Xfrontend -warn-long-function-bodies=200` I found some functions that needed cleaning up. Some were too complicated so I left them, but there are interesting parts of Swift that take a while to compile, like the ternary `?:` operator, or `+` for sequences.

Other bits I just wanted to clean up, like missed uses of `XCTAssertEquals`, etc.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
