### PR TITLE
Added UIAlertController extension

### DIFF
--- a/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
@@ -29,7 +29,7 @@ public extension UIAlertController {
             #endif
         }
     }
-
+    
     /// SwifterSwift: Add an action to Alert
     ///
     /// - Parameters:
@@ -49,7 +49,7 @@ public extension UIAlertController {
         addAction(action)
         return action
     }
-
+    
     /// SwifterSwift: Add a text field to Alert
     ///
     /// - Parameters:
@@ -94,7 +94,7 @@ public extension UIAlertController {
             view.tintColor = color
         }
     }
-
+    
     /// SwifterSwift: Create new error alert view controller from Error with default OK action.
     ///
     /// - Parameters:
@@ -115,6 +115,26 @@ public extension UIAlertController {
             view.tintColor = color
         }
     }
+    
+    /// SwifterSwift: Create new error alert view controller from LocalizedError with default OK action.
+    ///
+    /// - Parameters:
+    ///   - title: alert controller's title (default is "Error").
+    ///   - message: error to set alert controller's message to it's recoverySuggestion.
+ 
+    convenience init(localizedError: LocalizedError) {
+        let title = localizedError.errorDescription
+        let message = localizedError.recoverySuggestion
+        
+        self.init(title: title,
+                  message:message,
+                  preferredStyle:.alert)
+    }
 }
+
+
+
+
+
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
@@ -121,7 +121,6 @@ public extension UIAlertController {
     /// - Parameters:
     ///   - title: alert controller's title (default is "Error").
     ///   - message: error to set alert controller's message to it's recoverySuggestion.
- 
     convenience init(localizedError: LocalizedError) {
         let title = localizedError.errorDescription
         let message = localizedError.recoverySuggestion
@@ -131,4 +130,5 @@ public extension UIAlertController {
                   preferredStyle:.alert)
     }
 }
+
 #endif

--- a/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
@@ -131,10 +131,4 @@ public extension UIAlertController {
                   preferredStyle:.alert)
     }
 }
-
-
-
-
-
-
 #endif

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -4,20 +4,39 @@
 import UIKit
 
 public extension UIColor {
-    #if !os(watchOS)
-    /// SwifterSwift: Create a UIColor with different colors for light and dark mode.
-    ///
-    /// - Parameters:
-    ///     - light: Color to use in light/unspecified mode.
-    ///     - dark: Color to use in dark mode.
-    convenience init(light: UIColor, dark: UIColor) {
-        if #available(iOS 13.0, tvOS 13.0, *) {
-            self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
-        } else {
-            self.init(cgColor: light.cgColor)
-        }
+  #if !os(watchOS)
+  /// SwifterSwift: Create a UIColor with different colors for light and dark mode.
+  ///
+  /// - Parameters:
+  ///     - light: Color to use in light/unspecified mode.
+  ///     - dark: Color to use in dark mode.
+  convenience init(light: UIColor, dark: UIColor) {
+    if #available(iOS 13.0, tvOS 13.0, *) {
+      self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
+    } else {
+      self.init(cgColor: light.cgColor)
     }
-    #endif
+  }
+  #endif
+}
+
+
+public extension UIColor {
+  convenience init(red: Int, green: Int, blue: Int) {
+    assert(red >= 0 && red <= 255, "Invalid red component")
+    assert(green >= 0 && green <= 255, "Invalid green component")
+    assert(blue >= 0 && blue <= 255, "Invalid blue component")
+    
+    self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
+  }
+  
+  convenience init(rgb: Int) {
+    self.init(
+      red: (rgb >> 16) & 0xFF,
+      green: (rgb >> 8) & 0xFF,
+      blue: rgb & 0xFF
+    )
+  }
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIColorExtensions.swift
@@ -4,39 +4,19 @@
 import UIKit
 
 public extension UIColor {
-  #if !os(watchOS)
-  /// SwifterSwift: Create a UIColor with different colors for light and dark mode.
-  ///
-  /// - Parameters:
-  ///     - light: Color to use in light/unspecified mode.
-  ///     - dark: Color to use in dark mode.
-  convenience init(light: UIColor, dark: UIColor) {
-    if #available(iOS 13.0, tvOS 13.0, *) {
-      self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
-    } else {
-      self.init(cgColor: light.cgColor)
+    #if !os(watchOS)
+    /// SwifterSwift: Create a UIColor with different colors for light and dark mode.
+    ///
+    /// - Parameters:
+    ///     - light: Color to use in light/unspecified mode.
+    ///     - dark: Color to use in dark mode.
+    convenience init(light: UIColor, dark: UIColor) {
+        if #available(iOS 13.0, tvOS 13.0, *) {
+            self.init(dynamicProvider: { $0.userInterfaceStyle == .dark ? dark : light })
+        } else {
+            self.init(cgColor: light.cgColor)
+        }
     }
-  }
-  #endif
+    #endif
 }
