### PR TITLE
UIView Extension Rotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `isStandGoalMet`, `isExerciseTimeGoalMet`, and `isEnergyBurnedGoalMet`. [#875](https://github.com/SwifterSwift/SwifterSwift/pull/875) by [lhygilbert](https://github.com/lhygilbert)
 - **UIView**:
   - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
-  - Added `rotate(by:animated:duration:completion:)` to rotate a view by angle presented by `Measurement<UnitAngle>`.
+  - Added `rotate(by:animated:duration:completion:)` to rotate a view by angle presented by `Measurement<UnitAngle>`. [#940](https://github.com/SwifterSwift/SwifterSwift/pull/940) by [Shiva Huang](https://github.com/ShivaHuang)
 - **UIImage**
   - Added `averageColor`, which calculates the average UIColor for an entire image. [#884](https://github.com/SwifterSwift/SwifterSwift/pull/884) by [gurgeous](https://github.com/gurgeous)
   - Added `loadFromNib(withClass:)`, which loads a UIView of a particular type from a nib file. [#885](https://github.com/SwifterSwift/SwifterSwift/pull/885) by [gurgeous](https://github.com/gurgeous)
@@ -78,7 +78,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Sequence**:
   - Marked `map(by:)`, `compactMap(by:)`, `filter(by:)` as deprecated in favor use of Key Path expressions as functions feature in Swift 5.2. [#862](https://github.com/SwifterSwift/SwifterSwift/pull/862) by [Roman Podymov](https://github.com/RomanPodymov).
 - **UIView**:
-  - Marked `AngleUnit`, `rotate(byAngle:ofType:animated:duration:completion:)` and `rotate(toAngle:ofType:animated:duration:completion:)` as deprecated in favor of using `rotate(by:animated:duration:completion:)`, which takes `Measurement<UnitAngle>` to present the angle to rotate.
+  - Marked `AngleUnit`, `rotate(byAngle:ofType:animated:duration:completion:)` and `rotate(toAngle:ofType:animated:duration:completion:)` as deprecated in favor of using `rotate(by:animated:duration:completion:)`, which takes `Measurement<UnitAngle>` to present the angle to rotate. [#940](https://github.com/SwifterSwift/SwifterSwift/pull/940) by [Shiva Huang](https://github.com/ShivaHuang)
 
 ### Removed
 - **UIDatePicker**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `isStandGoalMet`, `isExerciseTimeGoalMet`, and `isEnergyBurnedGoalMet`. [#875](https://github.com/SwifterSwift/SwifterSwift/pull/875) by [lhygilbert](https://github.com/lhygilbert)
 - **UIView**:
   - Added `masksToBounds` (IBInspectable) extension. [#877](https://github.com/SwifterSwift/SwifterSwift/pull/877) by [hamtiko](https://github.com/hamtiko)
+  - Added `rotate(by:animated:duration:completion:)` to rotate a view by angle presented by `Measurement<UnitAngle>`.
 - **UIImage**
   - Added `averageColor`, which calculates the average UIColor for an entire image. [#884](https://github.com/SwifterSwift/SwifterSwift/pull/884) by [gurgeous](https://github.com/gurgeous)
   - Added `loadFromNib(withClass:)`, which loads a UIView of a particular type from a nib file. [#885](https://github.com/SwifterSwift/SwifterSwift/pull/885) by [gurgeous](https://github.com/gurgeous)
@@ -76,6 +77,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 - **Sequence**:
   - Marked `map(by:)`, `compactMap(by:)`, `filter(by:)` as deprecated in favor use of Key Path expressions as functions feature in Swift 5.2. [#862](https://github.com/SwifterSwift/SwifterSwift/pull/862) by [Roman Podymov](https://github.com/RomanPodymov).
+- **UIView**:
+  - Marked `AngleUnit`, `rotate(byAngle:ofType:animated:duration:completion:)` and `rotate(toAngle:ofType:animated:duration:completion:)` as deprecated in favor of using `rotate(by:animated:duration:completion:)`, which takes `Measurement<UnitAngle>` to present the angle to rotate.
 
 ### Removed
 - **UIDatePicker**

--- a/Sources/SwifterSwift/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/SwifterSwift/UIKit/Deprecated/UIKitDeprecated.swift
@@ -1,0 +1,64 @@
+// UIKitDeprecated.swift - Copyright 2021 SwifterSwift
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+public extension UIView {
+    /// SwifterSwift: Angle units.
+    ///
+    /// - degrees: degrees.
+    /// - radians: radians.
+    @available(*, deprecated, message: "Use UnitAngle instead.")
+    enum AngleUnit {
+        /// SwifterSwift: degrees.
+        case degrees
+
+        /// SwifterSwift: radians.
+        case radians
+    }
+
+    /// SwifterSwift: Rotate view by angle on relative axis.
+    ///
+    /// - Parameters:
+    ///   - angle: angle to rotate view by.
+    ///   - type: type of the rotation angle.
+    ///   - animated: set true to animate rotation (default is true).
+    ///   - duration: animation duration in seconds (default is 1 second).
+    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    @available(*, deprecated, message: "Use rotate(by:animated:duration:completion:) instead.")
+    func rotate(
+        byAngle angle: CGFloat,
+        ofType type: AngleUnit,
+        animated: Bool = false,
+        duration: TimeInterval = 1,
+        completion: ((Bool) -> Void)? = nil) {
+        let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
+        let aDuration = animated ? duration : 0
+        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
+            self.transform = self.transform.rotated(by: angleWithType)
+        }, completion: completion)
+    }
+
+    /// SwifterSwift: Rotate view to angle on fixed axis.
+    ///
+    /// - Parameters:
+    ///   - angle: angle to rotate view to.
+    ///   - type: type of the rotation angle.
+    ///   - animated: set true to animate rotation (default is false).
+    ///   - duration: animation duration in seconds (default is 1 second).
+    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    @available(*, deprecated, message: "Use rotate(by:animated:duration:completion:) instead.")
+    func rotate(
+        toAngle angle: CGFloat,
+        ofType type: AngleUnit,
+        animated: Bool = false,
+        duration: TimeInterval = 1,
+        completion: ((Bool) -> Void)? = nil) {
+        let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
+        let aDuration = animated ? duration : 0
+        UIView.animate(withDuration: aDuration, animations: {
+            self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: angleWithType))
+        }, completion: completion)
+    }
+}
+#endif

--- a/Sources/SwifterSwift/UIKit/Deprecated/UIKitDeprecated.swift
+++ b/Sources/SwifterSwift/UIKit/Deprecated/UIKitDeprecated.swift
@@ -20,11 +20,11 @@ public extension UIView {
     /// SwifterSwift: Rotate view by angle on relative axis.
     ///
     /// - Parameters:
-    ///   - angle: angle to rotate view by.
-    ///   - type: type of the rotation angle.
-    ///   - animated: set true to animate rotation (default is true).
-    ///   - duration: animation duration in seconds (default is 1 second).
-    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    ///   - angle: Angle to rotate view by.
+    ///   - type: Type of the rotation angle.
+    ///   - animated: Set `true` to animate rotation (default is `false`).
+    ///   - duration: Animation duration in seconds (default is `1` second).
+    ///   - completion: Optional completion handler to run with animation finishes (default is `nil`).
     @available(*, deprecated, message: "Use rotate(by:animated:duration:completion:) instead.")
     func rotate(
         byAngle angle: CGFloat,
@@ -42,11 +42,11 @@ public extension UIView {
     /// SwifterSwift: Rotate view to angle on fixed axis.
     ///
     /// - Parameters:
-    ///   - angle: angle to rotate view to.
-    ///   - type: type of the rotation angle.
-    ///   - animated: set true to animate rotation (default is false).
-    ///   - duration: animation duration in seconds (default is 1 second).
-    ///   - completion: optional completion handler to run with animation finishes (default is nil).
+    ///   - angle: Angle to rotate view to.
+    ///   - type: Type of the rotation angle.
+    ///   - animated: Set `true` to animate rotation (default is `false`).
+    ///   - duration: Animation duration in seconds (default is `1` second).
+    ///   - completion: Optional completion handler to run with animation finishes (default is `nil`).
     @available(*, deprecated, message: "Use rotate(by:animated:duration:completion:) instead.")
     func rotate(
         toAngle angle: CGFloat,

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -18,18 +18,6 @@ public extension UIView {
         case vertical
     }
 
-    /// SwifterSwift: Angle units.
-    ///
-    /// - degrees: degrees.
-    /// - radians: radians.
-    enum AngleUnit {
-        /// SwifterSwift: degrees.
-        case degrees
-
-        /// SwifterSwift: radians.
-        case radians
-    }
-
     /// SwifterSwift: Shake animations types.
     ///
     /// - linear: linear animation.
@@ -387,48 +375,6 @@ public extension UIView {
         let radians = CGFloat(angle.converted(to: .radians).value)
         UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
             self.transform = self.transform.rotated(by: radians)
-        }, completion: completion)
-    }
-
-    /// SwifterSwift: Rotate view by angle on relative axis.
-    ///
-    /// - Parameters:
-    ///   - angle: angle to rotate view by.
-    ///   - type: type of the rotation angle.
-    ///   - animated: set true to animate rotation (default is true).
-    ///   - duration: animation duration in seconds (default is 1 second).
-    ///   - completion: optional completion handler to run with animation finishes (default is nil).
-    func rotate(
-        byAngle angle: CGFloat,
-        ofType type: AngleUnit,
-        animated: Bool = false,
-        duration: TimeInterval = 1,
-        completion: ((Bool) -> Void)? = nil) {
-        let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
-        let aDuration = animated ? duration : 0
-        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
-            self.transform = self.transform.rotated(by: angleWithType)
-        }, completion: completion)
-    }
-
-    /// SwifterSwift: Rotate view to angle on fixed axis.
-    ///
-    /// - Parameters:
-    ///   - angle: angle to rotate view to.
-    ///   - type: type of the rotation angle.
-    ///   - animated: set true to animate rotation (default is false).
-    ///   - duration: animation duration in seconds (default is 1 second).
-    ///   - completion: optional completion handler to run with animation finishes (default is nil).
-    func rotate(
-        toAngle angle: CGFloat,
-        ofType type: AngleUnit,
-        animated: Bool = false,
-        duration: TimeInterval = 1,
-        completion: ((Bool) -> Void)? = nil) {
-        let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
-        let aDuration = animated ? duration : 0
-        UIView.animate(withDuration: aDuration, animations: {
-            self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: angleWithType))
         }, completion: completion)
     }
 

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -362,9 +362,9 @@ public extension UIView {
     ///
     /// - Parameters:
     ///   - angle: Angle to rotate view by.
-    ///   - animated: Set `true` to animate rotation (default is `true`).
-    ///   - duration: Animation duration in seconds (default is 1 second).
-    ///   - completion: Optional completion handler to run with animation finishes (default is nil).
+    ///   - animated: Set `true` to animate rotation (default is `false`).
+    ///   - duration: Animation duration in seconds (default is `1` second).
+    ///   - completion: Optional completion handler to run with animation finishes (default is `nil`).
     @available(watchOS 3.0, tvOS 10.0, *)
     func rotate(
         by angle: Measurement<UnitAngle>,

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -373,6 +373,26 @@ public extension UIView {
     /// SwifterSwift: Rotate view by angle on relative axis.
     ///
     /// - Parameters:
+    ///   - angle: Angle to rotate view by.
+    ///   - animated: Set `true` to animate rotation (default is `true`).
+    ///   - duration: Animation duration in seconds (default is 1 second).
+    ///   - completion: Optional completion handler to run with animation finishes (default is nil).
+    @available(watchOS 3.0, tvOS 10.0, *)
+    func rotate(
+        by angle: Measurement<UnitAngle>,
+        animated: Bool = false,
+        duration: TimeInterval = 1,
+        completion: ((Bool) -> Void)? = nil) {
+        let aDuration = animated ? duration : 0
+        let radians = CGFloat(angle.converted(to: .radians).value)
+        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
+            self.transform = self.transform.rotated(by: radians)
+        }, completion: completion)
+    }
+
+    /// SwifterSwift: Rotate view by angle on relative axis.
+    ///
+    /// - Parameters:
     ///   - angle: angle to rotate view by.
     ///   - type: type of the rotation angle.
     ///   - animated: set true to animate rotation (default is true).

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -362,6 +362,9 @@
 		58253513259CF23B00407B78 /* MeasurementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58253511259CF23B00407B78 /* MeasurementExtensions.swift */; };
 		58253514259CF23B00407B78 /* MeasurementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58253511259CF23B00407B78 /* MeasurementExtensions.swift */; };
 		58253515259CF23B00407B78 /* MeasurementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58253511259CF23B00407B78 /* MeasurementExtensions.swift */; };
+		587AC78725C1D4F0009977B5 /* UIKitDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587AC78625C1D4F0009977B5 /* UIKitDeprecated.swift */; };
+		587AC78825C1D4F0009977B5 /* UIKitDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587AC78625C1D4F0009977B5 /* UIKitDeprecated.swift */; };
+		587AC78925C1D4F0009977B5 /* UIKitDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587AC78625C1D4F0009977B5 /* UIKitDeprecated.swift */; };
 		5C88FBEC234CC1280065A942 /* NSColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C88FBEB234CC1280065A942 /* NSColorExtensionsTests.swift */; };
 		664CB96D2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */; };
 		664CB96E2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */; };
