### PR TITLE
Add ability to add actions for `UIControl` with closures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `.degrees(_:)`, `arcMinutes(_:)`, `arcSeconds(_:)`, `radians(_:)`, `gradians(_:)` and `revolutions(_:)`  to conveniently initialize measurement with corresponding unit. [#936](https://github.com/SwifterSwift/SwifterSwift/pull/936) by [Shiva Huang](https://github.com/ShivaHuang)
 - **UITextField**
   - Added `addToolbar(items:height:)` to add a toolbar to a `UITextField`. [#954](https://github.com/SwifterSwift/SwifterSwift/pull/954) by [Randhir Kumar](https://github.com/randhirkumar65)
+- **UIControl**
+  - Added `on(event:perform:)` to add events inline to `UIControl`. [#1002](https://github.com/SwifterSwift/SwifterSwift/pull/1002) by [Den Andreychuk](https://github.com/denandreychuk)
 - **URL**
   - Added the `(unsafeString: String)` initializer for `URL` as a more conveniently to construct unsafe `URL`s from `String` by [jevonmao](https://github.com/jevonmao)
 - **MKMultiPoint**

--- a/Sources/SwifterSwift/UIKit/UIControlExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIControlExtensions.swift
@@ -13,6 +13,7 @@ public extension UIControl {
     ///   - event: Event to perform action for.
     ///   - action: Action to perform.
     func on(_ event: UIControl.Event, perform action: @escaping () -> Void) {
+        // https://stackoverflow.com/a/41438789/9014720
         @objc final class ClosureSleeve: NSObject {
             private let closure: () -> Void
             init (_ closure: @escaping () -> Void) {

--- a/Sources/SwifterSwift/UIKit/UIControlExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIControlExtensions.swift
@@ -1,0 +1,30 @@
+// UIControlExtensions.swift - Copyright 2022 SwifterSwift
+
+#if canImport(UIKit)
+import UIKit
+
+// MARK: - Methods
+
+public extension UIControl {
+    
+    /// SwifterSwift: Perform action on specified event.
+    ///
+    /// - Parameters:
+    ///   - event: Event to perform action for.
+    ///   - action: Action to perform.
+    func on(_ event: UIControl.Event, perform action: @escaping () -> Void) {
+        @objc final class ClosureSleeve: NSObject {
+            private let closure: () -> Void
+            init (_ closure: @escaping () -> Void) {
+                self.closure = closure
+            }
+            @objc func invoke () {
+                closure()
+            }
+        }
+        let sleeve = ClosureSleeve(action)
+        addTarget(sleeve, action: #selector(ClosureSleeve.invoke), for: event)
+        objc_setAssociatedObject(self, UUID().uuidString, sleeve, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+    }
+}
+#endif

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -606,6 +606,12 @@
 		D9F36CF623521F440057258F /* MKMapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F36CF523521F440057258F /* MKMapViewTests.swift */; };
 		E5E5EB3A2350EED400B04C42 /* CAGradientLayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */; };
 		E5E5EB3D2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */; };
+		EB898B4C27C3B2860089D03E /* UIControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB898B4B27C3B2860089D03E /* UIControlExtensions.swift */; };
+		EB898B4D27C3B2860089D03E /* UIControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB898B4B27C3B2860089D03E /* UIControlExtensions.swift */; };
+		EB898B4E27C3B2860089D03E /* UIControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB898B4B27C3B2860089D03E /* UIControlExtensions.swift */; };
+		EB898B5427C3B7330089D03E /* UIControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB898B5027C3B5F90089D03E /* UIControlExtensionsTests.swift */; };
+		EB898B5527C3B7370089D03E /* UIControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB898B5027C3B5F90089D03E /* UIControlExtensionsTests.swift */; };
+		EB898B5627C3B7380089D03E /* UIControlExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB898B5027C3B5F90089D03E /* UIControlExtensionsTests.swift */; };
 		F850972424AF72690007F74D /* MyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36CB6424AC9909007727DA /* MyViewController.swift */; };
 		F850972524AF72690007F74D /* MyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36CB6424AC9909007727DA /* MyViewController.swift */; };
 		F854D2A52423AE92003A08A9 /* CGAffineTransformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */; };
