### PR TITLE
constraint finders (widthConstraint, heightConstraint, leadingConstraint, trailingConstraint, topConstraint, bottomConstraint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `isStandGoalMet`, `isExerciseTimeGoalMet`, and `isEnergyBurnedGoalMet`. [#875](https://github.com/SwifterSwift/SwifterSwift/pull/875) by [lhygilbert](https://github.com/lhygilbert)
 - **UIView**:
   - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
-  - Added `widthConstraint`, `heightConstraint`, `leadingConstraint`, `trailingConstraint`, `topConstraint`, and `bottomConstraint` for finding existing constraints
+  - Added `findConstraint` for finding an existing constraint
+  - Added `widthConstraint`, `heightConstraint`, `leadingConstraint`, `trailingConstraint`, `topConstraint`, and `bottomConstraint` for finding specific constraints
 
 ### Changed
 - **NSAttributedString**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `isStandGoalMet`, `isExerciseTimeGoalMet`, and `isEnergyBurnedGoalMet`. [#875](https://github.com/SwifterSwift/SwifterSwift/pull/875) by [lhygilbert](https://github.com/lhygilbert)
 - **UIView**:
   - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
+  - Added `widthConstraint`, `heightConstraint`, `leadingConstraint`, `trailingConstraint`, `topConstraint`, and `bottomConstraint` for finding existing constraints
 
 ### Changed
 - **NSAttributedString**:

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -232,54 +232,6 @@ public extension UIView {
             frame.origin.y = newValue
         }
     }
-
-    /// SwifterSwift: Return constraints for this view. This must enumerate superviews.
-    var allConstraints: [NSLayoutConstraint] {
-        // https://stackoverflow.com/questions/47053727
-
-        // build array of self and all superviews
-        var views = [self]
-        var current = self
-        while let superview = current.superview {
-            views.append(superview)
-            current = superview
-        }
-
-        // now collect constraints affecting this view
-        return views.flatMap { $0.constraints }.filter {
-            $0.firstItem as? UIView == self || $0.secondItem as? UIView == self
-        }
-    }
-
-    /// SwifterSwift: First width constraint for this view
-    var widthConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .width)
-    }
-
-    /// SwifterSwift: First height constraint for this view
-    var heightConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .height)
-    }
-
-    /// SwifterSwift: First leading constraint for this view
-    var leadingConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .leading)
-    }
-
-    /// SwifterSwift: First trailing constraint for this view
-    var trailingConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .trailing)
-    }
-
-    /// SwifterSwift: First top constraint for this view
-    var topConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .top)
-    }
-
-    /// SwifterSwift: First bottom constraint for this view
-    var bottomConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .bottom)
-    }
 }
 
 // MARK: - Methods
