### PR TITLE
Add range extensions for String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **FloatingPoint**
   - Moved the square root operator `√` from `Double` and `Float` to make it generic. [#880](https://github.com/SwifterSwift/SwifterSwift/pull/880) by [guykogus](https://github.com/guykogus)
 - **Collection**
+  - Added `fullRange` to get the entire range of indices in a collection. [#902](https://github.com/SwifterSwift/SwifterSwift/pull/902) by [guykogus](https://github.com/guykogus)
   - Moved `indices(of:)` from `RandomAccessCollection` to find the indices of an element. [#863](https://github.com/SwifterSwift/SwifterSwift/pull/863) by [guykogus](https://github.com/guykogus)
 - **UIViewController**:
   - Added `instantiate(from:bundle:identifier:)` function to `UIViewController` to make it easier to instantiate it from storyboard. [#860](https://github.com/SwifterSwift/SwifterSwift/pull/860) by [VatoKo](https://github.com/VatoKo)
 - **String**:
+  - Added `fullNSRange`, `range(from:)` and `nsRange(from:)` for converting between `Range<String.Index>` and `NSRange`. [#902](https://github.com/SwifterSwift/SwifterSwift/pull/902) by [guykogus](https://github.com/guykogus)
   - Overloaded Swift's 'contains' operator (`~=`) for `String` to check regex matching. [#858](https://github.com/SwifterSwift/SwifterSwift/pull/858) by [VatoKo](https://github.com/VatoKo)
   - `regexEscaped`, which returns an escaped string for inclusion in a regex pattern
 - **DispatchQueue**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIViewController**:
   - Added `instantiate(from:bundle:identifier:)` function to `UIViewController` to make it easier to instantiate it from storyboard. [#860](https://github.com/SwifterSwift/SwifterSwift/pull/860) by [VatoKo](https://github.com/VatoKo)
 - **String**:
-  - Added `fullNSRange`, `range(from:)` and `nsRange(from:)` for converting between `Range<String.Index>` and `NSRange`. [#902](https://github.com/SwifterSwift/SwifterSwift/pull/902) by [guykogus](https://github.com/guykogus)
+  - Added `fullNSRange`, `range(from:)`, `nsRange(from:)` and `subscript` for converting between `Range<String.Index>` and `NSRange`. [#902](https://github.com/SwifterSwift/SwifterSwift/pull/902) by [guykogus](https://github.com/guykogus)
   - Overloaded Swift's 'contains' operator (`~=`) for `String` to check regex matching. [#858](https://github.com/SwifterSwift/SwifterSwift/pull/858) by [VatoKo](https://github.com/VatoKo)
   - `regexEscaped`, which returns an escaped string for inclusion in a regex pattern
 - **DispatchQueue**:

--- a/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
@@ -4,6 +4,13 @@
 import Dispatch
 #endif
 
+// MARK: - Properties
+
+public extension Collection {
+    /// SwifterSwift: The full range of the collection.
+    var fullRange: Range<Index> { startIndex..<endIndex }
+}
+
 // MARK: - Methods
 
 public extension Collection {

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1286,7 +1286,7 @@ public extension String {
     /// SwifterSwift: Accesses a contiguous subrange of the collection’s elements.
     /// - Parameter nsRange: A range of the collection’s indices. The bounds of the range must be valid indices of the collection.
     /// - Returns: A slice of the receiving string.
-    subscript(nsRange bounds: NSRange) -> Substring {
+    subscript(bounds: NSRange) -> Substring {
         guard let range = Range(bounds, in: self) else { fatalError("Failed to find range \(bounds) in \(self)") }
         return self[range]
     }

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -437,7 +437,7 @@ public extension String {
     /// SwifterSwift: Check if the given string spelled correctly
     var isSpelledCorrectly: Bool {
         let checker = UITextChecker()
-        let range = NSRange(location: 0, length: utf16.count)
+        let range = NSRange(startIndex..<endIndex, in: self)
 
         let misspelledRange = checker.rangeOfMisspelledWord(
             in: self,
@@ -1222,6 +1222,9 @@ public extension String {
         return NSString(string: self)
     }
 
+    /// SwifterSwift: The full `NSRange` of the string.
+    var fullNSRange: NSRange { NSRange(startIndex..<endIndex, in: self) }
+
     /// SwifterSwift: NSString lastPathComponent.
     var lastPathComponent: String {
         return (self as NSString).lastPathComponent
@@ -1247,6 +1250,21 @@ public extension String {
         return (self as NSString).pathComponents
     }
 
+    /// SwifterSwift: Convert an `NSRange` into `Range<String.Index>`.
+    /// - Parameter nsRange: The `NSRange` within the receiver.
+    /// - Returns: The equivalent `Range<String.Index>` of `nsRange` found within the receiving string.
+    func range(from nsRange: NSRange) -> Range<Index> {
+        guard let range = Range(nsRange, in: self) else { fatalError("Failed to find range \(nsRange) in \(self)") }
+        return range
+    }
+
+    /// SwifterSwift: Convert a `Range<String.Index>` into `NSRange`.
+    /// - Parameter range: The `Range<String.Index>` within the receiver.
+    /// - Returns: The equivalent `NSRange` of `range` found within the receiving string.
+    func nsRange(from range: Range<Index>) -> NSRange {
+        return NSRange(range, in: self)
+    }
+
     /// SwifterSwift: NSString appendingPathComponent(str: String)
     ///
     /// - Note: This method only works with file paths (not, for example, string representations of URLs.
@@ -1263,6 +1281,14 @@ public extension String {
     /// - Returns: a new string made by appending to the receiver an extension separator followed by ext (if applicable).
     func appendingPathExtension(_ str: String) -> String? {
         return (self as NSString).appendingPathExtension(str)
+    }
+
+    /// SwifterSwift: Accesses a contiguous subrange of the collection’s elements.
+    /// - Parameter nsRange: A range of the collection’s indices. The bounds of the range must be valid indices of the collection.
+    /// - Returns: A slice of the receiving string.
+    subscript(nsRange bounds: NSRange) -> Substring {
+        guard let range = Range(bounds, in: self) else { fatalError("Failed to find range \(bounds) in \(self)") }
+        return self[range]
     }
 }
 

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -6,6 +6,11 @@ import XCTest
 final class CollectionExtensionsTests: XCTestCase {
     let collection = [1, 2, 3, 4, 5]
 
+    func testFullRange() {
+        XCTAssertEqual(collection.fullRange, 0..<5)
+        XCTAssertEqual([].fullRange, 0..<0)
+    }
+
     func testForEachInParallel() {
         let expectation = XCTestExpectation(description: "forEachInParallel")
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -5,7 +5,8 @@ import XCTest
 
 // swiftlint:disable:next type_body_length
 final class StringExtensionsTests: XCTestCase {
-    var helloWorld = "Hello World!"
+    let helloWorld = "Hello World!"
+    let flower = "💐" // for testing multi-byte characters
 
     override func setUp() {
         super.setUp()
@@ -793,6 +794,12 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Hello".nsString, NSString(string: "Hello"))
     }
 
+    func testFullNSRange() {
+        XCTAssertEqual("".fullNSRange, NSRange(location: 0, length: 0))
+        XCTAssertEqual(helloWorld.fullNSRange, NSRange(location: 0, length: 12))
+        XCTAssertEqual(flower.fullNSRange, NSRange(location: 0, length: 2))
+    }
+
     func testLastPathComponent() {
         let string = "hello"
         let nsString = NSString(string: "hello")
@@ -821,6 +828,34 @@ final class StringExtensionsTests: XCTestCase {
         let string = "hello"
         let nsString = NSString(string: "hello")
         XCTAssertEqual(string.pathComponents, nsString.pathComponents)
+    }
+
+    func testRange() {
+        let fullRange = helloWorld.range(from: NSRange(location: 0, length: 12))
+        XCTAssertEqual(String(helloWorld[fullRange]), helloWorld)
+
+        let range = helloWorld.range(from: NSRange(location: 6, length: 6))
+        XCTAssertEqual(helloWorld[range], "World!")
+
+        let emptyRange = helloWorld.range(from: NSRange(location: 0, length: 0))
+        XCTAssertEqual(helloWorld[emptyRange], "")
+
+        let flowerRange = flower.range(from: NSRange(location: 0, length: 2))
+        XCTAssertEqual(String(flower[flowerRange]), flower)
+    }
+
+    func testNSRange() {
+        let startIndex = helloWorld.startIndex
+        let endIndex = helloWorld.endIndex
+        XCTAssertEqual(helloWorld.nsRange(from: startIndex..<endIndex), NSRange(location: 0, length: 12))
+
+        XCTAssertEqual(
+            helloWorld.nsRange(from: helloWorld.index(startIndex, offsetBy: 6)..<endIndex),
+            NSRange(location: 6, length: 6))
+
+        XCTAssertEqual(helloWorld.nsRange(from: startIndex..<startIndex), NSRange(location: 0, length: 0))
+
+        XCTAssertEqual(flower.nsRange(from: flower.startIndex..<flower.endIndex), NSRange(location: 0, length: 2))
     }
 
     func testAppendingPathComponent() {
@@ -859,5 +894,12 @@ final class StringExtensionsTests: XCTestCase {
         let num = 12
         XCTAssertNotNil(num.ordinalString())
         XCTAssertEqual(num.ordinalString(), "12th")
+    }
+
+    func testNSRangeSubscript() {
+        XCTAssertEqual(helloWorld[nsRange: NSRange(location: 0, length: 0)], "")
+        XCTAssertEqual(String(helloWorld[nsRange: NSRange(location: 0, length: 12)]), helloWorld)
+        XCTAssertEqual(String(helloWorld[nsRange: NSRange(location: 6, length: 6)]), "World!")
+        XCTAssertEqual(String(flower[nsRange: NSRange(location: 0, length: 2)]), flower)
     }
 }

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -897,9 +897,9 @@ final class StringExtensionsTests: XCTestCase {
     }
 
     func testNSRangeSubscript() {
-        XCTAssertEqual(helloWorld[nsRange: NSRange(location: 0, length: 0)], "")
-        XCTAssertEqual(String(helloWorld[nsRange: NSRange(location: 0, length: 12)]), helloWorld)
-        XCTAssertEqual(String(helloWorld[nsRange: NSRange(location: 6, length: 6)]), "World!")
-        XCTAssertEqual(String(flower[nsRange: NSRange(location: 0, length: 2)]), flower)
+        XCTAssertEqual(helloWorld[NSRange(location: 0, length: 0)], "")
+        XCTAssertEqual(String(helloWorld[NSRange(location: 0, length: 12)]), helloWorld)
+        XCTAssertEqual(String(helloWorld[NSRange(location: 6, length: 6)]), "World!")
+        XCTAssertEqual(String(flower[NSRange(location: 0, length: 2)]), flower)
     }
 }


### PR DESCRIPTION
🚀
I can't believe we don't have these. They're essential for every project I've worked on...

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
