### PR TITLE
UIImage.averageColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `isStandGoalMet`, `isExerciseTimeGoalMet`, and `isEnergyBurnedGoalMet`. [#875](https://github.com/SwifterSwift/SwifterSwift/pull/875) by [lhygilbert](https://github.com/lhygilbert)
 - **UIView**:
   - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
+- **UIImage**
+  - Added `averageColor`, which calculates the average UIColor for an entire image.
 
 ### Changed
 - **NSAttributedString**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIView**:
   - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
 - **UIImage**
-  - Added `averageColor`, which calculates the average UIColor for an entire image.
+  - Added `averageColor`, which calculates the average UIColor for an entire image. [#884](https://github.com/SwifterSwift/SwifterSwift/pull/884) by [gurgeous](https://github.com/gurgeous)
 
 ### Changed
 - **NSAttributedString**:

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -261,7 +261,6 @@ public extension Color {
                      blue: max(blue - percentage, 0),
                      alpha: alpha)
     }
-
 }
 
 // MARK: - Initializers

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -261,6 +261,7 @@ public extension Color {
                      blue: max(blue - percentage, 0),
                      alpha: alpha)
     }
+
 }
 
 // MARK: - Initializers

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -36,7 +36,6 @@ public extension UIImage {
     /// SwifterSwift: Average color for this image
     func averageColor() -> UIColor? {
         // https://stackoverflow.com/questions/26330924
-        // note: self.ciImage appears to always be nil
         guard let ciImage = ciImage ?? CIImage(image: self) else { return nil }
 
         // CIAreaAverage returns a single-pixel image that contains the average color for a given region of an image.

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -32,8 +32,8 @@ public extension UIImage {
         return withRenderingMode(.alwaysTemplate)
     }
 
-    /// SwifterSwift: Average color for this image
     #if canImport(CoreImage)
+    /// SwifterSwift: Average color for this image
     func averageColor() -> UIColor? {
         // https://stackoverflow.com/questions/26330924
         guard let ciImage = CIImage(image: self) else {

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -39,7 +39,7 @@ public extension UIImage {
             return nil
         }
 
-        // run CIAreaAverage filter to get average
+        // CIAreaAverage returns a single-pixel image that contains the average color for a given region of an image.
         let parameters = [kCIInputImageKey: ciImage, kCIInputExtentKey: CIVector(cgRect: ciImage.extent)]
         guard let outputImage = CIFilter(name: "CIAreaAverage", parameters: parameters)?.outputImage else {
             return nil

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -34,7 +34,7 @@ public extension UIImage {
 
     /// SwifterSwift: Average color for this image
     #if canImport(CoreImage)
-    var averageColor: UIColor? {
+    func averageColor() -> UIColor? {
         // https://stackoverflow.com/questions/26330924
         guard let ciImage = CIImage(image: self) else {
             return nil

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -37,9 +37,7 @@ public extension UIImage {
     func averageColor() -> UIColor? {
         // https://stackoverflow.com/questions/26330924
         // note: self.ciImage appears to always be nil
-        guard let ciImage = CIImage(image: self) else {
-            return nil
-        }
+        guard let ciImage = ciImage ?? CIImage(image: self) else { return nil }
 
         // CIAreaAverage returns a single-pixel image that contains the average color for a given region of an image.
         let parameters = [kCIInputImageKey: ciImage, kCIInputExtentKey: CIVector(cgRect: ciImage.extent)]

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -36,6 +36,7 @@ public extension UIImage {
     /// SwifterSwift: Average color for this image
     func averageColor() -> UIColor? {
         // https://stackoverflow.com/questions/26330924
+        // note: self.ciImage appears to always be nil
         guard let ciImage = CIImage(image: self) else {
             return nil
         }
@@ -48,7 +49,8 @@ public extension UIImage {
 
         // After getting the single-pixel image from the filter extract pixel's RGBA8 data
         var bitmap = [UInt8](repeating: 0, count: 4)
-        let context = CIContext(options: [.workingColorSpace: NSNull()])
+        let workingColorSpace: Any = cgImage?.colorSpace ?? NSNull()
+        let context = CIContext(options: [.workingColorSpace: workingColorSpace])
         context.render(outputImage,
                        toBitmap: &bitmap,
                        rowBytes: 4,

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -32,11 +32,39 @@ public extension UIImage {
         return withRenderingMode(.alwaysTemplate)
     }
 
+    /// SwifterSwift: Average color for this image
+    var averageColor: UIColor? {
+        // https://stackoverflow.com/questions/26330924
+        guard let ciImage = CIImage(image: self) else {
+            return nil
+        }
+
+        // run CIAreaAverage filter to get average
+        let parameters = [kCIInputImageKey: ciImage, kCIInputExtentKey: CIVector(cgRect: ciImage.extent)]
+        guard let outputImage = CIFilter(name: "CIAreaAverage", parameters: parameters)?.outputImage else {
+            return nil
+        }
+
+        // extract single pixel of RGBA8 data
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        let context = CIContext(options: [.workingColorSpace: NSNull()])
+        context.render(outputImage,
+                       toBitmap: &bitmap,
+                       rowBytes: 4,
+                       bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+                       format: .RGBA8,
+                       colorSpace: nil)
+
+        // convert to UIColor
+        return UIColor(red: CGFloat(bitmap[0]) / 255.0,
+                       green: CGFloat(bitmap[1]) / 255.0,
+                       blue: CGFloat(bitmap[2]) / 255.0,
+                       alpha: CGFloat(bitmap[3]) / 255.0)
+    }
 }
 
 // MARK: - Methods
 public extension UIImage {
-
     /// SwifterSwift: Compressed UIImage from original UIImage.
     ///
     /// - Parameter quality: The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality), (default is 0.5).

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -45,7 +45,7 @@ public extension UIImage {
             return nil
         }
 
-        // extract single pixel of RGBA8 data
+        // After getting the single-pixel image from the filter extract pixel's RGBA8 data
         var bitmap = [UInt8](repeating: 0, count: 4)
         let context = CIContext(options: [.workingColorSpace: NSNull()])
         context.render(outputImage,

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -55,7 +55,7 @@ public extension UIImage {
                        format: .RGBA8,
                        colorSpace: nil)
 
-        // convert to UIColor
+        // Convert pixel data to UIColor
         return UIColor(red: CGFloat(bitmap[0]) / 255.0,
                        green: CGFloat(bitmap[1]) / 255.0,
                        blue: CGFloat(bitmap[2]) / 255.0,

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -65,6 +65,7 @@ public extension UIImage {
 
 // MARK: - Methods
 public extension UIImage {
+
     /// SwifterSwift: Compressed UIImage from original UIImage.
     ///
     /// - Parameter quality: The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality), (default is 0.5).

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -33,6 +33,7 @@ public extension UIImage {
     }
 
     /// SwifterSwift: Average color for this image
+    #if canImport(CoreImage)
     var averageColor: UIColor? {
         // https://stackoverflow.com/questions/26330924
         guard let ciImage = CIImage(image: self) else {
@@ -61,6 +62,7 @@ public extension UIImage {
                        blue: CGFloat(bitmap[2]) / 255.0,
                        alpha: CGFloat(bitmap[3]) / 255.0)
     }
+    #endif
 }
 
 // MARK: - Methods

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -13,6 +13,13 @@ import XCTest
 import UIKit
 
 final class UIImageExtensionsTests: XCTestCase {
+    func testAverageColor() {
+        // note that not all colors precisely survive the roundtrip due to CI colorspace
+        // management. Blue & brown seem safe, though.
+        let size = CGSize(width: 10, height: 5)
+        XCTAssertEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor)
+        XCTAssertEqual(UIColor.brown, UIImage(color: .brown, size: size).averageColor)
+    }
 
     func testBytesSize() {
         let bundle = Bundle.init(for: UIImageExtensionsTests.self)

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -14,11 +14,38 @@ import UIKit
 
 final class UIImageExtensionsTests: XCTestCase {
     func testAverageColor() {
-        // note that not all colors precisely survive the roundtrip due to CI colorspace
-        // management. Blue & brown seem safe, though.
+        // note that not all colors precisely survive the roundtrip due to colorspace
+        // management. Use XCTAssertEqual w/ accuracy.
+        func assertColorsEqual(_ color1: UIColor, _ color2: UIColor, accuracy: CGFloat = 0.01) {
+            var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
+            var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
+            color1.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+            color2.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+            XCTAssertEqual(r1, r2, accuracy: accuracy)
+            XCTAssertEqual(g1, g2, accuracy: accuracy)
+            XCTAssertEqual(b1, b2, accuracy: accuracy)
+            XCTAssertEqual(a1, a2, accuracy: accuracy)
+        }
+
         let size = CGSize(width: 10, height: 5)
-        XCTAssertEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor())
-        XCTAssertEqual(UIColor.brown, UIImage(color: .brown, size: size).averageColor())
+
+        // simple fill test
+        assertColorsEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor()!)
+        assertColorsEqual(UIColor.orange, UIImage(color: .orange, size: size).averageColor()!)
+
+        // more interesting - red + green = yellow
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let yellow = renderer.image {
+            var rect = CGRect(x: 0, y: 0, width: size.width / 2, height: size.height)
+            for color in [ UIColor.red, UIColor.green ] {
+                $0.cgContext.beginPath()
+                $0.cgContext.setFillColor(color.cgColor)
+                $0.cgContext.addRect(rect)
+                $0.cgContext.fillPath()
+                rect.origin.x += rect.size.width
+            }
+        }
+        assertColorsEqual(UIColor(red: 0.5, green: 0.5, blue: 0, alpha: 1), yellow.averageColor()!)
     }
 
     func testBytesSize() {

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -14,24 +14,11 @@ import UIKit
 
 final class UIImageExtensionsTests: XCTestCase {
     func testAverageColor() {
-        // note that not all colors precisely survive the roundtrip due to colorspace
-        // management. Use XCTAssertEqual w/ accuracy.
-        func assertColorsEqual(_ color1: UIColor, _ color2: UIColor, accuracy: CGFloat = 0.01) {
-            var r1: CGFloat = 0, g1: CGFloat = 0, b1: CGFloat = 0, a1: CGFloat = 0
-            var r2: CGFloat = 0, g2: CGFloat = 0, b2: CGFloat = 0, a2: CGFloat = 0
-            color1.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
-            color2.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
-            XCTAssertEqual(r1, r2, accuracy: accuracy)
-            XCTAssertEqual(g1, g2, accuracy: accuracy)
-            XCTAssertEqual(b1, b2, accuracy: accuracy)
-            XCTAssertEqual(a1, a2, accuracy: accuracy)
-        }
-
         let size = CGSize(width: 10, height: 5)
 
         // simple fill test
-        assertColorsEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor()!)
-        assertColorsEqual(UIColor.orange, UIImage(color: .orange, size: size).averageColor()!)
+        XCTAssertEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor()!, accuracy: 0.01)
+        XCTAssertEqual(UIColor.orange, UIImage(color: .orange, size: size).averageColor()!, accuracy: 0.01)
 
         // more interesting - red + green = yellow
         let renderer = UIGraphicsImageRenderer(size: size)
@@ -45,7 +32,7 @@ final class UIImageExtensionsTests: XCTestCase {
                 rect.origin.x += rect.size.width
             }
         }
-        assertColorsEqual(UIColor(red: 0.5, green: 0.5, blue: 0, alpha: 1), yellow.averageColor()!)
+        XCTAssertEqual(UIColor(red: 0.5, green: 0.5, blue: 0, alpha: 1), yellow.averageColor()!, accuracy: 0.01)
     }
 
     func testBytesSize() {

--- a/Tests/UIKitTests/UIImageExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageExtensionsTests.swift
@@ -17,8 +17,8 @@ final class UIImageExtensionsTests: XCTestCase {
         // note that not all colors precisely survive the roundtrip due to CI colorspace
         // management. Blue & brown seem safe, though.
         let size = CGSize(width: 10, height: 5)
-        XCTAssertEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor)
-        XCTAssertEqual(UIColor.brown, UIImage(color: .brown, size: size).averageColor)
+        XCTAssertEqual(UIColor.blue, UIImage(color: .blue, size: size).averageColor())
+        XCTAssertEqual(UIColor.brown, UIImage(color: .brown, size: size).averageColor())
     }
 
     func testBytesSize() {


### PR DESCRIPTION
Calculates the average color for an entire UIImage. This is useful for determining whether an image is light or dark, among other things. See #879.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
