### PR TITLE
chore: reenable rule legacy_constructor 🚀

### DIFF
--- a/Sources/SwifterSwift/UIKit/UITextViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UITextViewExtensions.swift
@@ -14,15 +14,13 @@ public extension UITextView {
 
     /// SwifterSwift: Scroll to the bottom of text view
     func scrollToBottom() {
-        // swiftlint:disable:next legacy_constructor
-        let range = NSMakeRange((text as NSString).length - 1, 1)
+        let range = NSRange(location: (text as NSString).length - 1, length: 1)
         scrollRangeToVisible(range)
     }
 
     /// SwifterSwift: Scroll to the top of text view
     func scrollToTop() {
-        // swiftlint:disable:next legacy_constructor
-        let range = NSMakeRange(0, 1)
+        let range = NSRange(location: 0, length: 1)
         scrollRangeToVisible(range)
     }
 


### PR DESCRIPTION
The change was autocorrected using swiftlint itself.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
