### PR TITLE
Add NSUbiquitousKeyValueStore.url(forKey:) solving issue number #910

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Rename `shadowColor`, `shadowOffset`, `shadowOpacity` and `shadowRadius` to `layerShadowColor`, `layerShadowOffset`, `layerShadowOpacity` and `layerShadowRadius` to avoid naming colisions with subclasses properties defined in other modules e.g. UIKit. [#897](https://github.com/SwifterSwift/SwifterSwift/pull/897) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 
 ### Added
+- **NSUbiquitousKeyValueStore**
+- Added `url(forKey key: String)` to Add NSUbiquitousKeyValueStore.url(forKey:). [#910](https://github.com/SwifterSwift/SwifterSwift/pull/910) by [RomanPodymov](https://github.com/RomanPodymov)
 - **SCN3Vector**
   - Added `normalized` method, and basic division functions (`SCNVector3 / scalar`, and `SCNVector3 /= scalar`. [#908](https://github.com/SwifterSwift/SwifterSwift/pull/908) by [thisIsTheFoxe](https://github.com/thisisthefoxe)
 - **Dictionary**

--- a/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSUbiquitousKeyValueStoreExtensions.swift
@@ -1,0 +1,18 @@
+// NSUbiquitousKeyValueStoreExtensions.swift - Copyright 2020 SwifterSwift
+
+#if canImport(Foundation) && !os(Linux)
+import Foundation
+
+// MARK: - Methods
+
+public extension NSUbiquitousKeyValueStore {
+    /// SwifterSwift: URL from NSUbiquitousKeyValueStore.
+    ///
+    /// - Parameter forKey: key to find URL for.
+    /// - Returns: URL object for key (if exists).
+    func url(forKey key: String) -> URL? {
+        return URL(string: object(forKey: key) as? String)
+    }
+}
+
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -523,6 +523,12 @@
 		9DC844A32349E1EE00E1571A /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */; };
 		9DC844A62349E27600E1571A /* NSColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC844A42349E24600E1571A /* NSColorExtensions.swift */; };
 		9DC844A82349E28100E1571A /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */; };
+		A7F70ED2256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F70ED1256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift */; };
+		A7F70ED3256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F70ED1256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift */; };
+		A7F70ED5256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F70ED1256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift */; };
+		A7F70EF7256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F70EF6256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift */; };
+		A7F70F1D256BB10E0082B499 /* NSUbiquitousKeyValueStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F70EF6256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift */; };
+		A7F70F25256BB10F0082B499 /* NSUbiquitousKeyValueStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F70EF6256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift */; };
 		A94AA78720280F9100E229A5 /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */; };
 		A94AA78A202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */; };
 		A94AA78B202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */; };
@@ -850,6 +856,8 @@
 		9DC29CF32349E7E200F5CAAD /* UIColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensionsTests.swift; sourceTree = "<group>"; };
 		9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 		9DC844A42349E24600E1571A /* NSColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSColorExtensions.swift; sourceTree = "<group>"; };
+		A7F70ED1256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUbiquitousKeyValueStoreExtensions.swift; sourceTree = "<group>"; };
+		A7F70EF6256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUbiquitousKeyValueStoreTest.swift; sourceTree = "<group>"; };
 		A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
 		A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensionsTests.swift; sourceTree = "<group>"; };
 		B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionExtensions.swift; sourceTree = "<group>"; };
@@ -1094,6 +1102,7 @@
 				07B7F1621F5EB41600E6F910 /* NSAttributedStringExtensions.swift */,
 				9D4914821F85138E00F3868F /* NSPredicateExtensions.swift */,
 				F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */,
+				A7F70ED1256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift */,
 				07B7F1781F5EB41600E6F910 /* URLExtensions.swift */,
 				077BA0891F6BE81F00D9C4AC /* URLRequestExtensions.swift */,
 				077BA08E1F6BE83600D9C4AC /* UserDefaultsExtensions.swift */,
@@ -1179,6 +1188,7 @@
 				07C50D291F5EB03200F46E5A /* NSAttributedStringExtensionsTests.swift */,
 				9D4914881F8515D100F3868F /* NSPredicateExtensionsTests.swift */,
 				F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */,
+				A7F70EF6256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift */,
 				07C50D071F5EB03200F46E5A /* URLExtensionsTests.swift */,
 				077BA0941F6BE98500D9C4AC /* URLRequestExtensionsTests.swift */,
 				077BA0991F6BE99F00D9C4AC /* UserDefaultsExtensionsTests.swift */,
@@ -2035,6 +2045,7 @@
 				07B7F19E1F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
 				07B7F20F1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				0DAEBCE024B0045F00F61684 /* HKActivitySummaryExtensions.swift in Sources */,
