### PR TITLE
Add `init?(argbHexString:)` to support the common ARGB format used in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Color**:
   - Refactored `init(light:dark:)` to remove deployment target version restrictions. [#844](https://github.com/SwifterSwift/SwifterSwift/pull/844) by [VincentSit](https://github.com/vincentsit).
   - Use `enum` to declare namespace instead of using `struct`. Thus private initializer is no longer needed. [#927](https://github.com/SwifterSwift/SwifterSwift/pull/927) by [Shiva Huang](https://github.com/ShivaHuang)
+  - Add `init?(argbHexString:)` to support the common ARGB format used in Android. [#971](https://github.com/SwifterSwift/SwifterSwift/pull/971) by [yonat](https://github.com/yonat)
 - **CAGradientLayer**:
   - In `init(colors:locations:startPoint:endPoint:type:)` added default values to `startPoint` and `endPoint`. [#864](https://github.com/SwifterSwift/SwifterSwift/pull/864) by [guykogus](https://github.com/guykogus)
 - **UITextField**:

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -332,6 +332,30 @@ public extension Color {
         self.init(red: red, green: green, blue: blue, transparency: trans)
     }
 
+    /// SwifterSwift: Create Color from hexadecimal string in the format ARGB (alpha-red-green-blue).
+    ///
+    /// - Parameters:
+    ///   - argbHexString: hexadecimal string (examples: 7FEDE7F6, 0x7FEDE7F6, #7FEDE7F6, #f0ff, 0xFF0F, ..).
+    convenience init?(argbHexString: String) {
+        var string = argbHexString.replacingOccurrences(of: "0x", with: "").replacingOccurrences(of: "#", with: "")
+
+        if string.count <= 4 { // convert hex to long format if in short format
+            var str = ""
+            string.forEach { str.append(String(repeating: String($0), count: 2)) }
+            string = str
+        }
+
+        guard let hexValue = Int(string, radix: 16) else { return nil }
+        let hasAlpha = string.count == 8
+
+        let alpha = hasAlpha ? (hexValue >> 24) & 0xFF : 0xFF
+        let red = (hexValue >> 16) & 0xFF
+        let green = (hexValue >> 8) & 0xFF
+        let blue = hexValue & 0xFF
+
+        self.init(red: red, green: green, blue: blue, transparency: CGFloat(alpha) / 255)
+    }
+
     /// SwifterSwift: Create Color from a complementary of a Color (if applicable).
     ///
     /// - Parameter color: color of which opposite color is desired.

--- a/Sources/SwifterSwift/Shared/ColorExtensions.swift
+++ b/Sources/SwifterSwift/Shared/ColorExtensions.swift
@@ -341,11 +341,14 @@ public extension Color {
 
         if string.count <= 4 { // convert hex to long format if in short format
             var str = ""
-            string.forEach { str.append(String(repeating: String($0), count: 2)) }
+            for character in string {
+                str.append(String(repeating: String(character), count: 2))
+            }
             string = str
         }
 
         guard let hexValue = Int(string, radix: 16) else { return nil }
+
         let hasAlpha = string.count == 8
 
         let alpha = hasAlpha ? (hexValue >> 24) & 0xFF : 0xFF

--- a/Tests/SharedTests/ColorExtensionsTests.swift
+++ b/Tests/SharedTests/ColorExtensionsTests.swift
@@ -374,6 +374,36 @@ final class ColorExtensionsTests: XCTestCase {
         XCTAssertNotNil(color)
     }
 
+    func testInitARGB() {
+        var color = Color(argbHexString: "0xFFFF")
+        XCTAssertNotNil(color)
+        XCTAssertEqual(color!.rgbComponents.red, 0xFF)
+        XCTAssertEqual(color!.rgbComponents.green, 0xFF)
+        XCTAssertEqual(color!.rgbComponents.blue, 0xFF)
+        XCTAssertEqual(color!.alpha, 1.0)
+
+        color = Color(argbHexString: "#FFFFFFFFF")
+        XCTAssertNotNil(color)
+        XCTAssertEqual(color!.rgbComponents.red, 0xFF)
+        XCTAssertEqual(color!.rgbComponents.green, 0xFF)
+        XCTAssertEqual(color!.rgbComponents.blue, 0xFF)
+        XCTAssertEqual(color!.alpha, 1.0)
+
+        color = Color(argbHexString: "7F123456")
+        XCTAssertNotNil(color)
+        XCTAssertEqual(color!.rgbComponents.red, 0x12)
+        XCTAssertEqual(color!.rgbComponents.green, 0x34)
+        XCTAssertEqual(color!.rgbComponents.blue, 0x56)
+        XCTAssertEqual(color!.alpha, 0.5, accuracy: 0.01)
+
+        color = Color(argbHexString: "#9999")
+        XCTAssertNotNil(color)
+        XCTAssertEqual(color!.rgbComponents.red, 0x99)
+        XCTAssertEqual(color!.rgbComponents.green, 0x99)
+        XCTAssertEqual(color!.rgbComponents.blue, 0x99)
+        XCTAssertEqual(color!.alpha, 0.6)
+    }
+
     func testInitWithComponents() {
         var red1: CGFloat = 0
         var red2: CGFloat = 0


### PR DESCRIPTION
🚀
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