@@ -626,6 +578,27 @@ public extension UIView {
     func ancestorView<T: UIView>(withClass name: T.Type) -> T? {
         return ancestorView(where: { $0 is T }) as? T
     }
+}
+
+// MARK: - findConstraint and friends
+public extension UIView {
+    /// SwifterSwift: Return constraints for this view. This must enumerate superviews.
+    var allConstraints: [NSLayoutConstraint] {
+        // https://stackoverflow.com/questions/47053727
+
+        // build array of self and all superviews
+        var views = [self]
+        var current = self
+        while let superview = current.superview {
+            views.append(superview)
+            current = superview
+        }
+
+        // now collect constraints affecting this view
+        return views.flatMap { $0.constraints }.filter {
+            $0.firstItem as? UIView == self || $0.secondItem as? UIView == self
+        }
+    }
 
     /// SwifterSwift: Search constraints for this view until we find one for the given attribute.
     ///
@@ -640,6 +613,36 @@ public extension UIView {
             ($0.firstAttribute == attribute && $0.firstItem as? UIView == self) ||
             ($0.secondAttribute == attribute && $0.secondItem as? UIView == self)
         }
+    }
+
+    /// SwifterSwift: First width constraint for this view
+    var widthConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .width)
+    }
+
+    /// SwifterSwift: First height constraint for this view
+    var heightConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .height)
+    }
+
+    /// SwifterSwift: First leading constraint for this view
+    var leadingConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .leading)
+    }
+
+    /// SwifterSwift: First trailing constraint for this view
+    var trailingConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .trailing)
+    }
+
+    /// SwifterSwift: First top constraint for this view
+    var topConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .top)
+    }
+
+    /// SwifterSwift: First bottom constraint for this view
+    var bottomConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .bottom)
     }
 }
 

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -632,6 +632,10 @@ public extension UIView {
     /// - Parameter attribute: the attribute to find
     /// - Returns: matching constraint
     func findConstraint(attribute: NSLayoutConstraint.Attribute) -> NSLayoutConstraint? {
+        // This is a bit subtle. While looking for .height, it's entirely
+        // possible that firstAttribute is .height but firstItem is not self
+        // (secondItem would be self in that case). That's not what we want to
+        // return.
         allConstraints.first {
             ($0.firstAttribute == attribute && $0.firstItem as? UIView == self) ||
             ($0.secondAttribute == attribute && $0.secondItem as? UIView == self)

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -582,67 +582,47 @@ public extension UIView {
 
 // MARK: - findConstraint and friends
 public extension UIView {
-    /// SwifterSwift: Return constraints for this view. This must enumerate superviews.
-    var allConstraints: [NSLayoutConstraint] {
-        // https://stackoverflow.com/questions/47053727
-
-        // build array of self and all superviews
-        var views = [self]
-        var current = self
-        while let superview = current.superview {
-            views.append(superview)
-            current = superview
-        }
-
-        // now collect constraints affecting this view
-        return views.flatMap { $0.constraints }.filter {
-            $0.firstItem as? UIView == self || $0.secondItem as? UIView == self
-        }
-    }
-
-    /// SwifterSwift: Search constraints for this view until we find one for the given attribute.
+    /// SwifterSwift: Search constraints until we find one for the given view and attribute. This will enumerate ancestors since constraints are always added to the common ancestor.
     ///
+    /// - Parameter view: the view to find
     /// - Parameter attribute: the attribute to find
     /// - Returns: matching constraint
-    func findConstraint(attribute: NSLayoutConstraint.Attribute) -> NSLayoutConstraint? {
-        // This is a bit subtle. While looking for .height, it's entirely
-        // possible that firstAttribute is .height but firstItem is not self
-        // (secondItem would be self in that case). That's not what we want to
-        // return.
-        allConstraints.first {
-            ($0.firstAttribute == attribute && $0.firstItem as? UIView == self) ||
-            ($0.secondAttribute == attribute && $0.secondItem as? UIView == self)
+    func findConstraint(view: UIView, attribute: NSLayoutConstraint.Attribute) -> NSLayoutConstraint? {
+        let constraint = constraints.first {
+            ($0.firstAttribute == attribute && $0.firstItem as? UIView == view) ||
+            ($0.secondAttribute == attribute && $0.secondItem as? UIView == view)
         }
+        return constraint ?? superview?.findConstraint(view: view, attribute: attribute)
     }
 
     /// SwifterSwift: First width constraint for this view
     var widthConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .width)
+        findConstraint(view: self, attribute: .width)
     }
 
     /// SwifterSwift: First height constraint for this view
     var heightConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .height)
+        findConstraint(view: self, attribute: .height)
     }
 
     /// SwifterSwift: First leading constraint for this view
     var leadingConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .leading)
+        findConstraint(view: self, attribute: .leading)
     }
 
     /// SwifterSwift: First trailing constraint for this view
     var trailingConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .trailing)
+        findConstraint(view: self, attribute: .trailing)
     }
 
     /// SwifterSwift: First top constraint for this view
     var topConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .top)