@@ -798,6 +801,7 @@
 		42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensions.swift; sourceTree = "<group>"; };
 		42F53FEF2039C7140070DC11 /* UIStackViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTests.swift; sourceTree = "<group>"; };
 		58253511259CF23B00407B78 /* MeasurementExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasurementExtensions.swift; sourceTree = "<group>"; };
+		587AC78625C1D4F0009977B5 /* UIKitDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitDeprecated.swift; sourceTree = "<group>"; };
 		5C88FBEB234CC1280065A942 /* NSColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSColorExtensionsTests.swift; sourceTree = "<group>"; };
 		5E36CB6424AC9909007727DA /* MyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyViewController.swift; sourceTree = "<group>"; };
 		664CB96C2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BidirectionalCollectionExtensions.swift; sourceTree = "<group>"; };
@@ -1114,6 +1118,7 @@
 		07B7F1791F5EB41600E6F910 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				587AC78525C1D4C7009977B5 /* Deprecated */,
 				07B7F17C1F5EB41600E6F910 /* UIAlertControllerExtensions.swift */,
 				07A1C446224FFDE4003272E4 /* UIApplicationExtensions.swift */,
 				07B7F17D1F5EB41600E6F910 /* UIBarButtonItemExtensions.swift */,
@@ -1307,6 +1312,14 @@
 				0DAEBCE224B0079700F61684 /* HKActivitySummaryExtensionsTests.swift */,
 			);
 			path = HealthKitTests;