@@ -908,6 +914,8 @@
 		D9F36CF523521F440057258F /* MKMapViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKMapViewTests.swift; sourceTree = "<group>"; };
 		E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensions.swift; sourceTree = "<group>"; };
 		E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensionsTests.swift; sourceTree = "<group>"; };
+		EB898B4B27C3B2860089D03E /* UIControlExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIControlExtensions.swift; sourceTree = "<group>"; };
+		EB898B5027C3B5F90089D03E /* UIControlExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIControlExtensionsTests.swift; sourceTree = "<group>"; };
 		F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensions.swift; sourceTree = "<group>"; };
 		F854D2A62423AF22003A08A9 /* CATransform3DExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CATransform3DExtensions.swift; sourceTree = "<group>"; };
 		F854D2BA2423E7C8003A08A9 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
@@ -1141,6 +1149,7 @@
 		07B7F1791F5EB41600E6F910 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				CF309489216AAC7A005609BC /* UIActivityExtensions.swift */,
 				07B7F17C1F5EB41600E6F910 /* UIAlertControllerExtensions.swift */,
 				07A1C446224FFDE4003272E4 /* UIApplicationExtensions.swift */,
 				07B7F17D1F5EB41600E6F910 /* UIBarButtonItemExtensions.swift */,
@@ -1148,17 +1157,23 @@
 				07B7F17E1F5EB41600E6F910 /* UIButtonExtensions.swift */,
 				07B7F17F1F5EB41600E6F910 /* UICollectionViewExtensions.swift */,
 				9DC844A22349E1EE00E1571A /* UIColorExtensions.swift */,
+				EB898B4B27C3B2860089D03E /* UIControlExtensions.swift */,
+				076AEC881FDB48580077D153 /* UIDatePickerExtensions.swift */,
 				074EAF1A1F7BA68B00C74636 /* UIFontExtensions.swift */,
 				90693550208B4F9400407C4D /* UIGestureRecognizerExtensions.swift */,
 				07B7F1811F5EB41600E6F910 /* UIImageExtensions.swift */,
 				07B7F1821F5EB41600E6F910 /* UIImageViewExtensions.swift */,
 				07B7F1831F5EB41600E6F910 /* UILabelExtensions.swift */,
+				8D4B424B212972AE002A5923 /* UILayoutPriorityExtensions.swift */,
 				07B7F1841F5EB41600E6F910 /* UINavigationBarExtensions.swift */,
 				07B7F1851F5EB41600E6F910 /* UINavigationControllerExtensions.swift */,
 				07B7F1861F5EB41600E6F910 /* UINavigationItemExtensions.swift */,
+				CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */,
+				86B3F7AB208D3D5C00BC297B /* UIScrollViewExtensions.swift */,
 				07B7F1871F5EB41600E6F910 /* UISearchBarExtensions.swift */,
 				07B7F1881F5EB41600E6F910 /* UISegmentedControlExtensions.swift */,
 				07B7F1891F5EB41600E6F910 /* UISliderExtensions.swift */,
+				42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */,
 				07B7F18A1F5EB41600E6F910 /* UIStoryboardExtensions.swift */,
 				07B7F18B1F5EB41600E6F910 /* UISwitchExtensions.swift */,
 				07B7F18C1F5EB41600E6F910 /* UITabBarExtensions.swift */,
@@ -1167,13 +1182,7 @@
 				07B7F18F1F5EB41600E6F910 /* UITextViewExtensions.swift */,
 				07B7F1901F5EB41600E6F910 /* UIViewControllerExtensions.swift */,
 				07B7F1911F5EB41600E6F910 /* UIViewExtensions.swift */,
-				076AEC881FDB48580077D153 /* UIDatePickerExtensions.swift */,
-				42F53FEB2039C5AC0070DC11 /* UIStackViewExtensions.swift */,
-				86B3F7AB208D3D5C00BC297B /* UIScrollViewExtensions.swift */,
 				0722CB3720C2E46B00C6C1B6 /* UIWindowExtensions.swift */,
-				CA1317532106D35E002F1B0D /* UIRefreshControlExtensions.swift */,
-				8D4B424B212972AE002A5923 /* UILayoutPriorityExtensions.swift */,
-				CF309489216AAC7A005609BC /* UIActivityExtensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -1258,6 +1267,7 @@
 				07C50D221F5EB03200F46E5A /* UIViewControllerExtensionsTests.swift */,
 				07C50D231F5EB03200F46E5A /* UIViewExtensionsTests.swift */,
 				0722CB3920C2E49900C6C1B6 /* UIWindowExtensionsTests.swift */,
+				EB898B5027C3B5F90089D03E /* UIControlExtensionsTests.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -2053,6 +2063,7 @@
 				9D806A742258E0D8008E500A /* SCNConeExtensions.swift in Sources */,
 				B22EB2B720E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				077BA08A1F6BE81F00D9C4AC /* URLRequestExtensions.swift in Sources */,
+				EB898B4C27C3B2860089D03E /* UIControlExtensions.swift in Sources */,
 				9D4914831F85138E00F3868F /* NSPredicateExtensions.swift in Sources */,
 				07B7F2131F5EB43C00E6F910 /* FloatExtensions.swift in Sources */,
 				18C8E5DE2074C58100F8AF51 /* SequenceExtensions.swift in Sources */,
