### PR TITLE
refactor: base operators on in-place ones

### DIFF
--- a/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGPointExtensions.swift
@@ -51,7 +51,9 @@ public extension CGPoint {
     ///   - rhs: CGPoint to add.
     /// - Returns: result of addition of the two given CGPoints.
     static func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
-        return CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+        var result = lhs
+        result += rhs
+        return result
     }
 
     /// SwifterSwift: Add a CGPoints to self.
@@ -65,8 +67,8 @@ public extension CGPoint {
     ///   - lhs: self
     ///   - rhs: CGPoint to add.
     static func += (lhs: inout CGPoint, rhs: CGPoint) {
-        // swiftlint:disable:next shorthand_operator
-        lhs = lhs + rhs
+        lhs.x += rhs.x
+        lhs.y += rhs.y
     }
 
     /// SwifterSwift: Subtract two CGPoints.
@@ -81,7 +83,9 @@ public extension CGPoint {
     ///   - rhs: CGPoint to subtract.
     /// - Returns: result of subtract of the two given CGPoints.
     static func - (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
-        return CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+        var result = lhs
+        result -= rhs
+        return result
     }
 
     /// SwifterSwift: Subtract a CGPoints from self.
@@ -95,8 +99,8 @@ public extension CGPoint {
     ///   - lhs: self
     ///   - rhs: CGPoint to subtract.
     static func -= (lhs: inout CGPoint, rhs: CGPoint) {
-        // swiftlint:disable:next shorthand_operator
-        lhs = lhs - rhs
+        lhs.x -= rhs.x
+        lhs.y -= rhs.y
     }
 
     /// SwifterSwift: Multiply a CGPoint with a scalar
@@ -110,7 +114,9 @@ public extension CGPoint {
     ///   - scalar: scalar value.
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     static func * (point: CGPoint, scalar: CGFloat) -> CGPoint {
-        return CGPoint(x: point.x * scalar, y: point.y * scalar)
+        var result = point
+        result *= scalar
+        return result
     }
 
     /// SwifterSwift: Multiply self with a scalar
@@ -124,8 +130,8 @@ public extension CGPoint {
     ///   - scalar: scalar value.
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     static func *= (point: inout CGPoint, scalar: CGFloat) {
-        // swiftlint:disable:next shorthand_operator
-        point = point * scalar
+        point.x *= scalar
+        point.y *= scalar
     }
 
     /// SwifterSwift: Multiply a CGPoint with a scalar
@@ -139,7 +145,9 @@ public extension CGPoint {
     ///   - point: CGPoint to multiply.
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     static func * (scalar: CGFloat, point: CGPoint) -> CGPoint {
-        return CGPoint(x: point.x * scalar, y: point.y * scalar)
+        var result = point
+        result *= scalar
+        return result
     }
 }
 

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -72,7 +72,9 @@ public extension CGSize {
     ///   - rhs: CGSize to add.
     /// - Returns: The result comes from the addition of the two given CGSize struct.
     static func + (lhs: CGSize, rhs: CGSize) -> CGSize {
-        return CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
+        var result = lhs
+        result += rhs
+        return result
     }
 
     /// SwifterSwift: Add a tuple to CGSize.
@@ -86,7 +88,9 @@ public extension CGSize {
     ///   - tuple: tuple value.
     /// - Returns: The result comes from the addition of the given CGSize and tuple.
     static func + (lhs: CGSize, tuple: (width: CGFloat, height: CGFloat)) -> CGSize {
-        return CGSize(width: lhs.width + tuple.width, height: lhs.height + tuple.height)
+        var result = lhs
+        result += tuple
+        return result
     }
 
     /// SwifterSwift: Add a CGSize to self.
@@ -130,7 +134,9 @@ public extension CGSize {
     ///   - rhs: CGSize to subtract.
     /// - Returns: The result comes from the subtract of the two given CGSize struct.
     static func - (lhs: CGSize, rhs: CGSize) -> CGSize {
-        return CGSize(width: lhs.width - rhs.width, height: lhs.height - rhs.height)
+        var result = lhs
+        result -= rhs
+        return result
     }
 
     /// SwifterSwift: Subtract a tuple from CGSize.
@@ -144,7 +150,9 @@ public extension CGSize {
     ///   - tuple: tuple value.
     /// - Returns: The result comes from the subtract of the given CGSize and tuple.
     static func - (lhs: CGSize, tuple: (width: CGFloat, heoght: CGFloat)) -> CGSize {
-        return CGSize(width: lhs.width - tuple.width, height: lhs.height - tuple.heoght)
+        var result = lhs
+        result -= tuple
+        return result
     }
 
     /// SwifterSwift: Subtract a CGSize from self.
@@ -188,7 +196,9 @@ public extension CGSize {
     ///   - rhs: CGSize to multiply with.
     /// - Returns: The result comes from the multiplication of the two given CGSize structs.
     static func * (lhs: CGSize, rhs: CGSize) -> CGSize {
-        return CGSize(width: lhs.width * rhs.width, height: lhs.height * rhs.height)
+        var result = lhs
+        result *= rhs
+        return result
     }
 
     /// SwifterSwift: Multiply a CGSize with a scalar.
@@ -202,7 +212,9 @@ public extension CGSize {
     ///   - scalar: scalar value.
     /// - Returns: The result comes from the multiplication of the given CGSize and scalar.
     static func * (lhs: CGSize, scalar: CGFloat) -> CGSize {
-        return CGSize(width: lhs.width * scalar, height: lhs.height * scalar)
+        var result = lhs
+        result *= scalar
+        return result
     }
 
     /// SwifterSwift: Multiply a CGSize with a scalar.
@@ -216,7 +228,9 @@ public extension CGSize {
     ///   - rhs: CGSize to multiply.
     /// - Returns: The result comes from the multiplication of the given scalar and CGSize.
     static func * (scalar: CGFloat, rhs: CGSize) -> CGSize {
-        return CGSize(width: scalar * rhs.width, height: scalar * rhs.height)
+        var result = rhs
+        result *= scalar
+        return result
     }
 
     /// SwifterSwift: Multiply self with a CGSize.

--- a/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGSizeExtensions.swift
@@ -149,7 +149,7 @@ public extension CGSize {
     ///   - lhs: CGSize to subtract from.
     ///   - tuple: tuple value.
     /// - Returns: The result comes from the subtract of the given CGSize and tuple.
-    static func - (lhs: CGSize, tuple: (width: CGFloat, heoght: CGFloat)) -> CGSize {
+    static func - (lhs: CGSize, tuple: (width: CGFloat, height: CGFloat)) -> CGSize {
         var result = lhs
         result -= tuple
         return result

--- a/Sources/SwifterSwift/CoreGraphics/CGVectorExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGVectorExtensions.swift
@@ -51,7 +51,9 @@ public extension CGVector {
     ///   - scalar: The scale by which the vector will be multiplied
     /// - Returns: The vector with its magnitude scaled
     static func * (vector: CGVector, scalar: CGFloat) -> CGVector {
-        return CGVector(dx: vector.dx * scalar, dy: vector.dy * scalar)
+        var result = vector
+        result *= scalar
+        return result
     }
 
     /// SwifterSwift: Multiplies a scalar and a vector (commutative).
@@ -64,7 +66,9 @@ public extension CGVector {
     ///   - vector: The vector to be multiplied
     /// - Returns: The vector with its magnitude scaled
     static func * (scalar: CGFloat, vector: CGVector) -> CGVector {
-        return CGVector(dx: scalar * vector.dx, dy: scalar * vector.dy)
+        var result = vector
+        result *= scalar
+        return result
     }
 
     /// SwifterSwift: Compound assignment operator for vector-scalr multiplication
@@ -76,8 +80,8 @@ public extension CGVector {
     ///   - vector: The vector to be multiplied
     ///   - scalar: The scale by which the vector will be multiplied
     static func *= (vector: inout CGVector, scalar: CGFloat) {
-        // swiftlint:disable:next shorthand_operator
-        vector = vector * scalar
+        vector.dx *= scalar
+        vector.dy *= scalar
     }
 
     /// SwifterSwift: Negates the vector. The direction is reversed, but magnitude remains the same.

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -55,6 +55,7 @@ public extension SCNVector3 {
         var result = lhs
         result += rhs
         return result
+    }
 
     /// SwifterSwift: Add a SCNVector3 to self.
     ///

--- a/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
+++ b/Sources/SwifterSwift/SceneKit/SCNVector3Extensions.swift
@@ -52,8 +52,9 @@ public extension SCNVector3 {
     ///   - rhs: SCNVector3 to add.
     /// - Returns: result of addition of the two given SCNVector3s.
     static func + (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
-        return SCNVector3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z)
-    }
+        var result = lhs
+        result += rhs
+        return result
 
     /// SwifterSwift: Add a SCNVector3 to self.
     ///
@@ -63,8 +64,9 @@ public extension SCNVector3 {
     ///   - lhs: self
     ///   - rhs: SCNVector3 to add.
     static func += (lhs: inout SCNVector3, rhs: SCNVector3) {
-        // swiftlint:disable:next shorthand_operator
-        lhs = lhs + rhs
+        lhs.x += rhs.x
+        lhs.y += rhs.y
+        lhs.z += rhs.z
     }
 
     /// SwifterSwift: Subtract two SCNVector3s.
@@ -76,7 +78,9 @@ public extension SCNVector3 {
     ///   - rhs: SCNVector3 to subtract.
     /// - Returns: result of subtract of the two given SCNVector3s.
     static func - (lhs: SCNVector3, rhs: SCNVector3) -> SCNVector3 {
-        return SCNVector3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z)
+        var result = lhs
+        result -= rhs
+        return result
     }
 
     /// SwifterSwift: Subtract a SCNVector3 from self.
@@ -87,8 +91,9 @@ public extension SCNVector3 {
     ///   - lhs: self
     ///   - rhs: SCNVector3 to subtract.
     static func -= (lhs: inout SCNVector3, rhs: SCNVector3) {
-        // swiftlint:disable:next shorthand_operator
-        lhs = lhs - rhs
+        lhs.x -= rhs.x
+        lhs.y -= rhs.y
+        lhs.z -= rhs.z
     }
 
     /// SwifterSwift: Multiply a SCNVector3 with a scalar
@@ -100,7 +105,9 @@ public extension SCNVector3 {
     ///   - scalar: scalar value.
     /// - Returns: result of multiplication of the given SCNVector3 with the scalar.
     static func * (vector: SCNVector3, scalar: SceneKitFloat) -> SCNVector3 {
-        return SCNVector3(vector.x * scalar, vector.y * scalar, vector.z * scalar)
+        var result = vector
+        result *= scalar
+        return result
     }
 
     /// SwifterSwift: Multiply self with a scalar
@@ -112,8 +119,9 @@ public extension SCNVector3 {
     ///   - scalar: scalar value.
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     static func *= (vector: inout SCNVector3, scalar: SceneKitFloat) {
-        // swiftlint:disable:next shorthand_operator
-        vector = vector * scalar
+        vector.x *= scalar
+        vector.y *= scalar
+        vector.z *= scalar
     }
 
     /// SwifterSwift: Multiply a scalar with a SCNVector3
@@ -125,7 +133,9 @@ public extension SCNVector3 {
     ///   - vector: SCNVector3 to multiply.
     /// - Returns: result of multiplication of the given CGPoint with the scalar.
     static func * (scalar: SceneKitFloat, vector: SCNVector3) -> SCNVector3 {
-        return SCNVector3(vector.x * scalar, vector.y * scalar, vector.z * scalar)
+        var result = vector
+        result *= scalar
+        return result
     }
     
     /// SwifterSwift: Divide a SCNVector3 with a scalar
@@ -137,7 +147,9 @@ public extension SCNVector3 {
     ///   - scalar: scalar value.
     /// - Returns: result of division of the given SCNVector3 with the scalar.
     static func / (vector: SCNVector3, scalar: SceneKitFloat) -> SCNVector3 {
-        return SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
+        var result = vector
+        result /= scalar
+        return result
     }
 
     /// SwifterSwift: Divide self with a scalar
@@ -149,7 +161,9 @@ public extension SCNVector3 {
     ///   - scalar: scalar value.
     /// - Returns: result of division of the given CGPoint with the scalar.
     static func /= (vector: inout SCNVector3, scalar: SceneKitFloat) {
-        vector = SCNVector3(vector.x / scalar, vector.y / scalar, vector.z / scalar)
+        vector.x /= scalar
+        vector.y /= scalar
+        vector.z /= scalar
     }
 }
 

--- a/Sources/SwifterSwift/Shared/EdgeInsetsExtensions.swift
+++ b/Sources/SwifterSwift/Shared/EdgeInsetsExtensions.swift
@@ -140,10 +140,9 @@ public extension EdgeInsets {
     ///   - rhs: The right-hand expression
     /// - Returns: A new `EdgeInsets` instance where the values of `lhs` and `rhs` are added together.
     static func + (_ lhs: EdgeInsets, _ rhs: EdgeInsets) -> EdgeInsets {
-        return EdgeInsets(top: lhs.top + rhs.top,
-                          left: lhs.left + rhs.left,
-                          bottom: lhs.bottom + rhs.bottom,
-                          right: lhs.right + rhs.right)
+        var result = lhs
+        result += rhs
+        return result
     }
 
     /// SwifterSwift: Add all the properties of two `EdgeInsets` to the left-hand instance.

--- a/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
@@ -256,11 +256,11 @@ public extension Dictionary {
     ///
     /// - Parameters:
     ///   - lhs: dictionary
-    ///   - rhs: array with the keys to be removed.
+    ///   - keys: array with the keys to be removed.
     /// - Returns: a new dictionary with keys removed.
     static func - <S: Sequence>(lhs: [Key: Value], keys: S) -> [Key: Value] where S.Element == Key {
         var result = lhs
-        result -= rhs
+        result -= keys
         return result
     }
 
@@ -274,7 +274,7 @@ public extension Dictionary {
     ///
     /// - Parameters:
     ///   - lhs: dictionary
-    ///   - rhs: array with the keys to be removed.
+    ///   - keys: array with the keys to be removed.
     static func -= <S: Sequence>(lhs: inout [Key: Value], keys: S) where S.Element == Key {
         lhs.removeAll(keys: keys)
     }

--- a/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DictionaryExtensions.swift
@@ -225,7 +225,7 @@ public extension Dictionary {
     /// - Returns: An dictionary with keys and values from both.
     static func + (lhs: [Key: Value], rhs: [Key: Value]) -> [Key: Value] {
         var result = lhs
-        rhs.forEach { result[$0] = $1 }
+        result += rhs
         return result
     }
 
@@ -260,7 +260,7 @@ public extension Dictionary {
     /// - Returns: a new dictionary with keys removed.
     static func - <S: Sequence>(lhs: [Key: Value], keys: S) -> [Key: Value] where S.Element == Key {
         var result = lhs
-        result.removeAll(keys: keys)
+        result -= rhs
         return result
     }
 


### PR DESCRIPTION
Operators should be implemented based on their in-place variants, not the other way around. In that way in-place operations won't allocate any new objects.

See #916 for more details.

This PR allows us to reenable the swiftlint rule shorthand_operator. It also refactors other operators to use their in-place variant to reduce code duplication.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
