### PR TITLE
Adding daysRemaining(in:) to DateExtensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `findConstraint` for finding an existing constraint. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/886) by [gurgeous]
   - Added `widthConstraint`, `heightConstraint`, `leadingConstraint`, `trailingConstraint`, `topConstraint`, and `bottomConstraint` for finding specific constraints. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/886) by [gurgeous]
   **Date**:
-  - Added `daysRemaining(in:)`, which returns the number of days remaining in various `Calendar.Components`. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/990) by [pbeyer08](https://github.com/pbeyer08)
+  - Added `daysRemaining(in:)`, which returns the number of days remaining in various `Calendar.Components`. [#982](https://github.com/SwifterSwift/SwifterSwift/pull/982) by [pbeyer08](https://github.com/pbeyer08)
 - **StringProtocol**
   - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **Measurement**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `loadFromNib(withClass:)`, which loads a UIView of a particular type from a nib file. [#885](https://github.com/SwifterSwift/SwifterSwift/pull/885) by [gurgeous](https://github.com/gurgeous)
   - Added `findConstraint` for finding an existing constraint. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/886) by [gurgeous]
   - Added `widthConstraint`, `heightConstraint`, `leadingConstraint`, `trailingConstraint`, `topConstraint`, and `bottomConstraint` for finding specific constraints. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/886) by [gurgeous]
+  **Date**:
+  - Added `daysRemaining(in:)`, which returns the number of days remaining in various `Calendar.Components`. [#886](https://github.com/SwifterSwift/SwifterSwift/pull/990) by [pbeyer08](https://github.com/pbeyer08)
 - **StringProtocol**
   - Added `replacingOccurrences(ofPattern:withTemplate:options:searchRange:)` as a more convenient way to replace patterns. [#901](https://github.com/SwifterSwift/SwifterSwift/pull/901) by [gurgeous](https://github.com/gurgeous)
 - **Measurement**

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -900,6 +900,24 @@ public extension Date {
         let componentValue = components.value(for: component)!
         return abs(componentValue) <= value
     }
+		
+	/// SwifterSwift: calculate number of full days remaining in various supported Calendar.Components.
+	///
+	/// - Parameters:
+	///   - component: Calendar.Component to use.
+	/// - Returns: number of days remaining in that Calendar.Component, nil if unsupported.
+	func daysRemaining(in component: Calendar.Component) -> Int? {
+		switch component {
+			case .month, .year, .weekOfMonth, .weekOfYear:
+				if let endOfComponent = self.end(of: component) {
+					let daysRemaining = endOfComponent.daysSince(self)
+					return Int(daysRemaining)
+				}
+			default:
+				()
+		}
+		return nil
+	}
 
     /// SwifterSwift: Returns a random date within the specified range.
     ///

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -989,6 +989,29 @@ final class DateExtensionsTests: XCTestCase {
         let tomorrowCheck = Calendar.current.date(byAdding: .day, value: 1, to: date)
         XCTAssertEqual(tomorrow, tomorrowCheck)
     }
+	
+	func testDaysRemaining() {
+		XCTAssertNil(Date().daysRemaining(in:.calendar))
+		XCTAssertNil(Date().daysRemaining(in:.quarter))
+		
+		// Year tests
+		XCTAssertEqual(Date(year: 2016, month: 1, day: 1, hour: 1)?.daysRemaining(in: .year), 365)	// leap
+		XCTAssertEqual(Date(year: 2017, month: 1, day: 1, hour: 1)?.daysRemaining(in: .year), 364)
+		XCTAssertEqual(Date(year: 2017, month: 12, day: 30, hour: 1)?.daysRemaining(in: .year), 1)
+		XCTAssertEqual(Date(year: 2017, month: 12, day: 31, hour: 1)?.daysRemaining(in: .year), 0)
+		
+		// Month tests
+		XCTAssertEqual(Date(year: 2016, month: 2, day: 1, hour: 1)?.daysRemaining(in: .month), 28)	// leap
+		XCTAssertEqual(Date(year: 2017, month: 2, day: 1, hour: 1)?.daysRemaining(in: .month), 27)
+		XCTAssertEqual(Date(year: 2017, month: 12, day: 21, hour: 1)?.daysRemaining(in: .month), 10)
+		
+		// Week tests
+		XCTAssertEqual(Date(year: 2021, month: 8, day: 31, hour: 1)?.daysRemaining(in: .weekOfMonth), 4)
+		XCTAssertEqual(Date(year: 2021, month: 8, day: 31, hour: 1)?.daysRemaining(in: .weekOfYear), 4)
+		XCTAssertEqual(Date(year: 2021, month: 9, day: 11, hour: 1)?.daysRemaining(in: .weekOfYear), 0)
+		XCTAssertEqual(Date(year: 2020, month: 2, day: 23, hour: 1)?.daysRemaining(in: .weekOfMonth), 6)  // leap
+
+	}
 }
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addresses #552.

This PR adds a `Date` extension which returns the number of days remaining in various `Calendar.Components` such as `.month` or `.year`.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