+				A7F70ED2256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift in Sources */,
 				07B7F19C1F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				9D806A5B2258D2B8008E500A /* SCNMaterialExtensions.swift in Sources */,
 				F87AA5D5241257E3005F5B28 /* NotificationCenterExtensions.swift in Sources */,
@@ -2109,6 +2120,7 @@
 				07B7F2391F5EB45200E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				07B7F1AD1F5EB42000E6F910 /* UIImageExtensions.swift in Sources */,
 				9D806A372258AE09008E500A /* UIBezierPathExtensions.swift in Sources */,
+				A7F70ED3256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift in Sources */,
 				077BA08B1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				07A1C448224FFE16003272E4 /* UIApplicationExtensions.swift in Sources */,
 				F854D2C42423ECF0003A08A9 /* CATransform3DExtensions.swift in Sources */,
@@ -2253,6 +2265,7 @@
 				07B7F1D71F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
 				9DC844A62349E27600E1571A /* NSColorExtensions.swift in Sources */,
 				07B7F2231F5EB44600E6F910 /* CGSizeExtensions.swift in Sources */,
+				A7F70ED5256BABDB0082B499 /* NSUbiquitousKeyValueStoreExtensions.swift in Sources */,
 				664CB9792171899800FC87B4 /* BinaryFloatingPointExtensions.swift in Sources */,
 				9D806A632258D503008E500A /* SCNPlaneExtensions.swift in Sources */,
 				07B7F1E11F5EB43B00E6F910 /* OptionalExtensions.swift in Sources */,
@@ -2404,6 +2417,7 @@
 				86B3F7AE208D3DF300BC297B /* UIScrollViewExtensionsTests.swift in Sources */,
 				18C8E5E32074C67000F8AF51 /* SequenceExtensionsTests.swift in Sources */,
 				116090B424187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */,
+				A7F70EF7256BAC2F0082B499 /* NSUbiquitousKeyValueStoreTest.swift in Sources */,
 				07C50D5D1F5EB05000F46E5A /* DictionaryExtensionsTests.swift in Sources */,
 				748B191F23B4F4FA0030FABB /* SKProductTests.swift in Sources */,
 				07C50D5B1F5EB05000F46E5A /* DataExtensionsTests.swift in Sources */,
@@ -2445,6 +2459,7 @@
 				07C50D421F5EB04700F46E5A /* UIBarButtonExtensionsTests.swift in Sources */,
 				D951E8B023D04E4600F2CD0B /* DecodableExtensionsTests.swift in Sources */,
 				9D806A8C2258F892008E500A /* SCNGeometryExtensionsTests.swift in Sources */,
+				A7F70F1D256BB10E0082B499 /* NSUbiquitousKeyValueStoreTest.swift in Sources */,
 				077BA0BA1F6BEA6A00D9C4AC /* UserDefaultsExtensionsTests.swift in Sources */,
 				9D806A832258F56F008E500A /* SCNBoxExtensionsTests.swift in Sources */,
 				07C50D671F5EB05100F46E5A /* CharacterExtensionsTests.swift in Sources */,
@@ -2584,6 +2599,7 @@
 				A94AA78C202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */,
 				9D806AA12258FF1A008E500A /* SCNSphereExtensionsTests.swift in Sources */,
 				9D806A8D2258F892008E500A /* SCNGeometryExtensionsTests.swift in Sources */,
+				A7F70F25256BB10F0082B499 /* NSUbiquitousKeyValueStoreTest.swift in Sources */,
 				078916DC2076077000AC0665 /* FloatingPointExtensionsTests.swift in Sources */,
 				9D806AA52258FF98008E500A /* SCNPlaneExtensionsTests.swift in Sources */,
 				07A494EB23C7CAC500DFCBFC /* CLVisitExtensionsTests.swift in Sources */,

--- a/Tests/FoundationTests/NSUbiquitousKeyValueStoreTest.swift
+++ b/Tests/FoundationTests/NSUbiquitousKeyValueStoreTest.swift
@@ -1,0 +1,23 @@
+// NSUbiquitousKeyValueStoreTest.swift - Copyright 2020 SwifterSwift
+
+@testable import SwifterSwift
+import XCTest
+
+#if canImport(Foundation)
+import Foundation
+
+final class NSUbiquitousKeyValueStoreTest: XCTestCase {
+
+    func testURL() {
+        #if !os(Linux)
+        let key = "urlTestKey"
+        let url = URL(string: "https://www.github.com")
+        NSUbiquitousKeyValueStore.default.set(url?.absoluteString, forKey: key)
+        NSUbiquitousKeyValueStore.default.synchronize()
+        XCTAssertNotNil(NSUbiquitousKeyValueStore.default.url(forKey: key))
+        XCTAssertEqual( NSUbiquitousKeyValueStore.default.url(forKey: key)!, url)
+        #endif
+    }
+}
+
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
