### PR TITLE
Added note for UIView.addShadow()

### DIFF
--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -270,7 +270,7 @@ public extension UIView {
 
     /// SwifterSwift: Add shadow to view.
     ///
-    /// - Note: This method only works with non-clear background color, or set a `shadowPath`.
+    /// - Note: This method only works with non-clear background color, or if the view has a `shadowPath` set.
     /// See parameter `opacity` for detail.
     ///
     /// - Parameters:

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -270,11 +270,14 @@ public extension UIView {
 
     /// SwifterSwift: Add shadow to view.
     ///
+    /// - Note: This method only works with non-clear background color, or set a `shadowPath`.
+    /// See parameter `opacity` for detail.
+    ///
     /// - Parameters:
     ///   - color: shadow color (default is #137992).
     ///   - radius: shadow radius (default is 3).
     ///   - offset: shadow offset (default is .zero).
-    ///   - opacity: shadow opacity (default is 0.5).
+    ///   - opacity: shadow opacity (default is 0.5). It will also be affected by the `alpha` of `backgroundColor`
     func addShadow(ofColor color: UIColor = UIColor(red: 0.07, green: 0.47, blue: 0.57, alpha: 1.0), radius: CGFloat = 3, offset: CGSize = .zero, opacity: Float = 0.5) {
         layer.shadowColor = color.cgColor
         layer.shadowOffset = offset


### PR DESCRIPTION
Added a note that I often forget to UIView addShadow(ofColor: radius: offset: opacity:)

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