+        findConstraint(view: self, attribute: .top)
     }
 
     /// SwifterSwift: First bottom constraint for this view
     var bottomConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .bottom)
+        findConstraint(view: self, attribute: .bottom)
     }
 }
 

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -589,42 +589,42 @@ public extension UIView {
     /// - Parameter attribute: the attribute to find
     /// - Parameter at: the view to find
     /// - Returns: matching constraint
-    func findConstraint(attribute: NSLayoutConstraint.Attribute, at view: UIView) -> NSLayoutConstraint? {
+    func findConstraint(attribute: NSLayoutConstraint.Attribute, for view: UIView) -> NSLayoutConstraint? {
         let constraint = constraints.first {
             ($0.firstAttribute == attribute && $0.firstItem as? UIView == view) ||
             ($0.secondAttribute == attribute && $0.secondItem as? UIView == view)
         }
-        return constraint ?? superview?.findConstraint(attribute: attribute, at: view)
+        return constraint ?? superview?.findConstraint(attribute: attribute, for: view)
     }
 
     /// SwifterSwift: First width constraint for this view
     var widthConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .width, at: self)
+        findConstraint(attribute: .width, for: self)
     }
 
     /// SwifterSwift: First height constraint for this view
     var heightConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .height, at: self)
+        findConstraint(attribute: .height, for: self)
     }
 
     /// SwifterSwift: First leading constraint for this view
     var leadingConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .leading, at: self)
+        findConstraint(attribute: .leading, for: self)
     }
 
     /// SwifterSwift: First trailing constraint for this view
     var trailingConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .trailing, at: self)
+        findConstraint(attribute: .trailing, for: self)
     }
 
     /// SwifterSwift: First top constraint for this view
     var topConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .top, at: self)
+        findConstraint(attribute: .top, for: self)
     }
 
     /// SwifterSwift: First bottom constraint for this view
     var bottomConstraint: NSLayoutConstraint? {
-        findConstraint(attribute: .bottom, at: self)
+        findConstraint(attribute: .bottom, for: self)
     }
 }
 

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -233,6 +233,53 @@ public extension UIView {
         }
     }
 
+    /// SwifterSwift: Return constraints for this view. This must enumerate superviews.
+    var allConstraints: [NSLayoutConstraint] {
+        // https://stackoverflow.com/questions/47053727
+
+        // build array of self and all superviews
+        var views = [self]
+        var current = self
+        while let superview = current.superview {
+            views.append(superview)
+            current = superview
+        }
+
+        // now collect constraints affecting this view
+        return views.flatMap { $0.constraints }.filter {
+            $0.firstItem as? UIView == self || $0.secondItem as? UIView == self
+        }
+    }
+
+    /// SwifterSwift: First width constraint for this view
+    var widthConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .width)
+    }
+
+    /// SwifterSwift: First height constraint for this view
+    var heightConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .height)
+    }
+
+    /// SwifterSwift: First leading constraint for this view
+    var leadingConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .leading)
+    }
+
+    /// SwifterSwift: First trailing constraint for this view
+    var trailingConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .trailing)
+    }
+
+    /// SwifterSwift: First top constraint for this view
+    var topConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .top)
+    }
+
+    /// SwifterSwift: First bottom constraint for this view
+    var bottomConstraint: NSLayoutConstraint? {
+        findConstraint(attribute: .bottom)
+    }
 }
 
 // MARK: - Methods
@@ -580,6 +627,16 @@ public extension UIView {
         return ancestorView(where: { $0 is T }) as? T
     }
 
+    /// SwifterSwift: Search constraints for this view until we find one for the given attribute.
+    ///
+    /// - Parameter attribute: the attribute to find
+    /// - Returns: matching constraint
+    func findConstraint(attribute: NSLayoutConstraint.Attribute) -> NSLayoutConstraint? {
+        allConstraints.first {
+            ($0.firstAttribute == attribute && $0.firstItem as? UIView == self) ||
+            ($0.secondAttribute == attribute && $0.secondItem as? UIView == self)
+        }
+    }
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -580,49 +580,51 @@ public extension UIView {
     }
 }
 
