### PR TITLE
Added SKSpriteNode extension

### DIFF
--- a/Sources/SwifterSwift/SpriteKit/SKSpriteNodeExtensions.swift
+++ b/Sources/SwifterSwift/SpriteKit/SKSpriteNodeExtensions.swift
@@ -1,0 +1,25 @@
+// SKSpriteNodeExtensions.swift - Copyright 2021 SwifterSwift
+
+#if canImport(SpriteKit)
+import SpriteKit
+
+// MARK: - Methods
+
+public extension SKSpriteNode {
+    /// SwifterSwift: SKSpriteNode sized with respect to aspect ratio.
+    ///
+    ///        node.aspectFill(to: CGSize(width: 300, height: 300)
+    ///
+    /// - Parameter fillSize: fill size to use for aspect ratio calculation.
+    func aspectFill(to fillSize: CGSize) {
+        if let texture = self.texture {
+            let horizontalRatio = fillSize.width / texture.size().width
+            let verticalRatio = fillSize.height / texture.size().height
+            let ratio = horizontalRatio < verticalRatio ? horizontalRatio : verticalRatio
+            size = CGSize(width: texture.size().width * ratio,
+                          height: texture.size().height * ratio)
+        }
+    }
+}
+
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -338,6 +338,11 @@
 		116090B424187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */; };
 		116090B524187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */; };
 		116090B624187D8100DDCD01 /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */; };
+		17A4B79326CCFFAE007D299F /* SKSpriteNodeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4B79226CCFFAE007D299F /* SKSpriteNodeExtensions.swift */; };
+		17A4B79426CCFFAF007D299F /* SKSpriteNodeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4B79226CCFFAE007D299F /* SKSpriteNodeExtensions.swift */; };
+		17A4B79526CCFFAF007D299F /* SKSpriteNodeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4B79226CCFFAE007D299F /* SKSpriteNodeExtensions.swift */; };
+		17A4B79626CCFFAF007D299F /* SKSpriteNodeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4B79226CCFFAE007D299F /* SKSpriteNodeExtensions.swift */; };
+		17A4B79826CD0DA2007D299F /* SKSpriteNodeExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4B79726CD0DA2007D299F /* SKSpriteNodeExtensionTests.swift */; };
 		182698AC1F8AB46E0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AD1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
 		182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */; };
@@ -789,6 +794,8 @@
 		0DAEBCE224B0079700F61684 /* HKActivitySummaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKActivitySummaryExtensionsTests.swift; sourceTree = "<group>"; };
 		116090AE24187D5C00DDCD01 /* CGRectExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensions.swift; sourceTree = "<group>"; };
 		116090B324187D8100DDCD01 /* CGRectExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensionsTests.swift; sourceTree = "<group>"; };
+		17A4B79226CCFFAE007D299F /* SKSpriteNodeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKSpriteNodeExtensions.swift; sourceTree = "<group>"; };
+		17A4B79726CD0DA2007D299F /* SKSpriteNodeExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKSpriteNodeExtensionTests.swift; sourceTree = "<group>"; };
 		185BDE601F8AAEFD00140E19 /* CGColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGColorExtensionsTests.swift; sourceTree = "<group>"; };
 		18C8E5DD2074C58100F8AF51 /* SequenceExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensions.swift; sourceTree = "<group>"; };
 		18C8E5E22074C67000F8AF51 /* SequenceExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionsTests.swift; sourceTree = "<group>"; };
@@ -1345,6 +1352,7 @@
 			isa = PBXGroup;
 			children = (
 				752AC79F20BC975E00659E76 /* SKNodeExtensions.swift */,
+				17A4B79226CCFFAE007D299F /* SKSpriteNodeExtensions.swift */,
 			);
 			path = SpriteKit;
 			sourceTree = "<group>";
@@ -1353,6 +1361,7 @@
 			isa = PBXGroup;
 			children = (
 				752AC7A420BC9FF500659E76 /* SKNodeExtensionTests.swift */,
+				17A4B79726CD0DA2007D299F /* SKSpriteNodeExtensionTests.swift */,
 			);
 			path = SpriteKitTests;
 			sourceTree = "<group>";
@@ -1991,6 +2000,7 @@
 				664CB96D2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */,
 				07B7F1951F5EB42000E6F910 /* UICollectionViewExtensions.swift in Sources */,
 				07B7F1A31F5EB42000E6F910 /* UITableViewExtensions.swift in Sources */,
