### PR TITLE
Improve `Sequence` extensions with cleaner code and performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ## Upcoming Release
 ### Breaking Change
+- **Sequence**
+  - Remove `last(where:)` and move `last(where:equals:)` to `BidirectionalCollection`, since it only makes semantic sense for ordered sequences. [#912](https://github.com/SwifterSwift/SwifterSwift/pull/912) by [guykogus](https://github.com/guykogus)
 - **UIView**
   - Rename `shadowColor`, `shadowOffset`, `shadowOpacity` and `shadowRadius` to `layerShadowColor`, `layerShadowOffset`, `layerShadowOpacity` and `layerShadowRadius` to avoid naming colisions with subclasses properties defined in other modules e.g. UIKit. [#897](https://github.com/SwifterSwift/SwifterSwift/pull/897) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **RangeReplaceableCollection**:
   - `subscript(offset:)` and `subscript(range:)` to access and replace elements by the index offsets. [#826](https://github.com/SwifterSwift/SwifterSwift/pull/826) by [guykogus](https://github.com/guykogus)
 - **Sequence**:
+  - Added `contains(_:)` for `Hashable` elements for performance improvement. [#912](https://github.com/SwifterSwift/SwifterSwift/pull/912) by [guykogus](https://github.com/guykogus)
   - Added `first(where:equals:)` to find the first element of the sequence with having property by given key path equals to given value. [#836](https://github.com/SwifterSwift/SwifterSwift/pull/836) by [hamtiko](https://github.com/hamtiko)
   - Added `last(where:equals:)` to find the last element of the sequence with having property by given key path equals to given value. [#838](https://github.com/SwifterSwift/SwifterSwift/pull/838) by [hamtiko](https://github.com/hamtiko)
 - **SKNode**:

--- a/Sources/SwifterSwift/SwiftStdlib/BidirectionalCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/BidirectionalCollectionExtensions.swift
@@ -14,4 +14,14 @@ public extension BidirectionalCollection {
         let index = distance >= 0 ? startIndex : endIndex
         return self[indices.index(index, offsetBy: distance)]
     }
+
+    /// SwifterSwift: Returns the last element of the sequence with having property by given key path equals to given `value`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` of property for `Element` to compare.
+    ///   - value: The value to compare with `Element` property
+    /// - Returns: The last element of the collection that has property by given key path equals to given `value` or `nil` if there is no such element.
+    func last<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
+        return last { $0[keyPath: keyPath] == value }
+    }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/Deprecated/StdlibDeprecated.swift
@@ -99,4 +99,18 @@ public extension Sequence {
     func filter(by keyPath: KeyPath<Element, Bool>) -> [Element] {
         return filter { $0[keyPath: keyPath] }
     }
+
+    /// SwifterSwift: Get last element that satisfies a conditon.
+    ///
+    ///        [2, 2, 4, 7].last(where: {$0 % 2 == 0}) -> 4
+    ///
+    /// - Parameter condition: condition to evaluate each element against.
+    /// - Returns: the last element in the array matching the specified condition. (optional)
+    @available(*, deprecated, message: "For an unordered sequence using `last` instead of `first` is equal.")
+    func last(where condition: (Element) throws -> Bool) rethrows -> Element? {
+        for element in reversed() {
+            if try condition(element) { return element }
+        }
+        return nil
+    }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -38,10 +38,16 @@ public extension Sequence {
     ///
     ///        [2, 2, 4, 7].last(where: {$0 % 2 == 0}) -> 4
     ///
-    /// - Parameter condition: condition to evaluate each element against.
+    /// - Parameter predicate: condition to evaluate each element against.
     /// - Returns: the last element in the array matching the specified condition. (optional)
-    func last(where condition: (Element) throws -> Bool) rethrows -> Element? {
-        return try reversed().first(where: condition)
+    func last(where predicate: (Element) throws -> Bool) rethrows -> Element? {
+        var lastElement: Element?
+        for element in self {
+            if try predicate(element) {
+                lastElement = element
+            }
+        }
+        return lastElement
     }
 
     /// SwifterSwift: Filter elements based on a rejection condition.

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -34,22 +34,6 @@ public extension Sequence {
         return try contains { try condition($0) }
     }
 
-    /// SwifterSwift: Get last element that satisfies a conditon.
-    ///
-    ///        [2, 2, 4, 7].last(where: {$0 % 2 == 0}) -> 4
-    ///
-    /// - Parameter predicate: condition to evaluate each element against.
-    /// - Returns: the last element in the array matching the specified condition. (optional)
-    func last(where predicate: (Element) throws -> Bool) rethrows -> Element? {
-        var lastElement: Element?
-        for element in self {
-            if try predicate(element) {
-                lastElement = element
-            }
-        }
-        return lastElement
-    }
-
     /// SwifterSwift: Filter elements based on a rejection condition.
     ///
     ///        [2, 2, 4, 7].reject(where: {$0 % 2 == 0}) -> [7]
@@ -245,16 +229,6 @@ public extension Sequence {
     /// - Returns: The first element of the collection that has property by given key path equals to given `value` or `nil` if there is no such element.
     func first<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
         return first { $0[keyPath: keyPath] == value }
-    }
-
-    /// SwifterSwift: Returns the last element of the sequence with having property by given key path equals to given `value`.
-    ///
-    /// - Parameters:
-    ///   - keyPath: The `KeyPath` of property for `Element` to compare.
-    ///   - value: The value to compare with `Element` property
-    /// - Returns: The last element of the collection that has property by given key path equals to given `value` or `nil` if there is no such element.
-    func last<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
-        return reversed().first { $0[keyPath: keyPath] == value }
     }
 }
 

--- a/Tests/SwiftStdlibTests/BidirectionalCollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/BidirectionalCollectionExtensionsTests.swift
@@ -10,4 +10,20 @@ final class BidirectionalCollectionExtensionsTests: XCTestCase {
         XCTAssertEqual(arr[offset: 4], 5)
         XCTAssertEqual(arr[offset: -2], 4)
     }
+
+    func testLastByKeyPath() {
+        let array1 = [
+            Person(name: "John", age: 30, location: Location(city: "Boston")),
+            Person(name: "Jan", age: 22, location: nil),
+            Person(name: "Roman", age: 30, location: Location(city: "Moscow"))
+        ]
+
+        let last30Age = array1.last(where: \.age, equals: 30)
+
+        XCTAssertEqual(last30Age, array1.last)
+
+        let missingPerson = array1.last(where: \.name, equals: "Tom")
+
+        XCTAssertNil(missingPerson)
+    }
 }

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -97,7 +97,22 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(tuple.1, [1, 3, 5])
     }
 
-    func testContains() {
+    func testContainsEquatable() {
+        struct Foo: Equatable, ExpressibleByIntegerLiteral {
+            let value: Int
+
+            init(integerLiteral value: Int) { self.value = value }
+        }
+
+        XCTAssert([Foo]().contains([]))
+        XCTAssertFalse([Foo]().contains([1, 2]))
+        XCTAssert(([1, 2, 3] as [Foo]).contains([1, 2]))
+        XCTAssert(([1, 2, 3] as [Foo]).contains([2, 3]))
+        XCTAssert(([1, 2, 3] as [Foo]).contains([1, 3]))
+        XCTAssertFalse(([1, 2, 3] as [Foo]).contains([4, 5]))
+    }
+
+    func testContainsHashable() {
         XCTAssert([Int]().contains([]))
         XCTAssertFalse([Int]().contains([1, 2]))
         XCTAssert([1, 2, 3].contains([1, 2]))

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -7,62 +7,10 @@ private enum SequenceTestError: Error {
     case closureThrows
 }
 
-/// Use a `LinkedList` for testing an ordered, unidirectional `Sequence`
-struct LinkedList<T>: Sequence, ExpressibleByArrayLiteral {
-    fileprivate class Node {
-        let value: T
-        var next: Node?
+struct TestValue: Equatable, ExpressibleByIntegerLiteral {
+    let value: Int
 
-        init(value: T) {
-            self.value = value
-        }
-    }
-
-    struct Iterator: IteratorProtocol {
-        private var node: Node?
-
-        fileprivate init(node: Node?) {
-            self.node = node
-        }
-
-        mutating func next() -> T? {
-            defer { node = node?.next }
-            return node?.value
-        }
-    }
-
-    // MARK: LinkedList
-
-    private var head: Node?
-    private var tail: Node?
-
-    init<S>(_ elements: S) where S: Sequence, Self.Element == S.Element {
-        for element in elements {
-            append(element)
-        }
-    }
-
-    mutating func append(_ value: T) {
-        let node = Node(value: value)
-        if let tail = tail {
-            tail.next = node
-        } else {
-            head = node
-        }
-        tail = node
-    }
-
-    // MARK: Sequence
-
-    func makeIterator() -> Iterator {
-        return Iterator(node: head)
-    }
-
-    // MARK: ExpressibleByArrayLiteral
-
-    init(arrayLiteral elements: T...) {
-        self.init(elements)
-    }
+    init(integerLiteral value: Int) { self.value = value }
 }
 
 final class SequenceExtensionsTests: XCTestCase {
@@ -79,13 +27,6 @@ final class SequenceExtensionsTests: XCTestCase {
     func testNoneMatch() {
         let collection = [3, 5, 7, 9, 11, 13]
         XCTAssert(collection.none { $0 % 2 == 0 })
-    }
-
-    func testLastWhere() {
-        let list = LinkedList([1, 1, 2, 1, 1, 1, 2, 1, 4, 1])
-        XCTAssertEqual(list.last { $0 % 2 == 0 }, 4)
-        XCTAssertNil(list.last { $0 == 0 })
-        XCTAssertNil(LinkedList<Int>().last { $0 % 2 == 0 })
     }
 
     func testRejectWhere() {
@@ -156,18 +97,12 @@ final class SequenceExtensionsTests: XCTestCase {
     }
 
     func testContainsEquatable() {
-        struct Foo: Equatable, ExpressibleByIntegerLiteral {
-            let value: Int
-
-            init(integerLiteral value: Int) { self.value = value }
-        }
-
-        XCTAssert([Foo]().contains([]))
-        XCTAssertFalse([Foo]().contains([1, 2]))
-        XCTAssert(([1, 2, 3] as [Foo]).contains([1, 2]))
-        XCTAssert(([1, 2, 3] as [Foo]).contains([2, 3]))
-        XCTAssert(([1, 2, 3] as [Foo]).contains([1, 3]))
-        XCTAssertFalse(([1, 2, 3] as [Foo]).contains([4, 5]))
+        XCTAssert([TestValue]().contains([]))
+        XCTAssertFalse([TestValue]().contains([1, 2]))
+        XCTAssert(([1, 2, 3] as [TestValue]).contains([1, 2]))
+        XCTAssert(([1, 2, 3] as [TestValue]).contains([2, 3]))
+        XCTAssert(([1, 2, 3] as [TestValue]).contains([1, 3]))
+        XCTAssertFalse(([1, 2, 3] as [TestValue]).contains([4, 5]))
     }
 
     func testContainsHashable() {
@@ -260,22 +195,6 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(first30Age, array1.first)
 
         let missingPerson = array1.first(where: \.name, equals: "Tom")
-
-        XCTAssertNil(missingPerson)
-    }
-
-    func testLastByKeyPath() {
-        let array1 = [
-            Person(name: "John", age: 30, location: Location(city: "Boston")),
-            Person(name: "Jan", age: 22, location: nil),
-            Person(name: "Roman", age: 30, location: Location(city: "Moscow"))
-        ]
-
-        let last30Age = array1.last(where: \.age, equals: 30)
-
-        XCTAssertEqual(last30Age, array1.last)
-
-        let missingPerson = array1.last(where: \.name, equals: "Tom")
 
         XCTAssertNil(missingPerson)
     }


### PR DESCRIPTION
Also added `contains(_:)` for `Hashable` elements

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