+			sourceTree = "<group>";
+		};
+		587AC78525C1D4C7009977B5 /* Deprecated */ = {
+			isa = PBXGroup;
+			children = (
+				587AC78625C1D4F0009977B5 /* UIKitDeprecated.swift */,
+			);
+			path = Deprecated;
 			sourceTree = "<group>";
 		};
 		664CB981217243BA00FC87B4 /* Dispatch */ = {
@@ -1958,6 +1971,7 @@
 				90693551208B4F9400407C4D /* UIGestureRecognizerExtensions.swift in Sources */,
 				F854D2C32423ECEF003A08A9 /* CATransform3DExtensions.swift in Sources */,
 				0726D7771F7C199E0028CAB5 /* ColorExtensions.swift in Sources */,
+				587AC78725C1D4F0009977B5 /* UIKitDeprecated.swift in Sources */,
 				B2A0DAC02336DA87002B0BC5 /* MutableCollectionExtensions.swift in Sources */,
 				07B7F2181F5EB43C00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				784C752F2051BD26001C48DD /* MKPolylineExtensions.swift in Sources */,
@@ -2151,6 +2165,7 @@
 				9D806A872258F624008E500A /* SCNGeometryExtensions.swift in Sources */,
 				07B7F1BB1F5EB42000E6F910 /* UITextViewExtensions.swift in Sources */,
 				9D806A502258CFF9008E500A /* SCNSphereExtensions.swift in Sources */,
+				587AC78825C1D4F0009977B5 /* UIKitDeprecated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2195,6 +2210,7 @@
 				07B7F1CD1F5EB42200E6F910 /* UISwitchExtensions.swift in Sources */,
 				07B7F1D01F5EB42200E6F910 /* UITextFieldExtensions.swift in Sources */,
 				07B7F1E71F5EB43B00E6F910 /* ArrayExtensions.swift in Sources */,
+				587AC78925C1D4F0009977B5 /* UIKitDeprecated.swift in Sources */,
 				D951E8AC23D04DCA00F2CD0B /* DecodableExtensions.swift in Sources */,
 				9D806A882258F624008E500A /* SCNGeometryExtensions.swift in Sources */,
 				07B7F1CC1F5EB42200E6F910 /* UIStoryboardExtensions.swift in Sources */,

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -252,6 +252,29 @@ final class UIViewExtensionsTests: XCTestCase {
         waitForExpectations(timeout: 0.5)
     }
 
+    func testRotateBy() {
+        let view1 = UIView()
+        let transform1 = CGAffineTransform(rotationAngle: 2)
+        view1.rotate(by: .init(value: 2, unit: .radians), animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, transform1)
+
+        let view2 = UIView()
+        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
+        view2.rotate(by: .init(value: 90, unit: .degrees), animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view2.transform, transform2)
+
+        let rotateExpectation = expectation(description: "view rotated")
+        
+        let view3 = UIView()
+        let transform3 = CGAffineTransform(rotationAngle: 2)
+
+        view3.rotate(by: .init(value: 2, unit: .radians), animated: true, duration: 0.5) { _ in
+            rotateExpectation.fulfill()
+        }
+        XCTAssertEqual(view3.transform, transform3)
+        waitForExpectations(timeout: 0.5)
+    }
+
     func testRotateByAngle() {
         let view1 = UIView()
         let transform1 = CGAffineTransform(rotationAngle: 2)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -260,7 +260,7 @@ final class UIViewExtensionsTests: XCTestCase {
 
         let view2 = UIView()
         let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
-        view2.rotate(by: .init(value: 90, unit: .degrees), animated: false, duration: 0, completion: nil)
+        view2.rotate(by: .degrees(90), animated: false, duration: 0, completion: nil)
         XCTAssertEqual(view2.transform, transform2)
 
         let rotateExpectation = expectation(description: "view rotated")

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -268,7 +268,7 @@ final class UIViewExtensionsTests: XCTestCase {
         let view3 = UIView()
         let transform3 = CGAffineTransform(rotationAngle: 2)
 
-        view3.rotate(by: .init(value: 2, unit: .radians), animated: true, duration: 0.5) { _ in
+        view3.rotate(by: .radians(2), animated: true, duration: 0.5) { _ in
             rotateExpectation.fulfill()
         }
         XCTAssertEqual(view3.transform, transform3)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -264,57 +264,11 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(view2.transform, transform2)
 
         let rotateExpectation = expectation(description: "view rotated")
-        
+
         let view3 = UIView()
         let transform3 = CGAffineTransform(rotationAngle: 2)
 
         view3.rotate(by: .init(value: 2, unit: .radians), animated: true, duration: 0.5) { _ in
-            rotateExpectation.fulfill()
-        }
-        XCTAssertEqual(view3.transform, transform3)
-        waitForExpectations(timeout: 0.5)
-    }
-
-    func testRotateByAngle() {
-        let view1 = UIView()
-        let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(byAngle: 2, ofType: .radians, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view1.transform, transform1)
-
-        let view2 = UIView()
-        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
-        view2.rotate(byAngle: 90, ofType: .degrees, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view2.transform, transform2)
-
-        let rotateExpectation = expectation(description: "view rotated")
-
-        let view3 = UIView()
-        let transform3 = CGAffineTransform(rotationAngle: 2)
-
-        view3.rotate(byAngle: 2, ofType: .radians, animated: true, duration: 0.5) { _ in
-            rotateExpectation.fulfill()
-        }
-        XCTAssertEqual(view3.transform, transform3)
-        waitForExpectations(timeout: 0.5)
-    }
-
-    func testRotateToAngle() {
-        let view1 = UIView()
-        let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(toAngle: 2, ofType: .radians, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view1.transform, transform1)
-
-        let view2 = UIView()
-        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
-        view2.rotate(toAngle: 90, ofType: .degrees, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view2.transform, transform2)
-
-        let rotateExpectation = expectation(description: "view rotated")
-
-        let view3 = UIView()
-        let transform3 = CGAffineTransform(rotationAngle: 2)
-
-        view3.rotate(toAngle: 2, ofType: .radians, animated: true, duration: 0.5) { _ in
             rotateExpectation.fulfill()
         }
         XCTAssertEqual(view3.transform, transform3)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -255,7 +255,7 @@ final class UIViewExtensionsTests: XCTestCase {
     func testRotateBy() {
         let view1 = UIView()
         let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(by: .init(value: 2, unit: .radians), animated: false, duration: 0, completion: nil)
+        view1.rotate(by: .radians(2), animated: false, duration: 0, completion: nil)
         XCTAssertEqual(view1.transform, transform1)
 
         let view2 = UIView()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently there are two functions to rotate a view.
* `rotate(byAngle:ofType:animated:duration:completion:)`
* `rotate(toAngle:ofType:animated:duration:completion:)`

However, there are several problems here.

1. Though these two functions have different names and different implementations, the result is identical. You can find the test cases of them are exactly the same.
2. They introduced a new type `UIView.AngleUnit` to library.
3. The naming is not fully following the naming convention of Swift.

To solve these problems, we can use `Measurement<UnitAngle>` to presenting the angle to rotate and change the function signature to `rotate(by:animated:duration:completion:)`, just like existed extension `UIImage.rotated(by:)`.

Ref: https://github.com/SwifterSwift/SwifterSwift/issues/928

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
