### PR TITLE
Rename conflicting UIView shadowExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
 ## Upcoming Release
-
+### Breaking Change
+- **UIView**
+  - Rename `shadowColor`, `shadowOffset`, `shadowOpacity` and `shadowRadius` to `layerShadowColor`, `layerShadowOffset`, `layerShadowOpacity` and `layerShadowRadius` to avoid naming colisions with subclasses properties defined in other modules e.g. UIKit. [#897](https://github.com/SwifterSwift/SwifterSwift/pull/897) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 ### Added
 - **UIScrollView**
   - Added `visibleRect`, `scrollToTop(animated:)`, `scrollToLeft(animated:)`, `scrollToBottom(animated:)`, `scrollToRight(animated:)`, `scrollUp(animated:)`, `scrollLeft(animated:)`, `scrollDown(animated:)`, `scrollRight(animated:)`. [#888](https://github.com/SwifterSwift/SwifterSwift/pull/888) by [guykogus](https://github.com/guykogus)

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -130,7 +130,7 @@ public extension UIView {
     }
 
     /// SwifterSwift: Shadow color of view; also inspectable from Storyboard.
-    @IBInspectable var shadowColor: UIColor? {
+    @IBInspectable var layerShadowColor: UIColor? {
         get {
             guard let color = layer.shadowColor else { return nil }
             return UIColor(cgColor: color)
@@ -141,7 +141,7 @@ public extension UIView {
     }
 
     /// SwifterSwift: Shadow offset of view; also inspectable from Storyboard.
-    @IBInspectable var shadowOffset: CGSize {
+    @IBInspectable var layerShadowOffset: CGSize {
         get {
             return layer.shadowOffset
         }
@@ -151,7 +151,7 @@ public extension UIView {
     }
 
     /// SwifterSwift: Shadow opacity of view; also inspectable from Storyboard.
-    @IBInspectable var shadowOpacity: Float {
+    @IBInspectable var layerShadowOpacity: Float {
         get {
             return layer.shadowOpacity
         }
@@ -161,7 +161,7 @@ public extension UIView {
     }
 
     /// SwifterSwift: Shadow radius of view; also inspectable from Storyboard.
-    @IBInspectable var shadowRadius: CGFloat {
+    @IBInspectable var layerShadowRadius: CGFloat {
         get {
             return layer.shadowRadius
         }

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -101,10 +101,10 @@ final class UIViewExtensionsTests: XCTestCase {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let view = UIView(frame: frame)
         view.layer.shadowColor = nil
-        XCTAssertNil(view.shadowColor)
-        view.shadowColor = UIColor.orange
+        XCTAssertNil(view.layerShadowColor)
+        view.layerShadowColor = UIColor.orange
         XCTAssertNotNil(view.layer.shadowColor!)
-        XCTAssertEqual(view.shadowColor, UIColor.orange)
+        XCTAssertEqual(view.layerShadowColor, UIColor.orange)
     }
 
     func testScreenshot() {
@@ -122,9 +122,9 @@ final class UIViewExtensionsTests: XCTestCase {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let view = UIView(frame: frame)
         view.layer.shadowOffset = CGSize.zero
-        XCTAssertEqual(view.shadowOffset, CGSize.zero)
+        XCTAssertEqual(view.layerShadowOffset, CGSize.zero)
         let size = CGSize(width: 5, height: 5)
-        view.shadowOffset = size
+        view.layerShadowOffset = size
         XCTAssertEqual(view.layer.shadowOffset, size)
     }
 
@@ -132,8 +132,8 @@ final class UIViewExtensionsTests: XCTestCase {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let view = UIView(frame: frame)
         view.layer.shadowOpacity = 0
-        XCTAssertEqual(view.shadowOpacity, 0)
-        view.shadowOpacity = 0.5
+        XCTAssertEqual(view.layerShadowOpacity, 0)
+        view.layerShadowOpacity = 0.5
         XCTAssertEqual(view.layer.shadowOpacity, 0.5)
     }
 
@@ -141,8 +141,8 @@ final class UIViewExtensionsTests: XCTestCase {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let view = UIView(frame: frame)
         view.layer.shadowRadius = 0
-        XCTAssertEqual(view.shadowRadius, 0)
-        view.shadowRadius = 0.5
+        XCTAssertEqual(view.layerShadowRadius, 0)
+        view.layerShadowRadius = 0.5
         XCTAssertEqual(view.layer.shadowRadius, 0.5)
     }
 
@@ -150,10 +150,10 @@ final class UIViewExtensionsTests: XCTestCase {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         let view = UIView(frame: frame)
         view.addShadow(ofColor: .red, radius: 5.0, offset: .zero, opacity: 0.5)
-        XCTAssertEqual(view.shadowColor, UIColor.red)
-        XCTAssertEqual(view.shadowRadius, 5.0)
-        XCTAssertEqual(view.shadowOffset, CGSize.zero)
-        XCTAssertEqual(view.shadowOpacity, 0.5)
+        XCTAssertEqual(view.layerShadowColor, UIColor.red)
+        XCTAssertEqual(view.layerShadowRadius, 5.0)
+        XCTAssertEqual(view.layerShadowOffset, CGSize.zero)
+        XCTAssertEqual(view.layerShadowOpacity, 0.5)
     }
 
     func testMasksToBounds() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #622 

* This may cause issues in users who use those properties in storyboard as `@IBInspectable`.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