@@ -2128,6 +2139,7 @@
 				116090B024187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
 				B2EEA14B211A7ACA00EF7F8E /* RangeReplaceableCollectionExtensions.swift in Sources */,
 				7832C2B0209BB19300224EED /* ComparableExtensions.swift in Sources */,
+				EB898B4D27C3B2860089D03E /* UIControlExtensions.swift in Sources */,
 				077BA0901F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
 				07B7F1B71F5EB42000E6F910 /* UISwitchExtensions.swift in Sources */,
 				9D806A752258E0D8008E500A /* SCNConeExtensions.swift in Sources */,
@@ -2295,6 +2307,7 @@
 				074C8D83224F86450050F040 /* MKMapViewExtensions.swift in Sources */,
 				07B7F1E01F5EB43B00E6F910 /* LocaleExtensions.swift in Sources */,
 				9D806A5E2258D2B8008E500A /* SCNMaterialExtensions.swift in Sources */,
+				EB898B4E27C3B2860089D03E /* UIControlExtensions.swift in Sources */,
 				07B7F1DA1F5EB43B00E6F910 /* DateExtensions.swift in Sources */,
 				07B7F1D81F5EB43B00E6F910 /* CollectionExtensions.swift in Sources */,
 				07B7F1DD1F5EB43B00E6F910 /* FloatExtensions.swift in Sources */,
@@ -2473,6 +2486,7 @@
 				07C50D901F5EB06000F46E5A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				07C50D3B1F5EB04700F46E5A /* UITabBarExtensionsTests.swift in Sources */,
 				078916DA2076077000AC0665 /* FloatingPointExtensionsTests.swift in Sources */,
+				EB898B5427C3B7330089D03E /* UIControlExtensionsTests.swift in Sources */,
 				9D806A9F2258FF1A008E500A /* SCNSphereExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2549,6 +2563,7 @@
 				07C50D681F5EB05100F46E5A /* CollectionExtensionsTests.swift in Sources */,
 				9D806A902258FAA0008E500A /* SCNCapsuleExtensionsTests.swift in Sources */,
 				664CB97C21718B1D00FC87B4 /* BinaryFloatingPointExtensionsTests.swift in Sources */,
+				EB898B5527C3B7370089D03E /* UIControlExtensionsTests.swift in Sources */,
 				07C50D4B1F5EB04700F46E5A /* UINavigationItemExtensionsTests.swift in Sources */,
 				A94AA78B202819B400E229A5 /* FileManagerExtensionsTests.swift in Sources */,
 				078916DF20760DA700AC0665 /* SignedIntegerExtensionsTests.swift in Sources */,
@@ -2627,6 +2642,7 @@
 				182698AE1F8AB46F0052F21E /* CGColorExtensionsTests.swift in Sources */,
 				077BA0A01F6BEA4A00D9C4AC /* URLRequestExtensionsTests.swift in Sources */,
 				07C50D801F5EB05100F46E5A /* URLExtensionsTests.swift in Sources */,
+				EB898B5627C3B7380089D03E /* UIControlExtensionsTests.swift in Sources */,
 				07C50D771F5EB05100F46E5A /* DataExtensionsTests.swift in Sources */,
 				07C50D831F5EB05800F46E5A /* CGSizeExtensionsTests.swift in Sources */,
 				B22EB2BE20E9EA20001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */,

--- a/Tests/UIKitTests/UIControlExtensionsTests.swift
+++ b/Tests/UIKitTests/UIControlExtensionsTests.swift
@@ -1,0 +1,33 @@
+//  UIControlExtensionsTests.swift - Copyright 2022 SwifterSwift
+
+@testable import SwifterSwift
+import XCTest
+
+#if canImport(UIKit)
+import UIKit
+
+final class UIControlExtensionsTests: XCTestCase {
+    
+    func simulateEvent(_ event: UIControl.Event, for control: UIControl) {
+        // https://stackoverflow.com/questions/58519479/xctestcase-of-a-uibutton-tap
+        for target in control.allTargets {
+            let target = target as NSObjectProtocol
+            for actionName in control.actions(forTarget: target, forControlEvent: event) ?? [] {
+                let selector = Selector(actionName)
+                target.perform(selector)
+            }
+        }
+    }
+    
+    func testOn() {
+        let control = UIButton()
+        let expectation = self.expectation(description: "Action")
+        
+        control.on(.touchUpInside) {
+            expectation.fulfill()
+        }
+        simulateEvent(.touchUpInside, for: control)
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+}
+#endif


### PR DESCRIPTION
It's nice to have extension to add `UIControl` events inline.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
