### PR TITLE
Added `masksToBounds` (IBInspectable) extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `loadURL(_:)` and `loadURLString(_:)` extensions for `WkWebView`. [#851](https://github.com/SwifterSwift/SwifterSwift/pull/851) by [hamtiko](https://github.com/hamtiko)
 - **HKActivitySummary**:
   - Added `isStandGoalMet`, `isExerciseTimeGoalMet`, and `isEnergyBurnedGoalMet`. [#875](https://github.com/SwifterSwift/SwifterSwift/pull/875) by [lhygilbert](https://github.com/lhygilbert)
+- **UIView**:
+  - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
 
 ### Changed
 - **NSAttributedString**:

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -170,6 +170,16 @@ public extension UIView {
         }
     }
 
+    /// SwifterSwift: Masks to bounds of view; also inspectable from Storyboard.
+    @IBInspectable var masksToBounds: Bool {
+        get {
+            return layer.masksToBounds
+        }
+        set {
+            layer.masksToBounds = newValue
+        }
+    }
+
     /// SwifterSwift: Size of view.
     var size: CGSize {
         get {

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -157,8 +157,7 @@ final class UIViewExtensionsTests: XCTestCase {
     }
 
     func testMasksToBounds() {
-        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
-        let view = UIView(frame: frame)
+        let view = UIView(frame: .zero)
         view.layer.masksToBounds = true
         XCTAssertTrue(view.masksToBounds)
         view.masksToBounds = false

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -156,6 +156,15 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(view.shadowOpacity, 0.5)
     }
 
+    func testMasksToBounds() {
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let view = UIView(frame: frame)
+        view.layer.masksToBounds = true
+        XCTAssertTrue(view.masksToBounds)
+        view.masksToBounds = false
+        XCTAssertFalse(view.masksToBounds)
+    }
+
     func testSize() {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let view = UIView(frame: frame)


### PR DESCRIPTION
Sometimes we need to set `masksToBounds` property of `UIView` from storyboard.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
