### PR TITLE
Modify Namespaces in ColorExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIAlertController**:
   - Mark `show` method as unavailable for `iOSAppExtension` targets. [#918](https://github.com/SwifterSwift/SwifterSwift/pull/918) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
 - **ColorExtension**:
-  - Use `enum` to declare namespace instead of using `struct`. Thus private initailizer is no longer needed. by [Shiva Huang](https://github.com/ShivaHuang)
+  - Use `enum` to declare namespace instead of using `struct`. Thus private initailizer is no longer needed. [#927] by [Shiva Huang](https://github.com/ShivaHuang)
 
 ### Deprecated
 - **Sequence**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `addPaddingRight`,`addPaddingRightIcon`extension,[#878](https://github.com/SwifterSwift/SwifterSwift/pull/878) by [Jayxiang](https://github.com/Jayxiang)
 - **UIAlertController**:
   - Mark `show` method as unavailable for `iOSAppExtension` targets. [#918](https://github.com/SwifterSwift/SwifterSwift/pull/918) by [LucianoPAlmeida](https://github.com/LucianoPAlmeida)
+- **ColorExtension**:
+  - Use `enum` to declare namespace instead of using `struct`. Thus private initailizer is no longer needed. by [Shiva Huang](https://github.com/ShivaHuang)
 
 ### Deprecated
 - **Sequence**:
@@ -86,6 +88,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Fixed a bug:UITextField `addPaddingLeftIcon` doesn't work on iOS 13[#876](https://github.com/SwifterSwift/SwifterSwift/issues/876) by [Jayxiang](https://github.com/Jayxiang)
 - **UIImage**
   - Fixed a bug:UIImage `rotated(by:)` lose origin scale, result in image blurred[#904](https://github.com/SwifterSwift/SwifterSwift/pull/904) by [yanpanpan](https://github.com/yanpanpan)
+- **ColorExtension**:
+  - Fixed a bug: `Color.FlatUI` can be initialized. by [Shiva Huang](https://github.com/ShivaHuang)
 
 ### Security
 

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -362,10 +362,8 @@ public extension Color {
 
 public extension Color {
     /// SwifterSwift: Brand identity color of popular social media platform.
-    struct Social {
+    enum Social {
         // https://www.lockedowndesign.com/social-media-colors/
-
-        private init() {}
 
         /// SwifterSwift: red: 59, green: 89, blue: 152
         public static let facebook = Color(red: 59, green: 89, blue: 152)!
@@ -455,10 +453,8 @@ public extension Color {
 public extension Color {
     // swiftlint:disable type_body_length
     /// SwifterSwift: Google Material design colors palette.
-    struct Material {
+    enum Material {
         // https://material.google.com/style/color.html
-
-        private init() {}
 
         /// SwifterSwift: color red500
         public static let red = red500
@@ -1291,10 +1287,8 @@ public extension Color {
 
 public extension Color {
     /// SwifterSwift: CSS colors.
-    struct CSS {
+    enum CSS {
         // http://www.w3schools.com/colors/colors_names.asp
-
-        private init() {}
 
         /// SwifterSwift: hex #F0F8FF
         public static let aliceBlue = Color(hex: 0xF0F8FF)!
@@ -1746,7 +1740,7 @@ public extension Color {
 
 public extension Color {
     /// SwifterSwift: Flat UI colors
-    struct FlatUI {
+    enum FlatUI {
         // http://flatuicolors.com.
 
         /// SwifterSwift: hex #1ABC9C


### PR DESCRIPTION
Use `enum` to declare a namespace, instead of `struct`.

The difference of using enum and struct is,  if struct is used, we need to make `init` private to prevent user create an instance of this namespace.

Like the following shows: https://github.com/SwifterSwift/SwifterSwift/blob/61187db25876a8bb3cb49548478d072bdefb52a5/Sources/SwifterSwift/Shared/ColorExtensions.swift#L365-L368
https://github.com/SwifterSwift/SwifterSwift/blob/61187db25876a8bb3cb49548478d072bdefb52a5/Sources/SwifterSwift/Shared/ColorExtensions.swift#L458-L461
https://github.com/SwifterSwift/SwifterSwift/blob/61187db25876a8bb3cb49548478d072bdefb52a5/Sources/SwifterSwift/Shared/ColorExtensions.swift#L1294-L1297

And it's easy to forget to do the protection like:
https://github.com/SwifterSwift/SwifterSwift/blob/61187db25876a8bb3cb49548478d072bdefb52a5/Sources/SwifterSwift/Shared/ColorExtensions.swift#L1749-L1751

Using `enum` can avoid these issues by natural.
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
