### PR TITLE
Add unsafeString initializer for URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **Measurement**
   - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)
-
+- **URL**
+  - Added the `(unsafeString: String)` initializer for `URL` as a more conviniently to construct unsafe `URL`s from `String` by [jevonmao](https://github.com/jevonmao)
+  
 ### Changed
 - **NSAttributedString**:
   - `bolded` maintains font size and works on all platforms except Linux. `italicized` maintains font size and works on all platforms except Linux and macOS. [#900](https://github.com/SwifterSwift/SwifterSwift/pull/900) by [guykogus](https://github.com/guykogus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Measurement**
   - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)
 - **URL**
-  - Added the `(unsafeString: String)` initializer for `URL` as a more conviniently to construct unsafe `URL`s from `String` by [jevonmao](https://github.com/jevonmao)
+  - Added the `(unsafeString: String)` initializer for `URL` as a more conveniently to construct unsafe `URL`s from `String` by [jevonmao](https://github.com/jevonmao)
   
 ### Changed
 - **NSAttributedString**:

--- a/Sources/SwifterSwift/Foundation/URLExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLExtensions.swift
@@ -37,6 +37,14 @@ public extension URL {
         guard let string = string else { return nil }
         self.init(string: string, relativeTo: url)
     }
+    
+    /**
+    SwifterSwift: Initializes a forced unwrapped `URL` from string. Can potentially crash if string is invalid.
+     - Parameter unsafeString: The URL string used to initialize the `URL`object.
+     */
+    init(unsafeString: String) {
+        self.init(string: unsafeString)!
+    }
 }
 
 // MARK: - Methods

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -102,6 +102,12 @@ final class URLExtensionsTests: XCTestCase {
             XCTAssertEqual(url.droppedScheme()?.absoluteString, expected, "input url: \(input)")
         }
     }
+    
+    func testStringInitializer() throws {
+        let testURL = try XCTUnwrap(URL(string: "https://google.com"))
+        let extensionURL = URL(unsafeString: "https://google.com")
+        XCTAssertEqual(testURL, extensionURL)
+    }
 }
 
 #endif


### PR DESCRIPTION
## PR Summary
### Problem
Apple developers frequently need to interface with networking requests and file systems. 

However, it can be inconvenient when the `URL` string initializer returns an optional `URL`, especially when developers put hard-coded URL string that should never fail to unwrap.
Unwrapping with`!` symbol that decreases code-readability and adds ceremony:
```swift
let website = URL(string: "https://www.youtube.com")!
```
### Solution
By adding a new class initializer in extension to `URL`, SwifterSwift can provide a syntactical sugar to initialize `URL` from string and implicitly force unwrap the `URL`

Now, developers can do:
```swift
let website = URL(unsafeString: "https://developer.apple.com/wwdc21/")
```
The `URL(string: )` initializer is not impacted and can still be used.

### Alternatives
One might argue that this addition is too insignificant because it adds more characters to the total amount of characters needed to type, and defeats the purpose of a syntactical sugar. The `!` symbol is only 1 character, but the `unsafeString` is 12 characters.

We can potentially override the `URL(string: )` initializer and simply return a `URL` from that.
From `let website = URL(string: "https://www.youtube.com")!` to `let website = URL(string: "https://www.youtube.com")`

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
