### PR TITLE
added a `slice` method

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -837,6 +837,23 @@ public extension String {
         return self
     }
 
+    /// SwifterSwift: Slice given string from a start character to an end character (if applicable).
+    ///
+    ///		var str = "Hello Slice World"
+    ///		str.slice(from: "Hello", to: "World")
+    ///		print(str) // prints "Slice"
+    ///
+    /// - Parameters:
+    ///   - start: string the slicing should start from.
+    ///   - end: string the slicing should end at.
+	func slice(start: String, end: String) -> String? {
+		return (range(of: start)?.upperBound).flatMap { substringFrom in
+		(range(of: end, range: substringFrom..<endIndex)?.lowerBound).map { substringTo in
+			String(self[substringFrom..<substringTo])
+			}
+		}
+	}
+
     /// SwifterSwift: Slice given string from a start index (if applicable).
     ///
     ///		var str = "Hello World"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a new method to slice from string

```Swift
var str = "Hello Slice World"
str.slice(from: "Hello", to: "World")
print(str) // prints "Slice"
```

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
