### PR TITLE
Array append for optional element and sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **Measurement**
   - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)
-
+- **Array**
+  - Added `append()` and `append(contentsOf` method overloads that can append optional element to `Array`. By [jevonmao](https://github.com/jevonmao)
+  
 ### Changed
 - **NSAttributedString**:
   - `bolded` maintains font size and works on all platforms except Linux. `italicized` maintains font size and works on all platforms except Linux and macOS. [#900](https://github.com/SwifterSwift/SwifterSwift/pull/900) by [guykogus](https://github.com/guykogus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:
   - Added `removeDuplicates(keyPath:)` for removing duplicate elements based on key path. [#737](https://github.com/SwifterSwift/SwifterSwift/pull/737) by [Ilya Glushchuk](https://github.com/iglushchuk).
-  - Added `appendIfNonNil(_:)` and `appendIfNonNil(contentsOf:)` methods that can append optional elements and sequences, by [jevonmao](https://github.com/jevonmao)
+  - Added `appendIfNonNil(_:)` and `appendIfNonNil(contentsOf:)` methods that can append optional elements and sequences. [#966](https://github.com/SwifterSwift/SwifterSwift/pull/966)  by [jevonmao](https://github.com/jevonmao)
 - **Color**:
   - Added `init(light:dark:)` to create an NSColor/UIColor with different variations for light and dark mode. Only available in iOS/tvOS 13.0, macOS 10.15. [#722](https://github.com/SwifterSwift/SwifterSwift/pull/722) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **String**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:
   - Added `removeDuplicates(keyPath:)` for removing duplicate elements based on key path. [#737](https://github.com/SwifterSwift/SwifterSwift/pull/737) by [Ilya Glushchuk](https://github.com/iglushchuk).
-  - Added `appendIfNonNil(_:)` and `appendIfNonNil(contentsOf:)` methods that can append optional elements and sequences. [#966](https://github.com/SwifterSwift/SwifterSwift/pull/966)  by [jevonmao](https://github.com/jevonmao)
+  - Added `appendIfNonNil(_:)` and `appendIfNonNil(contentsOf:)` methods that can append optional elements and sequences. [#966](https://github.com/SwifterSwift/SwifterSwift/pull/966) by [jevonmao](https://github.com/jevonmao)
 - **Color**:
   - Added `init(light:dark:)` to create an NSColor/UIColor with different variations for light and dark mode. Only available in iOS/tvOS 13.0, macOS 10.15. [#722](https://github.com/SwifterSwift/SwifterSwift/pull/722) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **String**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **StringProtocol**
   - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **Measurement**
-  - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)
-- **Array**
-  - Added `append()` and `append(contentsOf` method overloads that can append optional element to `Array`. By [jevonmao](https://github.com/jevonmao)
+  - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)  
   
 ### Changed
 - **NSAttributedString**:
@@ -132,6 +130,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:
   - Added `removeDuplicates(keyPath:)` for removing duplicate elements based on key path. [#737](https://github.com/SwifterSwift/SwifterSwift/pull/737) by [Ilya Glushchuk](https://github.com/iglushchuk).
+  - Added `appendIfNonNil()` and `appendIfNonNil(contentsOf: )` methods that can append optional elements and sequences, by [jevonmao](https://github.com/jevonmao)
 - **Color**:
   - Added `init(light:dark:)` to create an NSColor/UIColor with different variations for light and dark mode. Only available in iOS/tvOS 13.0, macOS 10.15. [#722](https://github.com/SwifterSwift/SwifterSwift/pull/722) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **String**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,11 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **StringProtocol**
   - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **Measurement**
-  - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)  
+  - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)
 - **UITextField**
   - Added `addToolbar(items:height:)` to add a toolbar to a `UITextField`. [#954](https://github.com/SwifterSwift/SwifterSwift/pull/954) by [Randhir Kumar](https://github.com/randhirkumar65)
 - **URL**
   - Added the `(unsafeString: String)` initializer for `URL` as a more conveniently to construct unsafe `URL`s from `String` by [jevonmao](https://github.com/jevonmao)
-  
 ### Changed
 - **NSAttributedString**:
   - `bolded` maintains font size and works on all platforms except Linux. `italicized` maintains font size and works on all platforms except Linux and macOS. [#900](https://github.com/SwifterSwift/SwifterSwift/pull/900) by [guykogus](https://github.com/guykogus)
@@ -134,7 +133,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(grouping:by:)` to initialize a dictionary by grouping sequence from a hashable `KeyPath`. [#751](https://github.com/SwifterSwift/SwifterSwift/pull/751) by [mmdock](https://github.com/mmdock)
 - **RangeReplaceableCollection**:
   - Added `removeDuplicates(keyPath:)` for removing duplicate elements based on key path. [#737](https://github.com/SwifterSwift/SwifterSwift/pull/737) by [Ilya Glushchuk](https://github.com/iglushchuk).
-  - Added `appendIfNonNil()` and `appendIfNonNil(contentsOf: )` methods that can append optional elements and sequences, by [jevonmao](https://github.com/jevonmao)
+  - Added `appendIfNonNil(_:)` and `appendIfNonNil(contentsOf:)` methods that can append optional elements and sequences, by [jevonmao](https://github.com/jevonmao)
 - **Color**:
   - Added `init(light:dark:)` to create an NSColor/UIColor with different variations for light and dark mode. Only available in iOS/tvOS 13.0, macOS 10.15. [#722](https://github.com/SwifterSwift/SwifterSwift/pull/722) by [MaxHaertwig](https://github.com/maxhaertwig).
 - **String**:

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -45,6 +45,30 @@ public extension Array {
             return thisIndex < otherIndex
         }
     }
+    
+    /**
+     SwifterSwift: Adds a new element at the end of the array, mutates the array in place
+     - Parameter newElements: The optional element to append to the array
+     */
+    @discardableResult
+    mutating func append(_ newElement: Self.Element?) -> [Element]
+        {
+            guard let newElement = newElement else {return self}
+            self.append(newElement)
+            return self
+        }
+    
+    /**
+     SwifterSwift: Adds the elements of a sequence to the end of the array, mutates the array in place
+     - Parameter newElements: The optional sequence to append to the array
+     */
+    @discardableResult
+    mutating func append<S>(contentsOf newElements: S?) -> [Element] where Element == S.Element, S : Sequence
+    {
+        guard let newElements = newElements else {return self}
+        self.append(contentsOf: newElements)
+        return self
+    }
 }
 
 // MARK: - Methods (Equatable)

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -45,30 +45,6 @@ public extension Array {
             return thisIndex < otherIndex
         }
     }
-    
-    /**
-     SwifterSwift: Adds a new element at the end of the array, mutates the array in place
-     - Parameter newElements: The optional element to append to the array
-     */
-    @discardableResult
-    mutating func append(_ newElement: Self.Element?) -> [Element]
-        {
-            guard let newElement = newElement else {return self}
-            self.append(newElement)
-            return self
-        }
-    
-    /**
-     SwifterSwift: Adds the elements of a sequence to the end of the array, mutates the array in place
-     - Parameter newElements: The optional sequence to append to the array
-     */
-    @discardableResult
-    mutating func append<S>(contentsOf newElements: S?) -> [Element] where Element == S.Element, S : Sequence
-    {
-        guard let newElements = newElements else {return self}
-        self.append(contentsOf: newElements)
-        return self
-    }
 }
 
 // MARK: - Methods (Equatable)

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -3,7 +3,7 @@
 // MARK: - Initializers
 
 public extension RangeReplaceableCollection {
-    /// SwifterSwift: Creates a new collection of a given size where for each position of the collection the value will be the result of a call of the given expression.
+/// SwifterSwift: Creates a new collection of a given size where for each position of the collection the value will be the result of a call of the given expression.
     ///
     ///     let values = Array(expression: "Value", count: 3)
     ///     print(values)
@@ -25,23 +25,22 @@ public extension RangeReplaceableCollection {
 }
 
 // MARK: - Methods
-
 public extension RangeReplaceableCollection {
-    ///  SwifterSwift: Returns a new rotated collection by the given places.
+    ///  SwifterSwift: Returns a new rotated collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotated(by: 1) -> [4,1,2,3]
     ///     [1, 2, 3, 4].rotated(by: 3) -> [2,3,4,1]
     ///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
     ///
     /// - Parameter places: Number of places that the array be rotated. If the value is positive the end becomes the start, if it negative it's that start become the end.
-    /// - Returns: The new rotated collection.
+    /// - Returns: The new rotated collection.
     func rotated(by places: Int) -> Self {
         // Inspired by: https://ruby-doc.org/core-2.2.0/Array.html#method-i-rotate
         var copy = self
         return copy.rotate(by: places)
     }
-    
-    ///  SwifterSwift: Rotate the collection by the given places.
+
+    ///  SwifterSwift: Rotate the collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotate(by: 1) -> [4,1,2,3]
     ///     [1, 2, 3, 4].rotate(by: 3) -> [2,3,4,1]
@@ -66,7 +65,7 @@ public extension RangeReplaceableCollection {
         }
         return self
     }
-    
+
     /// SwifterSwift: Removes the first element of the collection which satisfies the given predicate.
     ///
     ///        [1, 2, 2, 3, 4, 2, 5].removeFirst { $0 % 2 == 0 } -> [1, 2, 3, 4, 2, 5]
@@ -79,14 +78,14 @@ public extension RangeReplaceableCollection {
         guard let index = try firstIndex(where: predicate) else { return nil }
         return remove(at: index)
     }
-    
+
     /// SwifterSwift: Remove a random value from the collection.
     @discardableResult
     mutating func removeRandomElement() -> Element? {
         guard let randomIndex = indices.randomElement() else { return nil }
         return remove(at: randomIndex)
     }
-    
+
     /// SwifterSwift: Keep elements of Array while condition is true.
     ///
     ///        [0, 2, 4, 7].keep(while: { $0 % 2 == 0 }) -> [0, 2, 4]
@@ -101,7 +100,7 @@ public extension RangeReplaceableCollection {
         }
         return self
     }
-    
+
     /// SwifterSwift: Take element of Array while condition is true.
     ///
     ///        [0, 2, 4, 7, 6, 8].take( where: {$0 % 2 == 0}) -> [0, 2, 4]
@@ -111,7 +110,7 @@ public extension RangeReplaceableCollection {
     func take(while condition: (Element) throws -> Bool) rethrows -> Self {
         return Self(try prefix(while: condition))
     }
-    
+
     /// SwifterSwift: Skip elements of Array while condition is true.
     ///
     ///        [0, 2, 4, 7, 6, 8].skip( where: {$0 % 2 == 0}) -> [6, 8]
@@ -122,7 +121,7 @@ public extension RangeReplaceableCollection {
         guard let idx = try firstIndex(where: { try !condition($0) }) else { return Self() }
         return Self(self[idx...])
     }
-    
+
     /// SwifterSwift: Remove all duplicate elements using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Equatable.
@@ -136,7 +135,7 @@ public extension RangeReplaceableCollection {
             return true
         }
     }
-    
+
     /// SwifterSwift: Remove all duplicate elements using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.
@@ -144,7 +143,7 @@ public extension RangeReplaceableCollection {
         var set = Set<E>()
         removeAll { !set.insert($0[keyPath: path]).inserted }
     }
-    
+
     /// SwifterSwift: Accesses the element at the specified position.
     ///
     /// - Parameter offset: The offset position of the element to access. `offset` must be a valid index offset of the collection that is not equal to the `endIndex` property.
@@ -157,7 +156,7 @@ public extension RangeReplaceableCollection {
             replaceSubrange(offsetIndex..<index(after: offsetIndex), with: [newValue])
         }
     }
-    
+
     /// SwifterSwift: Accesses a contiguous subrange of the collection’s elements.
     ///
     /// - Parameter range: A range of the collection’s indices offsets. The bounds of the range must be valid indices of the collection.

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -3,7 +3,7 @@
 // MARK: - Initializers
 
 public extension RangeReplaceableCollection {
-/// SwifterSwift: Creates a new collection of a given size where for each position of the collection the value will be the result of a call of the given expression.
+    /// SwifterSwift: Creates a new collection of a given size where for each position of the collection the value will be the result of a call of the given expression.
     ///
     ///     let values = Array(expression: "Value", count: 3)
     ///     print(values)
@@ -25,22 +25,23 @@ public extension RangeReplaceableCollection {
 }
 
 // MARK: - Methods
+
 public extension RangeReplaceableCollection {
-    ///  SwifterSwift: Returns a new rotated collection by the given places.
+    ///  SwifterSwift: Returns a new rotated collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotated(by: 1) -> [4,1,2,3]
     ///     [1, 2, 3, 4].rotated(by: 3) -> [2,3,4,1]
     ///     [1, 2, 3, 4].rotated(by: -1) -> [2,3,4,1]
     ///
     /// - Parameter places: Number of places that the array be rotated. If the value is positive the end becomes the start, if it negative it's that start become the end.
-    /// - Returns: The new rotated collection.
+    /// - Returns: The new rotated collection.
     func rotated(by places: Int) -> Self {
         // Inspired by: https://ruby-doc.org/core-2.2.0/Array.html#method-i-rotate
         var copy = self
         return copy.rotate(by: places)
     }
 
-    ///  SwifterSwift: Rotate the collection by the given places.
+    ///  SwifterSwift: Rotate the collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotate(by: 1) -> [4,1,2,3]
     ///     [1, 2, 3, 4].rotate(by: 3) -> [2,3,4,1]
@@ -178,9 +179,9 @@ public extension RangeReplaceableCollection {
      SwifterSwift: Adds a new element at the end of the array, mutates the array in place
      - Parameter newElements: The optional element to append to the array
      */
-    mutating func appendIfNonNil(_ newElement: Element?) {
-        guard let newElement = newElement else {return}
-        self.append(newElement)
+    mutating func appendIfNonNil(_ newElement: Self.Element?) {
+            guard let newElement = newElement else {return}
+            self.append(newElement)
     }
     
     /**
@@ -188,7 +189,7 @@ public extension RangeReplaceableCollection {
      - Parameter newElements: The optional sequence to append to the array
      */
     mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence {
-        guard let newElements = newElements else {return}
-        self.append(contentsOf: newElements)
+            guard let newElements = newElements else {return}
+            self.append(contentsOf: newElements)
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -177,10 +177,10 @@ public extension RangeReplaceableCollection {
     
     /**
      SwifterSwift: Adds a new element at the end of the array, mutates the array in place
-     - Parameter newElements: The optional element to append to the array
+     - Parameter newElement: The optional element to append to the array
      */
     mutating func appendIfNonNil(_ newElement: Self.Element?) {
-        guard let newElement = newElement else {return}
+        guard let newElement = newElement else { return }
         self.append(newElement)
     }
     

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -174,4 +174,24 @@ public extension RangeReplaceableCollection {
                 with: newValue)
         }
     }
+    
+    /**
+     SwifterSwift: Adds a new element at the end of the array, mutates the array in place
+     - Parameter newElements: The optional element to append to the array
+     */
+    mutating func appendIfNonNil(_ newElement: Self.Element?)
+        {
+            guard let newElement = newElement else {return}
+            self.append(newElement)
+        }
+    
+    /**
+     SwifterSwift: Adds the elements of a sequence to the end of the array, mutates the array in place
+     - Parameter newElements: The optional sequence to append to the array
+     */
+    mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence
+        {
+            guard let newElements = newElements else {return}
+            self.append(contentsOf: newElements)
+        }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -189,7 +189,7 @@ public extension RangeReplaceableCollection {
      - Parameter newElements: The optional sequence to append to the array
      */
     mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence {
-            guard let newElements = newElements else {return}
-            self.append(contentsOf: newElements)
+       guard let newElements = newElements else {return}
+       self.append(contentsOf: newElements)
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -189,7 +189,7 @@ public extension RangeReplaceableCollection {
      - Parameter newElements: The optional sequence to append to the array
      */
     mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence {
-       guard let newElements = newElements else {return}
-       self.append(contentsOf: newElements)
+        guard let newElements = newElements else {return}
+        self.append(contentsOf: newElements)
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -180,8 +180,8 @@ public extension RangeReplaceableCollection {
      - Parameter newElements: The optional element to append to the array
      */
     mutating func appendIfNonNil(_ newElement: Self.Element?) {
-            guard let newElement = newElement else {return}
-            self.append(newElement)
+        guard let newElement = newElement else {return}
+        self.append(newElement)
     }
     
     /**

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -40,7 +40,7 @@ public extension RangeReplaceableCollection {
         var copy = self
         return copy.rotate(by: places)
     }
-
+    
     ///  SwifterSwift: Rotate the collection by the given places.
     ///
     ///     [1, 2, 3, 4].rotate(by: 1) -> [4,1,2,3]
@@ -66,7 +66,7 @@ public extension RangeReplaceableCollection {
         }
         return self
     }
-
+    
     /// SwifterSwift: Removes the first element of the collection which satisfies the given predicate.
     ///
     ///        [1, 2, 2, 3, 4, 2, 5].removeFirst { $0 % 2 == 0 } -> [1, 2, 3, 4, 2, 5]
@@ -79,14 +79,14 @@ public extension RangeReplaceableCollection {
         guard let index = try firstIndex(where: predicate) else { return nil }
         return remove(at: index)
     }
-
+    
     /// SwifterSwift: Remove a random value from the collection.
     @discardableResult
     mutating func removeRandomElement() -> Element? {
         guard let randomIndex = indices.randomElement() else { return nil }
         return remove(at: randomIndex)
     }
-
+    
     /// SwifterSwift: Keep elements of Array while condition is true.
     ///
     ///        [0, 2, 4, 7].keep(while: { $0 % 2 == 0 }) -> [0, 2, 4]
@@ -101,7 +101,7 @@ public extension RangeReplaceableCollection {
         }
         return self
     }
-
+    
     /// SwifterSwift: Take element of Array while condition is true.
     ///
     ///        [0, 2, 4, 7, 6, 8].take( where: {$0 % 2 == 0}) -> [0, 2, 4]
@@ -111,7 +111,7 @@ public extension RangeReplaceableCollection {
     func take(while condition: (Element) throws -> Bool) rethrows -> Self {
         return Self(try prefix(while: condition))
     }
-
+    
     /// SwifterSwift: Skip elements of Array while condition is true.
     ///
     ///        [0, 2, 4, 7, 6, 8].skip( where: {$0 % 2 == 0}) -> [6, 8]
@@ -122,7 +122,7 @@ public extension RangeReplaceableCollection {
         guard let idx = try firstIndex(where: { try !condition($0) }) else { return Self() }
         return Self(self[idx...])
     }
-
+    
     /// SwifterSwift: Remove all duplicate elements using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Equatable.
@@ -136,7 +136,7 @@ public extension RangeReplaceableCollection {
             return true
         }
     }
-
+    
     /// SwifterSwift: Remove all duplicate elements using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Hashable.
@@ -144,7 +144,7 @@ public extension RangeReplaceableCollection {
         var set = Set<E>()
         removeAll { !set.insert($0[keyPath: path]).inserted }
     }
-
+    
     /// SwifterSwift: Accesses the element at the specified position.
     ///
     /// - Parameter offset: The offset position of the element to access. `offset` must be a valid index offset of the collection that is not equal to the `endIndex` property.
@@ -157,7 +157,7 @@ public extension RangeReplaceableCollection {
             replaceSubrange(offsetIndex..<index(after: offsetIndex), with: [newValue])
         }
     }
-
+    
     /// SwifterSwift: Accesses a contiguous subrange of the collection’s elements.
     ///
     /// - Parameter range: A range of the collection’s indices offsets. The bounds of the range must be valid indices of the collection.
@@ -179,19 +179,17 @@ public extension RangeReplaceableCollection {
      SwifterSwift: Adds a new element at the end of the array, mutates the array in place
      - Parameter newElements: The optional element to append to the array
      */
-    mutating func appendIfNonNil(_ newElement: Self.Element?)
-        {
-            guard let newElement = newElement else {return}
-            self.append(newElement)
-        }
+    mutating func appendIfNonNil(_ newElement: Element?) {
+        guard let newElement = newElement else {return}
+        self.append(newElement)
+    }
     
     /**
      SwifterSwift: Adds the elements of a sequence to the end of the array, mutates the array in place
      - Parameter newElements: The optional sequence to append to the array
      */
-    mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence
-        {
-            guard let newElements = newElements else {return}
-            self.append(contentsOf: newElements)
-        }
+    mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence {
+        guard let newElements = newElements else {return}
+        self.append(contentsOf: newElements)
+    }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift
@@ -179,7 +179,7 @@ public extension RangeReplaceableCollection {
      SwifterSwift: Adds a new element at the end of the array, mutates the array in place
      - Parameter newElement: The optional element to append to the array
      */
-    mutating func appendIfNonNil(_ newElement: Self.Element?) {
+    mutating func appendIfNonNil(_ newElement: Element?) {
         guard let newElement = newElement else { return }
         self.append(newElement)
     }
@@ -189,7 +189,7 @@ public extension RangeReplaceableCollection {
      - Parameter newElements: The optional sequence to append to the array
      */
     mutating func appendIfNonNil<S>(contentsOf newElements: S?) where Element == S.Element, S : Sequence {
-        guard let newElements = newElements else {return}
+        guard let newElements = newElements else { return }
         self.append(contentsOf: newElements)
     }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -119,26 +119,23 @@ final class ArrayExtensionsTests: XCTestCase {
     func testAppendElement() {
         var testArray = ["h", "e", "l", "l", "o"]
         let optionalString: String? = "f"
-        let resultArray = testArray.append(optionalString)
+        testArray.appendIfNonNil(optionalString)
         XCTAssertEqual(testArray, ["h", "e", "l", "l", "o", "f"])
-        XCTAssertEqual(resultArray, ["h", "e", "l", "l", "o", "f"])
         
         let nilString: String? = nil
-        testArray.append(nilString)
+        testArray.appendIfNonNil(nilString)
         XCTAssertEqual(testArray, ["h", "e", "l", "l", "o", "f"])
-        
     }
     
     func testAppendSequence() {
         var testEmptyArray: [Double] = []
         let numbersToAppend: [Double]? = [69.0, 68.0, 67.0]
-        let resultArray = testEmptyArray.append(contentsOf: numbersToAppend)
+        testEmptyArray.appendIfNonNil(contentsOf: numbersToAppend)
         XCTAssertEqual(testEmptyArray, numbersToAppend)
-        XCTAssertEqual(numbersToAppend, resultArray)
         
         var testStringArray: [String] = ["h", "e", "l", "l", "o"]
         let nilArray: [String]? = nil
-        testStringArray.append(contentsOf: nilArray)
+        testStringArray.appendIfNonNil(contentsOf: nilArray)
         XCTAssertEqual(testStringArray, ["h", "e", "l", "l", "o"])
     }
 }

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -115,4 +115,30 @@ final class ArrayExtensionsTests: XCTestCase {
         ]
         XCTAssertEqual(arrayWithoutDuplicatesNHashable, arrayWithoutDuplicatesNHashablePrepared)
     }
+    
+    func testAppendElement() {
+        var testArray = ["h", "e", "l", "l", "o"]
+        let optionalString: String? = "f"
+        let resultArray = testArray.append(optionalString)
+        XCTAssertEqual(testArray, ["h", "e", "l", "l", "o", "f"])
+        XCTAssertEqual(resultArray, ["h", "e", "l", "l", "o", "f"])
+        
+        let nilString: String? = nil
+        testArray.append(nilString)
+        XCTAssertEqual(testArray, ["h", "e", "l", "l", "o", "f"])
+        
+    }
+    
+    func testAppendSequence() {
+        var testEmptyArray: [Double] = []
+        let numbersToAppend: [Double]? = [69.0, 68.0, 67.0]
+        let resultArray = testEmptyArray.append(contentsOf: numbersToAppend)
+        XCTAssertEqual(testEmptyArray, numbersToAppend)
+        XCTAssertEqual(numbersToAppend, resultArray)
+        
+        var testStringArray: [String] = ["h", "e", "l", "l", "o"]
+        let nilArray: [String]? = nil
+        testStringArray.append(contentsOf: nilArray)
+        XCTAssertEqual(testStringArray, ["h", "e", "l", "l", "o"])
+    }
 }


### PR DESCRIPTION
## PR Summary
### Motivation
The concept of optional types has been deeply ingrained into the design of Swift, and developers deal with appending optional elements to an array often.

It can be very inconvenient to be first unwrap optional, and append it:
```swift
var foo: [Double] = []
let bar: Double? = 69.0
if let unwrappedBar = bar {
   foo.append(unwrappedBar)
}
//or
if bar != nil {
   foo.append(bar!)
}
```

### Solution
By moving the logic of optional unwrap and checking to an `Array` extension method, developers can now use syntactical sugar:
```swift
var foo: [Double] = []
let bar: Double? = 69.0
foo.append(bar)
```

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
