### PR TITLE
fix bug: Rotated UIImage lose origin scale and blured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Fixed a bug: When the length of a string is 0, calling truncated method will crash. [#866](https://github.com/SwifterSwift/SwifterSwift/pull/866) by [phil zhang](https://github.com/philCc)
 - **UITextField**
   - Fixed a bug:UITextField `addPaddingLeftIcon` doesn't work on iOS 13[#876](https://github.com/SwifterSwift/SwifterSwift/issues/876) by [Jayxiang](https://github.com/Jayxiang)
+- **UIImage**
+  - Fixed a bug:UIImage `rotated(by:)` lose origin scale, result in image blurred[#904](https://github.com/SwifterSwift/SwifterSwift/pull/904) by [yanpanpan](https://github.com/yanpanpan)
 
 ### Security
 

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -169,7 +169,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, /*opaque=*/false, scale)
+        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -139,7 +139,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContext(roundedDestRect.size)
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
@@ -169,7 +169,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContext(roundedDestRect.size)
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -139,7 +139,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)
@@ -169,7 +169,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -139,7 +139,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, /*opaque=*/false, scale)
+        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -139,7 +139,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, false, scale)
+        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, /*opaque=*/false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)

--- a/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageExtensions.swift
@@ -169,7 +169,7 @@ public extension UIImage {
                                      width: destRect.width.rounded(),
                                      height: destRect.height.rounded())
 
-        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, false, scale)
+        UIGraphicsBeginImageContextWithOptions(roundedDestRect.size, /*opaque=*/false, scale)
         guard let contextRef = UIGraphicsGetCurrentContext() else { return nil }
 
         contextRef.translateBy(x: roundedDestRect.width / 2, y: roundedDestRect.height / 2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix bug. When UIImage rotated, it lost origin scale. 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