-
-
-public extension UIColor {
-  convenience init(red: Int, green: Int, blue: Int) {
-    assert(red >= 0 && red <= 255, "Invalid red component")
-    assert(green >= 0 && green <= 255, "Invalid green component")
-    assert(blue >= 0 && blue <= 255, "Invalid blue component")
-    
-    self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
-  }
-  
-  convenience init(rgb: Int) {
-    self.init(
-      red: (rgb >> 16) & 0xFF,
-      green: (rgb >> 8) & 0xFF,
-      blue: rgb & 0xFF
-    )
-  }
-}
-
 #endif

--- a/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
@@ -96,29 +96,21 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
     }
     
     func testLocalizeErrorAlert() {
-        
-        let alert = UIAlertController(localizedError: CustomError.netWorkError)
+        enum CustomError: Error, LocalizedError {
+            case networkError
+            var errorDescription: String? {
+                return "Wrong URL"
+            }
+            var recoverySuggestion: String? {
+                return "Make sure you don't make any typo"
+            }
+        }
+        let networkError = CustomError.networkError
+        let alert = UIAlertController(localizedError: networkError)
         XCTAssertNotNil(alert)
         
         XCTAssertEqual(alert.title, "Wrong URL")
         XCTAssertEqual(alert.message, "Make sure you don't make any typo")
     }
-
-    
 }
-
-    enum CustomError: Error {
-        case netWorkError
-    }
-
-    extension CustomError: LocalizedError {
-        var errorDescription: String? {
-            return "Wrong URL"
-        }
-    
-    var recoverySuggestion: String? {
-        return "Make sure you don't make any typo"
-        }
-    }
-
 #endif

--- a/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
@@ -14,86 +14,111 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
             style: .destructive,
             isEnabled: false,
             handler: nil)
-
+        
         XCTAssertNotNil(discardedResult)
-
+        
         XCTAssertEqual(alertController.actions.count, 1)
-
+        
         let action = alertController.actions.first
-
+        
         XCTAssertEqual(action?.title, "ActionTitle")
         XCTAssertEqual(action?.style, .destructive)
         XCTAssertEqual(action?.isEnabled, false)
     }
-
+    
     func testSelector() {}
-
+    
     func testAddTextField() {
         let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .alert)
-
+        
         let selector = #selector(testSelector)
-
+        
         alertController.addTextField(
             text: "TextField",
             placeholder: "PlaceHolder",
             editingChangedTarget: self,
             editingChangedSelector: selector)
-
+        
         XCTAssertEqual(alertController.textFields?.count, 1)
-
+        
         let textField = alertController.textFields?.first
-
+        
         XCTAssertEqual(textField?.text, "TextField")
         XCTAssertEqual(textField?.placeholder, "PlaceHolder")
         XCTAssertNotNil(textField?.allTargets)
         XCTAssertNotNil(textField?.actions(forTarget: self, forControlEvent: .editingChanged))
     }
