### PR TITLE
fix replace "0x" bug

### DIFF
--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -305,8 +305,9 @@ public extension Color {
     ///   - transparency: optional transparency value (default is 1).
     convenience init?(hexString: String, transparency: CGFloat = 1) {
         var string = ""
-        if hexString.lowercased().hasPrefix("0x") {
-            string = hexString.lowercased().replacingOccurrences(of: "0x", with: "")
+        let lowercaseHexString = hexString.lowercased()
+        if lowercaseHexString.hasPrefix("0x") {
+            string = lowercaseHexString.replacingOccurrences(of: "0x", with: "")
         } else if hexString.hasPrefix("#") {
             string = hexString.replacingOccurrences(of: "#", with: "")
         } else {

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -306,7 +306,7 @@ public extension Color {
     convenience init?(hexString: String, transparency: CGFloat = 1) {
         var string = ""
         if hexString.lowercased().hasPrefix("0x") {
-            string = hexString.replacingOccurrences(of: "0x", with: "")
+            string = hexString.lowercased().replacingOccurrences(of: "0x", with: "")
         } else if hexString.hasPrefix("#") {
             string = hexString.replacingOccurrences(of: "#", with: "")
         } else {

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -351,6 +351,9 @@ final class ColorExtensionsTests: XCTestCase {
     func testFailableInit() {
         var color = Color(hexString: "0xFFFFFF")
         XCTAssertNotNil(color)
+        
+        color = Color(hexString: "0XFFAABB")
+        XCTAssertNotNil(color)
 
         color = Color(hexString: "#FFFFFF")
         XCTAssertNotNil(color)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

--------

If the hex string is "0XFFFFFF", `hexString.replacingOccurrences(of: "0x", with: "")` do nothing, `0X` will not be removed, so i add `lowercased` .

I think it was a mistake due to carelessness. 😄
