### PR TITLE
Make √ generic for FloatingPoint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
+- **FloatingPoint**
+  - Moved the square root operator `√` from `Double` and `Float` to make it generic. [#880](https://github.com/SwifterSwift/SwifterSwift/pull/880) by [guykogus](https://github.com/guykogus)
 - **Collection**
   - Moved `indices(of:)` from `RandomAccessCollection` to find the indices of an element. [#863](https://github.com/SwifterSwift/SwifterSwift/pull/863) by [guykogus](https://github.com/guykogus)
 - **UIViewController**:

--- a/Sources/SwifterSwift/SwiftStdlib/DoubleExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DoubleExtensions.swift
@@ -52,15 +52,3 @@ func ** (lhs: Double, rhs: Double) -> Double {
     // http://nshipster.com/swift-operators/
     return pow(lhs, rhs)
 }
-
-// swiftlint:disable identifier_name
-prefix operator √
-/// SwifterSwift: Square root of double.
-///
-/// - Parameter double: double value to find square root for.
-/// - Returns: square root of given double.
-public prefix func √ (double: Double) -> Double {
-    // http://nshipster.com/swift-operators/
-    return sqrt(double)
-}
-// swiftlint:enable identifier_name

--- a/Sources/SwifterSwift/SwiftStdlib/FloatExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/FloatExtensions.swift
@@ -52,15 +52,3 @@ func ** (lhs: Float, rhs: Float) -> Float {
     // http://nshipster.com/swift-operators/
     return pow(lhs, rhs)
 }
-
-// swiftlint:disable identifier_name
-prefix operator √
-/// SwifterSwift: Square root of float.
-///
-/// - Parameter float: float value to find square root for
-/// - Returns: square root of given float.
-public prefix func √ (float: Float) -> Float {
-    // http://nshipster.com/swift-operators/
-    return sqrt(float)
-}
-// swiftlint:enable identifier_name

--- a/Sources/SwifterSwift/SwiftStdlib/FloatingPointExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/FloatingPointExtensions.swift
@@ -81,3 +81,15 @@ public prefix func ± <T: FloatingPoint> (number: T) -> (T, T) {
     return 0 ± number
 }
 // swiftlint:enable identifier_name
+
+// swiftlint:disable identifier_name
+prefix operator √
+/// SwifterSwift: Square root of float.
+///
+/// - Parameter float: float value to find square root for
+/// - Returns: square root of given float.
+public prefix func √<T> (float: T) -> T where T: FloatingPoint {
+    // http://nshipster.com/swift-operators/
+    return sqrt(float)
+}
+// swiftlint:enable identifier_name

--- a/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/DoubleExtensionsTests.swift
@@ -31,7 +31,6 @@ final class DoubleExtensionsTests: XCTestCase {
 
     func testOperators() {
         XCTAssertEqual((Double(5.0) ** Double(2.0)), Double(25.0))
-        XCTAssertEqual((√Double(25.0)), Double(5.0))
     }
 
 }

--- a/Tests/SwiftStdlibTests/FloatExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/FloatExtensionsTests.swift
@@ -31,7 +31,6 @@ final class FloatExtensionsTests: XCTestCase {
 
     func testOperators() {
         XCTAssertEqual((Float(5.0) ** Float(2.0)), Float(25.0))
-        XCTAssertEqual((√Float(25.0)), Float(5.0))
     }
 
 }

--- a/Tests/SwiftStdlibTests/FloatingPointExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/FloatingPointExtensionsTests.swift
@@ -59,9 +59,11 @@ final class FloatingPointExtensionsTests: XCTestCase {
     func testOperators() {
         XCTAssert((Float(5.0) ± Float(2.0)) == (Float(3.0), Float(7.0)) || (Float(5.0) ± Float(2.0)) == (Float(7.0), Float(3.0)))
         XCTAssert((±Float(2.0)) == (Float(2.0), Float(-2.0)) || (±Float(2.0)) == (Float(-2.0), Float(2.0)))
+        XCTAssertEqual(√Float(25.0), Float(5.0))
 
         XCTAssert((Double(5.0) ± Double(2.0)) == (Double(3.0), Double(7.0)) || (Double(5.0) ± Double(2.0)) == (Double(7.0), Double(3.0)))
         XCTAssert((±Double(2.0)) == (Double(2.0), Double(-2.0)) || (±Double(2.0)) == (Double(-2.0), Double(2.0)))
+        XCTAssertEqual(√Double(25.0), Double(5.0))
     }
 
 }


### PR DESCRIPTION
🚀
The underlying function is generic, so might as well do the same.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
