### PR TITLE
deletingAllPathComponents can now handle empty paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **ColorExtension**:
   - Fixed a bug: `Color.FlatUI` can be initialized. by [Shiva Huang](https://github.com/ShivaHuang)
   - Fixed `Color.init?(hexString: String, transparency: CGFloat = 1)` was not handling uppercase `0X` in hex prefix [#947](https://github.com/SwifterSwift/SwifterSwift/pull/947) by [Zero.D.Saber](https://github.com/faimin)
+- **URLExtension**
+  - Fixed `deletingAllPathComponents()` and `deleteAllPathComponents` to handle empty paths, as raised in [#1012](https://github.com/SwifterSwift/SwifterSwift/pull/1012). [#1018](https://github.com/SwifterSwift/SwifterSwift/pull/1018) by [guykogus](https://github.com/guykogus)
 
 ### Security
 

--- a/Sources/SwifterSwift/Foundation/URLExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLExtensions.swift
@@ -1,4 +1,4 @@
-// URLExtensions.swift - Copyright 2020 SwifterSwift
+// URLExtensions.swift - Copyright 2022 SwifterSwift
 
 #if canImport(Foundation)
 import Foundation
@@ -14,7 +14,7 @@ public extension URL {
     /// SwifterSwift: Dictionary of the URL's query parameters.
     var queryParameters: [String: String]? {
         guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
-            let queryItems = components.queryItems else { return nil }
+              let queryItems = components.queryItems else { return nil }
 
         var items: [String: String] = [:]
 
@@ -37,11 +37,11 @@ public extension URL {
         guard let string = string else { return nil }
         self.init(string: string, relativeTo: url)
     }
-    
+
     /**
-    SwifterSwift: Initializes a forced unwrapped `URL` from string. Can potentially crash if string is invalid.
-     - Parameter unsafeString: The URL string used to initialize the `URL`object.
-     */
+     SwifterSwift: Initializes a forced unwrapped `URL` from string. Can potentially crash if string is invalid.
+      - Parameter unsafeString: The URL string used to initialize the `URL`object.
+      */
     init(unsafeString: String) {
         self.init(string: unsafeString)!
     }
@@ -97,6 +97,8 @@ public extension URL {
     ///
     /// - Returns: URL with all path components removed.
     func deletingAllPathComponents() -> URL {
+        guard !pathComponents.isEmpty else { return self }
+
         var url: URL = self
         for _ in 0..<pathComponents.count - 1 {
             url.deleteLastPathComponent()
@@ -110,6 +112,8 @@ public extension URL {
     ///        url.deleteAllPathComponents()
     ///        print(url) // prints "https://domain.com/"
     mutating func deleteAllPathComponents() {
+        guard !pathComponents.isEmpty else { return }
+
         for _ in 0..<pathComponents.count - 1 {
             deleteLastPathComponent()
         }

--- a/Tests/FoundationTests/URLExtensionsTests.swift
+++ b/Tests/FoundationTests/URLExtensionsTests.swift
@@ -1,4 +1,4 @@
-// URLExtensionsTests.swift - Copyright 2020 SwifterSwift
+// URLExtensionsTests.swift - Copyright 2022 SwifterSwift
 
 @testable import SwifterSwift
 import XCTest
@@ -65,12 +65,20 @@ final class URLExtensionsTests: XCTestCase {
         let url = URL(string: "https://domain.com/path/other/")!
         let result = url.deletingAllPathComponents()
         XCTAssertEqual(result.absoluteString, "https://domain.com/")
+
+        let pathlessURL = URL(string: "https://domain.com")!
+        let pathlessResult = pathlessURL.deletingAllPathComponents()
+        XCTAssertEqual(pathlessResult.absoluteString, "https://domain.com")
     }
 
     func testDeleteAllPathComponents() {
         var url = URL(string: "https://domain.com/path/other/")!
         url.deleteAllPathComponents()
         XCTAssertEqual(url.absoluteString, "https://domain.com/")
+
+        var pathlessURL = URL(string: "https://domain.com")!
+        pathlessURL.deleteAllPathComponents()
+        XCTAssertEqual(pathlessURL.absoluteString, "https://domain.com")
     }
 
     #if os(iOS) || os(tvOS)
@@ -102,7 +110,7 @@ final class URLExtensionsTests: XCTestCase {
             XCTAssertEqual(url.droppedScheme()?.absoluteString, expected, "input url: \(input)")
         }
     }
-    
+
     func testStringInitializer() throws {
         let testURL = try XCTUnwrap(URL(string: "https://google.com"))
         let extensionURL = URL(unsafeString: "https://google.com")


### PR DESCRIPTION
Fixes #1012

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