-// MARK: - findConstraint and friends
+// MARK: - Constraints
 public extension UIView {
-    /// SwifterSwift: Search constraints until we find one for the given view and attribute. This will enumerate ancestors since constraints are always added to the common ancestor.
+    /// SwifterSwift: Search constraints until we find one for the given view
+    /// and attribute. This will enumerate ancestors since constraints are
+    /// always added to the common ancestor.
     ///
-    /// - Parameter view: the view to find
     /// - Parameter attribute: the attribute to find
+    /// - Parameter at: the view to find
     /// - Returns: matching constraint
-    func findConstraint(view: UIView, attribute: NSLayoutConstraint.Attribute) -> NSLayoutConstraint? {
+    func findConstraint(attribute: NSLayoutConstraint.Attribute, at view: UIView) -> NSLayoutConstraint? {
         let constraint = constraints.first {
             ($0.firstAttribute == attribute && $0.firstItem as? UIView == view) ||
             ($0.secondAttribute == attribute && $0.secondItem as? UIView == view)
         }
-        return constraint ?? superview?.findConstraint(view: view, attribute: attribute)
+        return constraint ?? superview?.findConstraint(attribute: attribute, at: view)
     }
 
     /// SwifterSwift: First width constraint for this view
     var widthConstraint: NSLayoutConstraint? {
-        findConstraint(view: self, attribute: .width)
+        findConstraint(attribute: .width, at: self)
     }
 
     /// SwifterSwift: First height constraint for this view
     var heightConstraint: NSLayoutConstraint? {
-        findConstraint(view: self, attribute: .height)
+        findConstraint(attribute: .height, at: self)
     }
 
     /// SwifterSwift: First leading constraint for this view
     var leadingConstraint: NSLayoutConstraint? {
-        findConstraint(view: self, attribute: .leading)
+        findConstraint(attribute: .leading, at: self)
     }
 
     /// SwifterSwift: First trailing constraint for this view
     var trailingConstraint: NSLayoutConstraint? {
-        findConstraint(view: self, attribute: .trailing)
+        findConstraint(attribute: .trailing, at: self)
     }
 
     /// SwifterSwift: First top constraint for this view
     var topConstraint: NSLayoutConstraint? {
-        findConstraint(view: self, attribute: .top)
+        findConstraint(attribute: .top, at: self)
     }
 
     /// SwifterSwift: First bottom constraint for this view
     var bottomConstraint: NSLayoutConstraint? {
-        findConstraint(view: self, attribute: .bottom)
+        findConstraint(attribute: .bottom, at: self)
     }
 }
 

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -478,11 +478,11 @@ final class UIViewExtensionsTests: XCTestCase {
             view.widthAnchor.constraint(equalToConstant: 1),
             container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3)
         ])
-        XCTAssertNotNil(view.findConstraint(attribute: .width, at: view))
-        XCTAssertNil(view.findConstraint(attribute: .height, at: view))
+        XCTAssertNotNil(view.findConstraint(attribute: .width, for: view))
+        XCTAssertNil(view.findConstraint(attribute: .height, for: view))
 
         // pathological case