-
+    
     func testMessageInit() {
         let alertController = UIAlertController(
             title: "Title",
             message: "Message",
             defaultActionButtonTitle: "Ok",
             tintColor: .blue)
-
+        
         XCTAssertNotNil(alertController)
-
+        
         XCTAssertEqual(alertController.title, "Title")
         XCTAssertEqual(alertController.message, "Message")
         XCTAssertEqual(alertController.view.tintColor, .blue)
-
+        
         XCTAssertEqual(alertController.actions.count, 1)
-
+        
         let defaultAction = alertController.actions.first
-
+        
         XCTAssertEqual(defaultAction?.title, "Ok")
         XCTAssertEqual(defaultAction?.style, .default)
     }
-
+    
     enum TestError: Error { case error }
-
+    
     func testErrorInit() {
         let error = TestError.error
-
+        
         let alertController = UIAlertController(
             title: "Title",
             error: error,
             defaultActionButtonTitle: "Ok",
             tintColor: .red)
-
+        
         XCTAssertNotNil(alertController)
-
+        
         XCTAssertEqual(alertController.title, "Title")
         XCTAssertEqual(alertController.message, error.localizedDescription)
         XCTAssertEqual(alertController.view.tintColor, .red)
-
+        
         XCTAssertEqual(alertController.actions.count, 1)
-
+        
         let defaultAction = alertController.actions.first
-
+        
         XCTAssertEqual(defaultAction?.title, "Ok")
         XCTAssertEqual(defaultAction?.style, .default)
     }
+    
+    func testLocalizeErrorAlert() {
+        
+        let alert = UIAlertController(localizedError: CustomError.netWorkError)
+        XCTAssertNotNil(alert)
+        
+        XCTAssertEqual(alert.title, "Wrong URL")
+        XCTAssertEqual(alert.message, "Make sure you don't make any typo")
+    }
+
+    
 }
+
+    enum CustomError: Error {
+        case netWorkError
+    }
+
+    extension CustomError: LocalizedError {
+        var errorDescription: String? {
+            return "Wrong URL"
+        }
+    
+    var recoverySuggestion: String? {
+        return "Make sure you don't make any typo"
+        }
+    }
 
 #endif

--- a/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIAlertControllerExtensionsTests.swift
@@ -61,11 +61,10 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
         XCTAssertEqual(alertController.title, "Title")
         XCTAssertEqual(alertController.message, "Message")
         XCTAssertEqual(alertController.view.tintColor, .blue)
-        
         XCTAssertEqual(alertController.actions.count, 1)
         
         let defaultAction = alertController.actions.first
-        
+
         XCTAssertEqual(defaultAction?.title, "Ok")
         XCTAssertEqual(defaultAction?.style, .default)
     }
@@ -86,7 +85,6 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
         XCTAssertEqual(alertController.title, "Title")
         XCTAssertEqual(alertController.message, error.localizedDescription)
         XCTAssertEqual(alertController.view.tintColor, .red)
-        
         XCTAssertEqual(alertController.actions.count, 1)
         
         let defaultAction = alertController.actions.first
@@ -107,10 +105,11 @@ final class UIAlertControllerExtensionsTests: XCTestCase {
         }
         let networkError = CustomError.networkError
         let alert = UIAlertController(localizedError: networkError)
+
         XCTAssertNotNil(alert)
-        
         XCTAssertEqual(alert.title, "Wrong URL")
         XCTAssertEqual(alert.message, "Make sure you don't make any typo")
     }
 }
+
 #endif

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -21,6 +21,8 @@ final class UIColorExtensionsTests: XCTestCase {
         }
     }
     #endif
+  
+  
 }
 
 #endif

--- a/Tests/UIKitTests/UIColorExtensionsTests.swift
+++ b/Tests/UIKitTests/UIColorExtensionsTests.swift
@@ -21,8 +21,5 @@ final class UIColorExtensionsTests: XCTestCase {
         }
     }
     #endif
-  
-  
 }
-
 #endif

--- a/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewControllerExtensionsTests.swift
@@ -211,5 +211,4 @@ final class UIViewControllerExtensionsTests: XCTestCase {
     }
     #endif
 }
-
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
