### PR TITLE
extensions & tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **String**:
   - Overloaded Swift's 'contains' operator (`~=`) for `String` to check regex matching. [#858](https://github.com/SwifterSwift/SwifterSwift/pull/858) by [VatoKo](https://github.com/VatoKo)
   - `regexEscaped`, which returns an escaped string for inclusion in a regex pattern
+  - Added `matches(regex:options:)` and the `~= regex` to check directly against NSRegularExpression. Also added `replacingOccurrences(pattern:template:searchRange:)` and `replacingOccurrences(regex:template:searchRange:)` as a more convenient way to replace patterns and NSRegularExpressions. 
+[#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **DispatchQueue**:
   - Added `asyncAfter(delay:qos:flags:execute:)` method to use it more conveniently without typing unnecessary `.now() + delay`. [#859](https://github.com/SwifterSwift/SwifterSwift/pull/859) by [VatoKo](https://github.com/VatoKo)
   - Re-added `debounce(delay:action:)` for only executing a closure once using a throttle delay. [#869](https://github.com/SwifterSwift/SwifterSwift/pull/869) by [guykogus](https://github.com/guykogus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **String**:
   - Overloaded Swift's 'contains' operator (`~=`) for `String` to check regex matching. [#858](https://github.com/SwifterSwift/SwifterSwift/pull/858) by [VatoKo](https://github.com/VatoKo)
   - `regexEscaped`, which returns an escaped string for inclusion in a regex pattern
-  - Added `matches(regex:options:)` and the `~= regex` to check directly against NSRegularExpression. Also added `replacingOccurrences(regex:template:searchRange:)` as a more convenient way to replace NSRegularExpressions. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
+  - Added `matches(regex:options:)` and the `~= regex` to check directly against NSRegularExpression. Also added `replacingOccurrences(regex:template:options:searchRange:)` as a more convenient way to replace NSRegularExpressions. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **DispatchQueue**:
   - Added `asyncAfter(delay:qos:flags:execute:)` method to use it more conveniently without typing unnecessary `.now() + delay`. [#859](https://github.com/SwifterSwift/SwifterSwift/pull/859) by [VatoKo](https://github.com/VatoKo)
   - Re-added `debounce(delay:action:)` for only executing a closure once using a throttle delay. [#869](https://github.com/SwifterSwift/SwifterSwift/pull/869) by [guykogus](https://github.com/guykogus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **String**:
   - Overloaded Swift's 'contains' operator (`~=`) for `String` to check regex matching. [#858](https://github.com/SwifterSwift/SwifterSwift/pull/858) by [VatoKo](https://github.com/VatoKo)
   - `regexEscaped`, which returns an escaped string for inclusion in a regex pattern
-  - Added `matches(regex:options:)` and the `~= regex` to check directly against NSRegularExpression. Also added `replacingOccurrences(pattern:template:searchRange:)` and `replacingOccurrences(regex:template:searchRange:)` as a more convenient way to replace patterns and NSRegularExpressions. 
-[#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
+  - Added `matches(regex:options:)` and the `~= regex` to check directly against NSRegularExpression. Also added `replacingOccurrences(regex:template:searchRange:)` as a more convenient way to replace NSRegularExpressions. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **DispatchQueue**:
   - Added `asyncAfter(delay:qos:flags:execute:)` method to use it more conveniently without typing unnecessary `.now() + delay`. [#859](https://github.com/SwifterSwift/SwifterSwift/pull/859) by [VatoKo](https://github.com/VatoKo)
   - Re-added `debounce(delay:action:)` for only executing a closure once using a throttle delay. [#869](https://github.com/SwifterSwift/SwifterSwift/pull/869) by [guykogus](https://github.com/guykogus)
@@ -45,6 +44,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `loadFromNib(withClass:)`, which loads a UIView of a particular type from a nib file. [#885](https://github.com/SwifterSwift/SwifterSwift/pull/885) by [gurgeous](https://github.com/gurgeous)
   - Added `findConstraint` for finding an existing constraint. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/886) by [gurgeous]
   - Added `widthConstraint`, `heightConstraint`, `leadingConstraint`, `trailingConstraint`, `topConstraint`, and `bottomConstraint` for finding specific constraints. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/886) by [gurgeous]
+- **StringProtocol**
+  - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 
 ### Changed
 - **NSAttributedString**:

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -968,6 +968,17 @@ public extension String {
     #endif
 
     #if canImport(Foundation)
+    /// SwifterSwift: Verify if string matches the regex.
+    ///
+    /// - Parameter regex: Regex to verify.
+    /// - Returns: true if string matches the regex.
+    func matches(regex: NSRegularExpression) -> Bool {
+        let range = NSRange(location: 0, length: utf16.count)
+        return regex.firstMatch(in: self, options: [], range: range) != nil
+    }
+    #endif
+
+    #if canImport(Foundation)
     /// SwifterSwift: Overload Swift's 'contains' operator for matching regex pattern
     ///
     /// - Parameter lhs: String to check on regex pattern.
@@ -975,6 +986,50 @@ public extension String {
     /// - Returns: true if string matches the pattern.
     static func ~= (lhs: String, rhs: String) -> Bool {
         return lhs.range(of: rhs, options: .regularExpression) != nil
+    }
+    #endif
+
+    #if canImport(Foundation)
+    /// SwifterSwift: Overload Swift's 'contains' operator for matching regex
+    ///
+    /// - Parameter lhs: String to check on regex.
+    /// - Parameter rhs: Regex to match against.
+    /// - Returns: true if string matches the regex.
+    static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
+        let range = NSRange(location: 0, length: lhs.utf16.count)
+        return rhs.firstMatch(in: lhs, options: [], range: range) != nil
+    }
+    #endif
+
+    #if canImport(Foundation)
+    /// SwifterSwift: Returns a new string in which all occurrences of a regex pattern in a specified range of the receiver are replaced by the template.
+    /// - Parameter pattern: Regex pattern to replace.
+    /// - Parameter template: The regex template to replace the pattern.
+    /// - Parameter searchRange: The range in the receiver in which to search.
+    /// - Returns: A new string in which all occurrences of regex pattern in searchRange of the receiver are replaced by template.
+    func replacingOccurrences(of pattern: String, with template: String,
+                              range searchRange: Range<String.Index>? = nil) -> String {
+        return replacingOccurrences(of: pattern, with: template, options: .regularExpression, range: searchRange)
+    }
+    #endif
+
+    #if canImport(Foundation)
+    /// SwifterSwift: Returns a new string in which all occurrences of a regex in a specified range of the receiver are replaced by the template.
+    /// - Parameter regex: Regex to replace.
+    /// - Parameter template: The template to replace the regex.
+    /// - Parameter searchRange: The range in the receiver in which to search.
+    /// - Returns: A new string in which all occurrences of regex in searchRange of the receiver are replaced by template.
+    func replacingOccurrences(
+        of regex: NSRegularExpression,
+        with template: String,
+        range searchRange: Range<String.Index>? = nil) -> String {
+        let range: NSRange
+        if let searchRange = searchRange {
+            range = NSRange(searchRange, in: self)
+        } else {
+            range = NSRange(location: 0, length: utf16.count)
+        }
+        return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: template)
     }
     #endif
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -974,7 +974,7 @@ public extension String {
     /// - Parameter options: The matching options to use.
     /// - Returns: true if string matches the regex.
     func matches(regex: NSRegularExpression, options: NSRegularExpression.MatchingOptions = []) -> Bool {
-        let range = NSRange(location: 0, length: utf16.count)
+        let range = NSRange(startIndex..<endIndex, in: self)
         return regex.firstMatch(in: self, options: options, range: range) != nil
     }
     #endif

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -961,7 +961,7 @@ public extension String {
     /// SwifterSwift: Verify if string matches the regex pattern.
     ///
     /// - Parameter pattern: Pattern to verify.
-    /// - Returns: true if string matches the pattern.
+    /// - Returns: `true` if string matches the pattern.
     func matches(pattern: String) -> Bool {
         return range(of: pattern, options: .regularExpression, range: nil, locale: nil) != nil
     }
@@ -997,7 +997,7 @@ public extension String {
     /// - Parameter rhs: Regex to match against.
     /// - Returns: `true` if there is at least one match for the regex in the string.
     static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
-        let range = NSRange(startIndex..<endIndex, in: self)
+        let range = NSRange(lhs.startIndex..<lhs.endIndex, in: lhs)
         return rhs.firstMatch(in: lhs, range: range) != nil
     }
     #endif
@@ -1024,7 +1024,7 @@ public extension String {
         of regex: NSRegularExpression,
         with template: String,
         range searchRange: Range<String.Index>? = nil) -> String {
-        let range =NSRange(searchRange ?? startIndex..<endIndex, in: self)
+        let range = NSRange(searchRange ?? startIndex..<endIndex, in: self)
         return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: template)
     }
     #endif

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -994,7 +994,7 @@ public extension String {
     ///
     /// - Parameter lhs: String to check on regex.
     /// - Parameter rhs: Regex to match against.
-    /// - Returns: true if string matches the regex.
+    /// - Returns: true if there is at least one match for the regex in the string.
     static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
         let range = NSRange(location: 0, length: lhs.utf16.count)
         return rhs.firstMatch(in: lhs, options: [], range: range) != nil

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1006,14 +1006,16 @@ public extension String {
     /// SwifterSwift: Returns a new string in which all occurrences of a regex in a specified range of the receiver are replaced by the template.
     /// - Parameter regex: Regex to replace.
     /// - Parameter template: The template to replace the regex.
+    /// - Parameter options: The matching options to use
     /// - Parameter searchRange: The range in the receiver in which to search.
     /// - Returns: A new string in which all occurrences of regex in searchRange of the receiver are replaced by template.
     func replacingOccurrences(
         of regex: NSRegularExpression,
         with template: String,
+        options: NSRegularExpression.MatchingOptions = [],
         range searchRange: Range<String.Index>? = nil) -> String {
         let range = NSRange(searchRange ?? startIndex..<endIndex, in: self)
-        return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: template)
+        return regex.stringByReplacingMatches(in: self, options: options, range: range, withTemplate: template)
     }
     #endif
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1024,12 +1024,7 @@ public extension String {
         of regex: NSRegularExpression,
         with template: String,
         range searchRange: Range<String.Index>? = nil) -> String {
-        let range: NSRange
-        if let searchRange = searchRange {
-            range = NSRange(searchRange, in: self)
-        } else {
-            range = NSRange(location: 0, length: utf16.count)
-        }
+        let range =NSRange(searchRange ?? startIndex..<endIndex, in: self)
         return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: template)
     }
     #endif

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -998,7 +998,7 @@ public extension String {
     /// - Returns: true if there is at least one match for the regex in the string.
     static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
         let range = NSRange(location: 0, length: lhs.utf16.count)
-        return rhs.firstMatch(in: lhs, options: [], range: range) != nil
+        return rhs.firstMatch(in: lhs, range: range) != nil
     }
     #endif
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -997,7 +997,7 @@ public extension String {
     /// - Parameter rhs: Regex to match against.
     /// - Returns: `true` if there is at least one match for the regex in the string.
     static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
-        let range = NSRange(location: 0, length: lhs.utf16.count)
+        let range = NSRange(startIndex..<endIndex, in: self)
         return rhs.firstMatch(in: lhs, range: range) != nil
     }
     #endif

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1003,18 +1003,6 @@ public extension String {
     #endif
 
     #if canImport(Foundation)
-    /// SwifterSwift: Returns a new string in which all occurrences of a regex pattern in a specified range of the receiver are replaced by the template.
-    /// - Parameter pattern: Regex pattern to replace.
-    /// - Parameter template: The regex template to replace the pattern.
-    /// - Parameter searchRange: The range in the receiver in which to search.
-    /// - Returns: A new string in which all occurrences of regex pattern in searchRange of the receiver are replaced by template.
-    func replacingOccurrences(of pattern: String, with template: String,
-                              range searchRange: Range<String.Index>? = nil) -> String {
-        return replacingOccurrences(of: pattern, with: template, options: .regularExpression, range: searchRange)
-    }
-    #endif
-
-    #if canImport(Foundation)
     /// SwifterSwift: Returns a new string in which all occurrences of a regex in a specified range of the receiver are replaced by the template.
     /// - Parameter regex: Regex to replace.
     /// - Parameter template: The template to replace the regex.

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -972,7 +972,7 @@ public extension String {
     ///
     /// - Parameter regex: Regex to verify.
     /// - Parameter options: The matching options to use.
-    /// - Returns: true if string matches the regex.
+    /// - Returns: `true` if string matches the regex.
     func matches(regex: NSRegularExpression, options: NSRegularExpression.MatchingOptions = []) -> Bool {
         let range = NSRange(startIndex..<endIndex, in: self)
         return regex.firstMatch(in: self, options: options, range: range) != nil

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -971,10 +971,11 @@ public extension String {
     /// SwifterSwift: Verify if string matches the regex.
     ///
     /// - Parameter regex: Regex to verify.
+    /// - Parameter options: The matching options to use.
     /// - Returns: true if string matches the regex.
-    func matches(regex: NSRegularExpression) -> Bool {
+    func matches(regex: NSRegularExpression, options: NSRegularExpression.MatchingOptions = []) -> Bool {
         let range = NSRange(location: 0, length: utf16.count)
-        return regex.firstMatch(in: self, options: [], range: range) != nil
+        return regex.firstMatch(in: self, options: options, range: range) != nil
     }
     #endif
 

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -995,7 +995,7 @@ public extension String {
     ///
     /// - Parameter lhs: String to check on regex.
     /// - Parameter rhs: Regex to match against.
-    /// - Returns: true if there is at least one match for the regex in the string.
+    /// - Returns: `true` if there is at least one match for the regex in the string.
     static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
         let range = NSRange(location: 0, length: lhs.utf16.count)
         return rhs.firstMatch(in: lhs, range: range) != nil

--- a/Sources/SwifterSwift/SwiftStdlib/StringProtocolExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringProtocolExtensions.swift
@@ -37,7 +37,6 @@ public extension StringProtocol {
         assert(
             options.isStrictSubset(of: [.regularExpression, .anchored, .caseInsensitive]),
             "Invalid options for regular expression replacement")
-        print(options.union(.regularExpression))
         return replacingOccurrences(
             of: pattern,
             with: template,

--- a/Sources/SwifterSwift/SwiftStdlib/StringProtocolExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringProtocolExtensions.swift
@@ -20,4 +20,29 @@ public extension StringProtocol {
             .map { (lhs: Character, _: Character) in lhs }
             .reversed())
     }
+
+    #if canImport(Foundation)
+    /// SwifterSwift: Returns a new string in which all occurrences of a regex pattern in a specified range of the receiver are replaced by the template.
+    /// - Parameter ofPattern: Regex pattern to replace.
+    /// - Parameter template: The regex template to replace the pattern.
+    /// - Parameter options: Options to use when matching the regex. Only .regularExpression, .anchored .and caseInsensitive are supported.
+    /// - Parameter searchRange: The range in the receiver in which to search.
+    /// - Returns: A new string in which all occurrences of regex pattern in searchRange of the receiver are replaced by template.
+    func replacingOccurrences<Target, Replacement>(
+        ofPattern pattern: Target,
+        withTemplate template: Replacement,
+        options: String.CompareOptions = [.regularExpression],
+        range searchRange: Range<Self.Index>? = nil) -> String where Target: StringProtocol,
+        Replacement: StringProtocol {
+        assert(
+            options.isStrictSubset(of: [.regularExpression, .anchored, .caseInsensitive]),
+            "Invalid options for regular expression replacement")
+        print(options.union(.regularExpression))
+        return replacingOccurrences(
+            of: pattern,
+            with: template,
+            options: options.union(.regularExpression),
+            range: searchRange)
+    }
+    #endif
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -568,19 +568,17 @@ final class StringExtensionsTests: XCTestCase {
     let emailPattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
 
     func testPatternMatches() {
-        XCTAssert("123".matches(pattern: "\\d{3}"))
+        XCTAssertTrue("123".matches(pattern: "\\d{3}"))
         XCTAssertFalse("dasda".matches(pattern: "\\d{3}"))
         XCTAssertFalse("notanemail.com".matches(pattern: emailPattern))
-        XCTAssert("email@mail.com".matches(pattern: emailPattern))
+        XCTAssertTrue("email@mail.com".matches(pattern: emailPattern))
     }
 
-    func testRegexMatches() {
-        // swiftlint:disable force_try
-        XCTAssert("123".matches(regex: try! NSRegularExpression(pattern: "\\d{3}")))
-        XCTAssertFalse("dasda".matches(regex: try! NSRegularExpression(pattern: "\\d{3}")))
-        XCTAssertFalse("notanemail.com".matches(regex: try! NSRegularExpression(pattern: emailPattern)))
-        XCTAssert("email@mail.com".matches(regex: try! NSRegularExpression(pattern: emailPattern)))
-        // swiftlint:enable force_try
+    func testRegexMatches() throws {
+        XCTAssertTrue("123".matches(regex: try NSRegularExpression(pattern: "\\d{3}")))
+        XCTAssertFalse("dasda".matches(regex: try NSRegularExpression(pattern: "\\d{3}")))
+        XCTAssertFalse("notanemail.com".matches(regex: try NSRegularExpression(pattern: emailPattern)))
+        XCTAssertTrue("email@mail.com".matches(regex: try NSRegularExpression(pattern: emailPattern)))
     }
 
     #if canImport(Foundation)
@@ -596,9 +594,8 @@ final class StringExtensionsTests: XCTestCase {
     }
     #endif
 
-    func testRegexMatchOperator() {
-        // swiftlint:disable:next force_try
-        let regex = try! NSRegularExpression(pattern: "\\d{3}")
+    func testRegexMatchOperator() throws {
+        let regex = try NSRegularExpression(pattern: "\\d{3}")
         XCTAssert("123" ~= regex)
         XCTAssertFalse("abc" ~= regex)
     }
@@ -880,29 +877,32 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testReplacingOccurrencesPattern() {
+        XCTAssertEqual("", "".replacingOccurrences(of: "empty", with: "case"))
+
         let string = "hello"
         XCTAssertEqual("hello", string.replacingOccurrences(of: "not", with: "found"))
         XCTAssertEqual("hexo", string.replacingOccurrences(of: "l+", with: "x"))
         XCTAssertEqual("hellxo", string.replacingOccurrences(of: "(ll)", with: "$1x"))
 
-        let range = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
-        XCTAssertEqual("hexlo", string.replacingOccurrences(of: "l", with: "x", range: range))
+        let range1 = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
+        XCTAssertEqual("hexlo", string.replacingOccurrences(of: "l", with: "x", range: range1))
     }
 
-    func testReplacingOccurrencesRegex() {
-        // swiftlint:disable force_try
+    func testReplacingOccurrencesRegex() throws {
+        let re1 = try NSRegularExpression(pattern: "empty")
+        XCTAssertEqual("", "".replacingOccurrences(of: re1, with: "case"))
+
         let string = "hello"
 
-        let re1 = try! NSRegularExpression(pattern: "not")
-        XCTAssertEqual("hello", string.replacingOccurrences(of: re1, with: "found"))
-        let re2 = try! NSRegularExpression(pattern: "l+")
-        XCTAssertEqual("hexo", string.replacingOccurrences(of: re2, with: "x"))
-        let re3 = try! NSRegularExpression(pattern: "(ll)")
-        XCTAssertEqual("hellxo", string.replacingOccurrences(of: re3, with: "$1x"))
+        let re2 = try NSRegularExpression(pattern: "not")
+        XCTAssertEqual("hello", string.replacingOccurrences(of: re2, with: "found"))
+        let re3 = try NSRegularExpression(pattern: "l+")
+        XCTAssertEqual("hexo", string.replacingOccurrences(of: re3, with: "x"))
+        let re4 = try NSRegularExpression(pattern: "(ll)")
+        XCTAssertEqual("hellxo", string.replacingOccurrences(of: re4, with: "$1x"))
 
-        let re4 = try! NSRegularExpression(pattern: "l")
+        let re5 = try NSRegularExpression(pattern: "l")
         let range = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
-        XCTAssertEqual("hexlo", string.replacingOccurrences(of: re4, with: "x", range: range))
-        // swiftlint:enable force_try
+        XCTAssertEqual("hexlo", string.replacingOccurrences(of: re5, with: "x", range: range))
     }
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -876,18 +876,6 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(num.ordinalString(), "12th")
     }
 
-    func testReplacingOccurrencesPattern() {
-        XCTAssertEqual("", "".replacingOccurrences(of: "empty", with: "case"))
-
-        let string = "hello"
-        XCTAssertEqual("hello", string.replacingOccurrences(of: "not", with: "found"))
-        XCTAssertEqual("hexo", string.replacingOccurrences(of: "l+", with: "x"))
-        XCTAssertEqual("hellxo", string.replacingOccurrences(of: "(ll)", with: "$1x"))
-
-        let range1 = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
-        XCTAssertEqual("hexlo", string.replacingOccurrences(of: "l", with: "x", range: range1))
-    }
-
     func testReplacingOccurrencesRegex() throws {
         let re1 = try NSRegularExpression(pattern: "empty")
         XCTAssertEqual("", "".replacingOccurrences(of: re1, with: "case"))

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -565,25 +565,43 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(url, "it's%20easy%20to%20encode%20strings")
     }
 
-    func testMatches() {
+    let emailPattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
+
+    func testPatternMatches() {
         XCTAssert("123".matches(pattern: "\\d{3}"))
         XCTAssertFalse("dasda".matches(pattern: "\\d{3}"))
-        XCTAssertFalse("notanemail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
-        XCTAssert("email@mail.com".matches(pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"))
+        XCTAssertFalse("notanemail.com".matches(pattern: emailPattern))
+        XCTAssert("email@mail.com".matches(pattern: emailPattern))
+    }
+
+    func testRegexMatches() {
+        // swiftlint:disable force_try
+        XCTAssert("123".matches(regex: try! NSRegularExpression(pattern: "\\d{3}")))
+        XCTAssertFalse("dasda".matches(regex: try! NSRegularExpression(pattern: "\\d{3}")))
+        XCTAssertFalse("notanemail.com".matches(regex: try! NSRegularExpression(pattern: emailPattern)))
+        XCTAssert("email@mail.com".matches(regex: try! NSRegularExpression(pattern: emailPattern)))
+        // swiftlint:enable force_try
     }
 
     #if canImport(Foundation)
-    func testRegexMatchOperator() {
+    func testPatternMatchOperator() {
         XCTAssert("123" ~= "\\d{3}")
         XCTAssertFalse("dasda" ~= "\\d{3}")
-        XCTAssertFalse("notanemail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
-        XCTAssert("email@mail.com" ~= "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
+        XCTAssertFalse("notanemail.com" ~= emailPattern)
+        XCTAssert("email@mail.com" ~= emailPattern)
         XCTAssert("hat" ~= "[a-z]at")
         XCTAssertFalse("" ~= "[a-z]at")
         XCTAssert("" ~= "[a-z]*")
         XCTAssertFalse("" ~= "[0-9]+")
     }
     #endif
+
+    func testRegexMatchOperator() {
+        // swiftlint:disable:next force_try
+        let regex = try! NSRegularExpression(pattern: "\\d{3}")
+        XCTAssert("123" ~= regex)
+        XCTAssertFalse("abc" ~= regex)
+    }
 
     func testPadStart() {
         var str: String = "str"
@@ -859,5 +877,32 @@ final class StringExtensionsTests: XCTestCase {
         let num = 12
         XCTAssertNotNil(num.ordinalString())
         XCTAssertEqual(num.ordinalString(), "12th")
+    }
+
+    func testReplacingOccurrencesPattern() {
+        let string = "hello"
+        XCTAssertEqual("hello", string.replacingOccurrences(of: "not", with: "found"))
+        XCTAssertEqual("hexo", string.replacingOccurrences(of: "l+", with: "x"))
+        XCTAssertEqual("hellxo", string.replacingOccurrences(of: "(ll)", with: "$1x"))
+
+        let range = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
+        XCTAssertEqual("hexlo", string.replacingOccurrences(of: "l", with: "x", range: range))
+    }
+
+    func testReplacingOccurrencesRegex() {
+        // swiftlint:disable force_try
+        let string = "hello"
+
+        let re1 = try! NSRegularExpression(pattern: "not")
+        XCTAssertEqual("hello", string.replacingOccurrences(of: re1, with: "found"))
+        let re2 = try! NSRegularExpression(pattern: "l+")
+        XCTAssertEqual("hexo", string.replacingOccurrences(of: re2, with: "x"))
+        let re3 = try! NSRegularExpression(pattern: "(ll)")
+        XCTAssertEqual("hellxo", string.replacingOccurrences(of: re3, with: "$1x"))
+
+        let re4 = try! NSRegularExpression(pattern: "l")
+        let range = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
+        XCTAssertEqual("hexlo", string.replacingOccurrences(of: re4, with: "x", range: range))
+        // swiftlint:enable force_try
     }
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -889,8 +889,12 @@ final class StringExtensionsTests: XCTestCase {
         let re4 = try NSRegularExpression(pattern: "(ll)")
         XCTAssertEqual("hellxo", string.replacingOccurrences(of: re4, with: "$1x"))
 
-        let re5 = try NSRegularExpression(pattern: "l")
+        let re5 = try NSRegularExpression(pattern: "ell")
+        let options: NSRegularExpression.MatchingOptions = [.anchored]
+        XCTAssertEqual("hello", string.replacingOccurrences(of: re5, with: "not found", options: options))
+
+        let re6 = try NSRegularExpression(pattern: "l")
         let range = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
-        XCTAssertEqual("hexlo", string.replacingOccurrences(of: re5, with: "x", range: range))
+        XCTAssertEqual("hexlo", string.replacingOccurrences(of: re6, with: "x", range: range))
     }
 }

--- a/Tests/SwiftStdlibTests/StringProtocolExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringProtocolExtensionsTests.swift
@@ -26,4 +26,19 @@ final class StringProtocolExtensionsTests: XCTestCase {
 
         XCTAssertEqual(string1.commonSuffix(with: "你好世界"), "")
     }
+
+    func testReplacingOccurrences() {
+        XCTAssertEqual("", "".replacingOccurrences(ofPattern: "empty", withTemplate: "case"))
+
+        let string = "hello"
+        XCTAssertEqual("hello", string.replacingOccurrences(ofPattern: "not", withTemplate: "found"))
+        XCTAssertEqual("hexo", string.replacingOccurrences(ofPattern: "l+", withTemplate: "x"))
+        XCTAssertEqual("hellxo", string.replacingOccurrences(ofPattern: "(ll)", withTemplate: "$1x"))
+
+        let options: String.CompareOptions = [.caseInsensitive]
+        XCTAssertEqual("hexo", string.replacingOccurrences(ofPattern: "L+", withTemplate: "x", options: options))
+
+        let range1 = string.startIndex..<string.index(string.startIndex, offsetBy: 3)
+        XCTAssertEqual("hexlo", string.replacingOccurrences(ofPattern: "l", withTemplate: "x", range: range1))
+    }
 }


### PR DESCRIPTION
New String regex extensions as discussed in #896:

```swift
func matches(regex: NSRegularExpression) -> Bool
func replacingOccurrences(of pattern: String, with template: String, range searchRange: Range<String.Index>? = nil) -> String
func replacingOccurrences(of regex: NSRegularExpression, with template: String, range searchRange: Range<String.Index>? = nil) -> String
static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool
```

Once I get the thumbs up I'll add the changelog.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
