### PR TITLE
SCNVector3 normalize() / divide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **SCN3Vector**
-  - Added `normal` method, and basic division functions (`SCNVector3 / scalar`, `scalar / SCNVector3`, and `SCNVector3 /= scalar`. [#908](https://github.com/SwifterSwift/SwifterSwift/pull/908) by [thisIsTheFoxe](https://github.com/thisisthefoxe)
+  - Added `normalized` method, and basic division functions (`SCNVector3 / scalar`, `scalar / SCNVector3`, and `SCNVector3 /= scalar`. [#908](https://github.com/SwifterSwift/SwifterSwift/pull/908) by [thisIsTheFoxe](https://github.com/thisisthefoxe)
 - **UIScrollView**
   - Added `visibleRect`, `scrollToTop(animated:)`, `scrollToLeft(animated:)`, `scrollToBottom(animated:)`, `scrollToRight(animated:)`, `scrollUp(animated:)`, `scrollLeft(animated:)`, `scrollDown(animated:)`, `scrollRight(animated:)`. [#888](https://github.com/SwifterSwift/SwifterSwift/pull/888) by [guykogus](https://github.com/guykogus)
 - **XCTest**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Added
 - **SCN3Vector**
-  - Added `normalized` method, and basic division functions (`SCNVector3 / scalar`, `scalar / SCNVector3`, and `SCNVector3 /= scalar`. [#908](https://github.com/SwifterSwift/SwifterSwift/pull/908) by [thisIsTheFoxe](https://github.com/thisisthefoxe)
+  - Added `normalized` method, and basic division functions (`SCNVector3 / scalar`, and `SCNVector3 /= scalar`. [#908](https://github.com/SwifterSwift/SwifterSwift/pull/908) by [thisIsTheFoxe](https://github.com/thisisthefoxe)
 - **UIScrollView**
   - Added `visibleRect`, `scrollToTop(animated:)`, `scrollToLeft(animated:)`, `scrollToBottom(animated:)`, `scrollToRight(animated:)`, `scrollUp(animated:)`, `scrollLeft(animated:)`, `scrollDown(animated:)`, `scrollRight(animated:)`. [#888](https://github.com/SwifterSwift/SwifterSwift/pull/888) by [guykogus](https://github.com/guykogus)
 - **XCTest**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Rename `shadowColor`, `shadowOffset`, `shadowOpacity` and `shadowRadius` to `layerShadowColor`, `layerShadowOffset`, `layerShadowOpacity` and `layerShadowRadius` to avoid naming colisions with subclasses properties defined in other modules e.g. UIKit. [#897](https://github.com/SwifterSwift/SwifterSwift/pull/897) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 
 ### Added
+- **SCN3Vector**
+  - Added `normal` method, and basic division functions (`SCNVector3 / scalar`, `scalar / SCNVector3`, and `SCNVector3 /= scalar`. [#908](https://github.com/SwifterSwift/SwifterSwift/pull/908) by [thisIsTheFoxe](https://github.com/thisisthefoxe)
 - **UIScrollView**
   - Added `visibleRect`, `scrollToTop(animated:)`, `scrollToLeft(animated:)`, `scrollToBottom(animated:)`, `scrollToRight(animated:)`, `scrollUp(animated:)`, `scrollLeft(animated:)`, `scrollDown(animated:)`, `scrollRight(animated:)`. [#888](https://github.com/SwifterSwift/SwifterSwift/pull/888) by [guykogus](https://github.com/guykogus)
 - **XCTest**

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -29,6 +29,10 @@ public extension SCNVector3 {
     var length: SceneKitFloat {
         return sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2))
     }
+    
+    func normalize() -> SCNVector3 {
+        return SCNVector3(simd.normalize(SIMD3<SceneKitFloat>(self)))
+    }
 }
 
 // MARK: - Operators

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -35,7 +35,7 @@ public extension SCNVector3 {
     ///     SCNVector3(2, 3, 6).normalized  -> SCNVector3(2/7, 3/7, 6/7)
     ///
     var normalized: SCNVector3 {
-        SCNVector3(normalize(SIMD3<Float>(self)))
+        SCNVector3(x / length, y / length, z / length)
     }
 }
 

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -32,10 +32,10 @@ public extension SCNVector3 {
     
     /// SwifterSwift: Returns the unit or normalized vector where `length = 1`.
     ///
-    ///     SCNVector3(2, 3, 6).normal  -> SCNVector3(2/7, 3/7, 6/7)
+    ///     SCNVector3(2, 3, 6).normalized  -> SCNVector3(2/7, 3/7, 6/7)
     ///
     var normalized: SCNVector3 {
-        self / self.length
+        SCNVector3(normalize(SIMD3<Float>(self)))
     }
 }
 

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -149,7 +149,6 @@ public extension SCNVector3 {
     ///   - scalar: scalar value.
     /// - Returns: result of division of the given CGPoint with the scalar.
     static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
-        // swiftlint:disable:next shorthand_operator
         vector = SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
     }
 }

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -139,6 +139,19 @@ public extension SCNVector3 {
     static func / (vector: SCNVector3, scalar: SceneKitFloat) -> SCNVector3 {
         return SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
     }
+
+    /// SwifterSwift: Divide self with a scalar
+    ///
+    ///     SCNVector3(10, 20, -30) /= 3 -> SCNVector3(3/10, 0.15, -30)
+    ///
+    /// - Parameters:
+    ///   - vector: self.
+    ///   - scalar: scalar value.
+    /// - Returns: result of division of the given CGPoint with the scalar.
+    static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
+        // swiftlint:disable:next shorthand_operator
+        vector = SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
+    }
 }
 
 #endif

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -35,8 +35,8 @@ public extension SCNVector3 {
     ///     SCNVector3(2, 3, 6).normalized  -> SCNVector3(2/7, 3/7, 6/7)
     ///
     var normalized: SCNVector3 {
-        let len = sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2))
-        return SCNVector3(x / len, y / len, z / len)
+        let length = sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2))
+        return SCNVector3(x / length, y / length, z / length)
     }
 }
 

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -34,7 +34,7 @@ public extension SCNVector3 {
     ///
     ///     SCNVector3(2, 3, 6).normal  -> SCNVector3(2/7, 3/7, 6/7)
     ///
-    var normal: SCNVector3 {
+    var normalized: SCNVector3 {
         self / self.length
     }
 }
@@ -148,6 +148,7 @@ public extension SCNVector3 {
     ///   - scalar: scalar value.
     /// - Returns: result of division of the given CGPoint with the scalar.
     static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
+        // swiftlint:disable:next shorthand_operator
         vector = vector / scalar
     }
 

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -35,7 +35,8 @@ public extension SCNVector3 {
     ///     SCNVector3(2, 3, 6).normalized  -> SCNVector3(2/7, 3/7, 6/7)
     ///
     var normalized: SCNVector3 {
-        SCNVector3(x / length, y / length, z / length)
+        let len = sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2))
+        return SCNVector3(x / len, y / len, z / len)
     }
 }
 
@@ -149,19 +150,7 @@ public extension SCNVector3 {
     /// - Returns: result of division of the given CGPoint with the scalar.
     static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
         // swiftlint:disable:next shorthand_operator
-        vector = vector / scalar
-    }
-
-    /// SwifterSwift: Divide a scalar with a SCNVector3
-    ///
-    ///     3 / SCNVector3(10, 20, -30) -> SCNVector3(3/10, 0.15, -30)
-    ///
-    /// - Parameters:
-    ///   - scalar: scalar value.
-    ///   - vector: SCNVector3 to divide.
-    /// - Returns: result of division of the given CGPoint with the scalar.
-    static func / (scalar: SceneKitFloat, vector: SCNVector3) -> SCNVector3 {
-        return SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
+        vector = SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
     }
 }
 

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -30,8 +30,12 @@ public extension SCNVector3 {
         return sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2))
     }
     
-    func normalize() -> SCNVector3 {
-        return SCNVector3(simd.normalize(SIMD3<SceneKitFloat>(self)))
+    /// SwifterSwift: Returns the unit or normalized vector where `length = 1`.
+    ///
+    ///     SCNVector3(2, 3, 6).normal  -> SCNVector3(2/7, 3/7, 6/7)
+    ///
+    var normal: SCNVector3 {
+        self / self.length
     }
 }
 
@@ -121,6 +125,42 @@ public extension SCNVector3 {
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     static func * (scalar: SceneKitFloat, vector: SCNVector3) -> SCNVector3 {
         return SCNVector3(vector.x * scalar, vector.y * scalar, vector.z * scalar)
+    }
+    
+    /// SwifterSwift: Divide a SCNVector3 with a scalar
+    ///
+    ///     SCNVector3(10, 20, -30) / 3 -> SCNVector3(3/10, 0.15, -30)
+    ///
+    /// - Parameters:
+    ///   - vector: SCNVector3 to divide.
+    ///   - scalar: scalar value.
+    /// - Returns: result of division of the given SCNVector3 with the scalar.
+    static func / (vector: SCNVector3, scalar: SceneKitFloat) -> SCNVector3 {
+        return SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
+    }
+
+    /// SwifterSwift: Divide self with a scalar
+    ///
+    ///     SCNVector3(10, 20, -30) /= 3 -> SCNVector3(3/10, 0.15, -30)
+    ///
+    /// - Parameters:
+    ///   - vector: self.
+    ///   - scalar: scalar value.
+    /// - Returns: result of division of the given CGPoint with the scalar.
+    static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
+        vector = vector / scalar
+    }
+
+    /// SwifterSwift: Divide a scalar with a SCNVector3
+    ///
+    ///     3 / SCNVector3(10, 20, -30) -> SCNVector3(3/10, 0.15, -30)
+    ///
+    /// - Parameters:
+    ///   - scalar: scalar value.
+    ///   - vector: SCNVector3 to divide.
+    /// - Returns: result of division of the given CGPoint with the scalar.
+    static func / (scalar: SceneKitFloat, vector: SCNVector3) -> SCNVector3 {
+        return SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
     }
 }
 

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -139,19 +139,6 @@ public extension SCNVector3 {
     static func / (vector: SCNVector3, scalar: SceneKitFloat) -> SCNVector3 {
         return SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
     }
-
-    /// SwifterSwift: Divide self with a scalar
-    ///
-    ///     SCNVector3(10, 20, -30) /= 3 -> SCNVector3(3/10, 0.15, -30)
-    ///
-    /// - Parameters:
-    ///   - vector: self.
-    ///   - scalar: scalar value.
-    /// - Returns: result of division of the given CGPoint with the scalar.
-    static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
-        // swiftlint:disable:next shorthand_operator
-        vector = SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
-    }
 }
 
 #endif

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -27,7 +27,7 @@ final class SceneKitTests: XCTestCase {
         let v4Norm = vector4.normalized
         XCTAssertEqual(v4Norm.x, 4 / 6)
         XCTAssertEqual(v4Norm.x, v4Norm.y)
-        XCTAssertEqual(v4Norm.z, 2/6)
+        XCTAssertEqual(v4Norm.z, 2 / 6)
     }
     
     func testAdd() {

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -19,6 +19,16 @@ final class SceneKitTests: XCTestCase {
         XCTAssertEqual(vector.length, 7)
     }
 
+    func testNormaize() {
+        let v1Norm = vector1.normalize()
+        XCTAssertEqual(v1Norm.length, 1)
+        
+        let vector3 = SCNVector3(1,1,1)
+        let v3Norm = vector3.normalize()
+        XCTAssertEqual(v3Norm.x, v3Norm.y)
+        XCTAssertEqual(v3Norm.y, v3Norm.z)
+    }
+    
     func testAdd() {
         let result = vector1 + vector2
         XCTAssertEqual(result, SCNVector3(30, -20, 20))

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -72,12 +72,6 @@ final class SceneKitTests: XCTestCase {
         let result = vector1 / 10
         XCTAssertEqual(result, SCNVector3(1, -2, 3))
     }
-
-    func testDivideEqual() {
-        var vector = vector1
-        vector /= 10
-        XCTAssertEqual(vector, SCNVector3(1, -2, 3))
-    }
 }
 
 extension SCNVector3: Equatable {

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -78,11 +78,6 @@ final class SceneKitTests: XCTestCase {
         vector /= 10
         XCTAssertEqual(vector, SCNVector3(1, -2, 3))
     }
-
-    func testDivideScalarFirst() {
-        let result = 10 / vector1
-        XCTAssertEqual(result, SCNVector3(1, -2, 3))
-    }
 }
 
 extension SCNVector3: Equatable {

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -20,13 +20,14 @@ final class SceneKitTests: XCTestCase {
     }
 
     func testNormaize() {
-        let v1Norm = vector1.normalize()
+        let v1Norm = vector1.normalized
         XCTAssertEqual(v1Norm.length, 1)
         
-        let vector3 = SCNVector3(1,1,1)
-        let v3Norm = vector3.normalize()
+        let vector3 = SCNVector3(4,4,2)
+        let v3Norm = vector3.normalized
+        XCTAssertEqual(v3Norm.x, 4/6)
         XCTAssertEqual(v3Norm.x, v3Norm.y)
-        XCTAssertEqual(v3Norm.y, v3Norm.z)
+        XCTAssertEqual(v3Norm.z, 2/6)
     }
     
     func testAdd() {
@@ -65,6 +66,22 @@ final class SceneKitTests: XCTestCase {
     func testMultiplyScalarFirst() {
         let result = 3 * vector1
         XCTAssertEqual(result, SCNVector3(30, -60, 90))
+    }
+    
+    func testDivide() {
+        let result = vector1 / 10
+        XCTAssertEqual(result, SCNVector3(1, -2, 3))
+    }
+
+    func testDivideEqual() {
+        var vector = vector1
+        vector /= 10
+        XCTAssertEqual(vector, SCNVector3(1, -2, 3))
+    }
+
+    func testDivideScalarFirst() {
+        let result = 10 / vector1
+        XCTAssertEqual(result, SCNVector3(1, -2, 3))
     }
 }
 

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -25,7 +25,7 @@ final class SceneKitTests: XCTestCase {
         
         let vector4 = SCNVector3(4, 4, 2)
         let v4Norm = vector4.normalized
-        XCTAssertEqual(v4Norm.x, 4/6)
+        XCTAssertEqual(v4Norm.x, 4 / 6)
         XCTAssertEqual(v4Norm.x, v4Norm.y)
         XCTAssertEqual(v4Norm.z, 2/6)
     }

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -19,11 +19,11 @@ final class SceneKitTests: XCTestCase {
         XCTAssertEqual(vector.length, 7)
     }
 
-    func testNormaize() {
+    func testNormaized() {
         let v1Norm = vector1.normalized
         XCTAssertEqual(v1Norm.length, 1)
         
-        let vector3 = SCNVector3(4,4,2)
+        let vector3 = SCNVector3(4, 4, 2)
         let v3Norm = vector3.normalized
         XCTAssertEqual(v3Norm.x, 4/6)
         XCTAssertEqual(v3Norm.x, v3Norm.y)

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -20,14 +20,14 @@ final class SceneKitTests: XCTestCase {
     }
 
     func testNormaized() {
-        let v1Norm = vector1.normalized
-        XCTAssertEqual(v1Norm.length, 1)
+        let v3Norm = SCNVector3(3, -5, 0.125).normalized
+        XCTAssertEqual(v3Norm.length, 1)
         
-        let vector3 = SCNVector3(4, 4, 2)
-        let v3Norm = vector3.normalized
-        XCTAssertEqual(v3Norm.x, 4/6)
-        XCTAssertEqual(v3Norm.x, v3Norm.y)
-        XCTAssertEqual(v3Norm.z, 2/6)
+        let vector4 = SCNVector3(4, 4, 2)
+        let v4Norm = vector4.normalized
+        XCTAssertEqual(v4Norm.x, 0.6666666)
+        XCTAssertEqual(v4Norm.x, v4Norm.y)
+        XCTAssertEqual(v4Norm.z, 0.3333333)
     }
     
     func testAdd() {

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -25,9 +25,9 @@ final class SceneKitTests: XCTestCase {
         
         let vector4 = SCNVector3(4, 4, 2)
         let v4Norm = vector4.normalized
-        XCTAssertEqual(v4Norm.x, 0.6666666)
+        XCTAssertEqual(v4Norm.x, 4/6)
         XCTAssertEqual(v4Norm.x, v4Norm.y)
-        XCTAssertEqual(v4Norm.z, 0.3333333)
+        XCTAssertEqual(v4Norm.z, 2/6)
     }
     
     func testAdd() {

--- a/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
+++ b/Tests/SceneKitTests/SCNVector3ExtensionsTests.swift
@@ -72,6 +72,12 @@ final class SceneKitTests: XCTestCase {
         let result = vector1 / 10
         XCTAssertEqual(result, SCNVector3(1, -2, 3))
     }
+
+    func testDivideEqual() {
+        var vector = vector1
+        vector /= 10
+        XCTAssertEqual(vector, SCNVector3(1, -2, 3))
+    }
 }
 
 extension SCNVector3: Equatable {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Added normalize function to SCNVector3 
Closes #907
The function uses the SIMD function `normalize` to scale the vector to have a length of 1, while still keeping the same trajectory.
> In mathematics, a unit vector in a normed vector space is a vector (often a spatial vector) of length 1.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