-        XCTAssertNil(view.findConstraint(attribute: .height, at: UIView()))
+        XCTAssertNil(view.findConstraint(attribute: .height, for: UIView()))
     }
 
     func testConstraintProperties() {

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -474,10 +474,15 @@ final class UIViewExtensionsTests: XCTestCase {
         let view = UIView()
         let container = UIView()
         container.addSubview(view)
-        view.widthAnchor.constraint(equalToConstant: 1).isActive = true
-        container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3).isActive = true
-        XCTAssertNotNil(view.findConstraint(view: view, attribute: .width))
-        XCTAssertNil(view.findConstraint(view: view, attribute: .height))
+        NSLayoutConstraint.activate([
+            view.widthAnchor.constraint(equalToConstant: 1),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3)
+        ])
+        XCTAssertNotNil(view.findConstraint(attribute: .width, at: view))
+        XCTAssertNil(view.findConstraint(attribute: .height, at: view))
+
+        // pathological case
+        XCTAssertNil(view.findConstraint(attribute: .height, at: UIView()))
     }
 
     func testConstraintProperties() {
@@ -486,12 +491,14 @@ final class UIViewExtensionsTests: XCTestCase {
         container.addSubview(view)
 
         // setup constraints, some in container and some in view
-        view.widthAnchor.constraint(equalToConstant: 1).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 2).isActive = true
-        container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3).isActive = true
-        container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 4).isActive = true
-        view.topAnchor.constraint(equalTo: container.topAnchor, constant: 5).isActive = true
-        view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: 6).isActive = true
+        NSLayoutConstraint.activate([
+            view.widthAnchor.constraint(equalToConstant: 1),
+            view.heightAnchor.constraint(equalToConstant: 2),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3),
+            container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 4),
+            view.topAnchor.constraint(equalTo: container.topAnchor, constant: 5),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: 6)
+        ])
 
         // find them
         XCTAssertEqual(view.widthConstraint!.constant, 1)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -470,6 +470,31 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(buttonSubview.ancestorView(withClass: UITableView.self), tableView)
     }
 
+    func testConstraintFinders() {
+        let container = UIView()
+        let view = UIView()
+        container.addSubview(view)
+
+        // setup constraints, some in container and some in view
+        view.widthAnchor.constraint(equalToConstant: 1).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 2).isActive = true
+        container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3).isActive = true
+        container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 4).isActive = true
+        view.topAnchor.constraint(equalTo: container.topAnchor, constant: 5).isActive = true
+        view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: 6).isActive = true
+        XCTAssertEqual(view.allConstraints.count, 6)
+
+        // find them
+        XCTAssertEqual(view.widthConstraint!.constant, 1)
+        XCTAssertEqual(view.heightConstraint!.constant, 2)
+        XCTAssertEqual(view.leadingConstraint!.constant, 3)
+        XCTAssertEqual(view.trailingConstraint!.constant, 4)
+        XCTAssertEqual(view.topConstraint!.constant, 5)
+        XCTAssertEqual(view.bottomConstraint!.constant, 6)
+
+        // simple empty case test
+        XCTAssertNil(container.widthConstraint)
+    }
 }
 
 #endif

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -470,7 +470,17 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(buttonSubview.ancestorView(withClass: UITableView.self), tableView)
     }
 
-    func testConstraintFinders() {
+    func testFindConstraint() {
+        let view = UIView()
+        let container = UIView()
+        container.addSubview(view)
+        view.widthAnchor.constraint(equalToConstant: 1).isActive = true
+        container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 3).isActive = true
+        XCTAssertNotNil(view.findConstraint(view: view, attribute: .width))
+        XCTAssertNil(view.findConstraint(view: view, attribute: .height))
+    }
+
+    func testConstraintProperties() {
         let container = UIView()
         let view = UIView()
         container.addSubview(view)
@@ -482,7 +492,6 @@ final class UIViewExtensionsTests: XCTestCase {
         container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 4).isActive = true
         view.topAnchor.constraint(equalTo: container.topAnchor, constant: 5).isActive = true
         view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: 6).isActive = true
-        XCTAssertEqual(view.allConstraints.count, 6)
 
         // find them
         XCTAssertEqual(view.widthConstraint!.constant, 1)


### PR DESCRIPTION
Handy helpers for finding existing constraints on a view. Under the hood they use `allConstraints`, which enumerates all ancestors to find all constraints for a view. See #879.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