+				17A4B79326CCFFAE007D299F /* SKSpriteNodeExtensions.swift in Sources */,
 				077BA08F1F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
 				07B7F1A11F5EB42000E6F910 /* UISwitchExtensions.swift in Sources */,
 				0722CB3820C2E46C00C6C1B6 /* UIWindowExtensions.swift in Sources */,
@@ -2120,6 +2130,7 @@
 				07B7F1FB1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F2081F5EB43C00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F2391F5EB45200E6F910 /* NSAttributedStringExtensions.swift in Sources */,
+				17A4B79426CCFFAF007D299F /* SKSpriteNodeExtensions.swift in Sources */,
 				07B7F1AD1F5EB42000E6F910 /* UIImageExtensions.swift in Sources */,
 				9D806A372258AE09008E500A /* UIBezierPathExtensions.swift in Sources */,
 				077BA08B1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
@@ -2189,6 +2200,7 @@
 				734308092108E4640029CD16 /* CGVectorExtensions.swift in Sources */,
 				9D806A382258AE0A008E500A /* UIBezierPathExtensions.swift in Sources */,
 				07B7F1C11F5EB42200E6F910 /* UICollectionViewExtensions.swift in Sources */,
+				17A4B79526CCFFAF007D299F /* SKSpriteNodeExtensions.swift in Sources */,
 				07B7F1CF1F5EB42200E6F910 /* UITableViewExtensions.swift in Sources */,
 				077BA0911F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
 				7832C2B1209BB19300224EED /* ComparableExtensions.swift in Sources */,
@@ -2275,6 +2287,7 @@
 				07B7F2221F5EB44600E6F910 /* CGPointExtensions.swift in Sources */,
 				9D806A442258B931008E500A /* SCNVector3Extensions.swift in Sources */,
 				D951E8AD23D04DCB00F2CD0B /* DecodableExtensions.swift in Sources */,
+				17A4B79626CCFFAF007D299F /* SKSpriteNodeExtensions.swift in Sources */,
 				07B7F2251F5EB44600E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				077BA08D1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
 				9D806A772258E0D8008E500A /* SCNConeExtensions.swift in Sources */,
@@ -2403,6 +2416,7 @@
 				A94AA78A202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */,
 				7832C2B4209BB32500224EED /* ComparableExtensionsTests.swift in Sources */,
 				182698AC1F8AB46E0052F21E /* CGColorExtensionsTests.swift in Sources */,
+				17A4B79826CD0DA2007D299F /* SKSpriteNodeExtensionTests.swift in Sources */,
 				07C50D8F1F5EB06000F46E5A /* CLLocationExtensionsTests.swift in Sources */,
 				9D806A972258FD81008E500A /* SCNCylinderExtensionsTests.swift in Sources */,
 				07C50D8D1F5EB06000F46E5A /* CGPointExtensionsTests.swift in Sources */,

--- a/Tests/SpriteKitTests/SKSpriteNodeExtensionTests.swift
+++ b/Tests/SpriteKitTests/SKSpriteNodeExtensionTests.swift
@@ -6,7 +6,6 @@ import XCTest
 #if canImport(SpriteKit)
 import SpriteKit
 
-
 final class SKSpriteNodeExtensionTests: XCTestCase {
 
     func testAspectFill() {

--- a/Tests/SpriteKitTests/SKSpriteNodeExtensionTests.swift
+++ b/Tests/SpriteKitTests/SKSpriteNodeExtensionTests.swift
@@ -1,0 +1,30 @@
+// SKSpriteNodeExtensionTests.swift - Copyright 2021 SwifterSwift
+
+@testable import SwifterSwift
+import XCTest
+
+#if canImport(SpriteKit)
+import SpriteKit
+
+
+final class SKSpriteNodeExtensionTests: XCTestCase {
+
+    func testAspectFill() {
+        let bundle = Bundle(for: SKSpriteNodeExtensionTests.self)
+        let scene = SKScene(size: CGSize(width: 750, height: 1334))
+        let node = SKSpriteNode()
+        let image = UIImage(named: "TestImage", in: bundle, compatibleWith: nil)!
+        
+        node.size = CGSize(width: 300, height: 300)
+        node.texture = SKTexture(image: image)
+        scene.addChild(node)
+        
+        node.aspectFill(to: CGSize(width: 100, height: 100))
+        
+        let accuracy = CGFloat(0.01)
+        XCTAssertEqual(node.size.width, 100, accuracy: accuracy)
+        XCTAssertEqual(node.size.height, 23.2, accuracy: accuracy)
+    }
+}
+
+#endif


### PR DESCRIPTION
🚀 
Added `aspectFill` method to dynamically size sprite node with respect to aspect ratio.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
