### PR TITLE
Fixes UIView.rotate(toAngle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Fixed a bug:UITextField `addPaddingLeftIcon` doesn't work on iOS 13[#876](https://github.com/SwifterSwift/SwifterSwift/issues/876) by [Jayxiang](https://github.com/Jayxiang)
 - **UIImage**
   - Fixed a bug:UIImage `rotated(by:)` lose origin scale, result in image blurred[#904](https://github.com/SwifterSwift/SwifterSwift/pull/904) by [yanpanpan](https://github.com/yanpanpan)
+- **UIView**
+  - Fixed `rotate(toAngle)` to rotate _to_ an angle instead of _by_ an angle, as raised in [#935](https://github.com/SwifterSwift/SwifterSwift/pull/935). [#1019](https://github.com/SwifterSwift/SwifterSwift/pull/1019) by [guykogus](https://github.com/guykogus)
 - **ColorExtension**:
   - Fixed a bug: `Color.FlatUI` can be initialized. by [Shiva Huang](https://github.com/ShivaHuang)
   - Fixed `Color.init?(hexString: String, transparency: CGFloat = 1)` was not handling uppercase `0X` in hex prefix [#947](https://github.com/SwifterSwift/SwifterSwift/pull/947) by [Zero.D.Saber](https://github.com/faimin)

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -1,4 +1,4 @@
-// UIViewExtensions.swift - Copyright 2020 SwifterSwift
+// UIViewExtensions.swift - Copyright 2022 SwifterSwift
 
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
@@ -386,7 +386,7 @@ public extension UIView {
         completion: ((Bool) -> Void)? = nil) {
         let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
         let aDuration = animated ? duration : 0
-        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () -> Void in
+        UIView.animate(withDuration: aDuration, delay: 0, options: .curveLinear, animations: { () in
             self.transform = self.transform.rotated(by: angleWithType)
         }, completion: completion)
     }
@@ -406,9 +406,10 @@ public extension UIView {
         duration: TimeInterval = 1,
         completion: ((Bool) -> Void)? = nil) {
         let angleWithType = (type == .degrees) ? .pi * angle / 180.0 : angle
+        let currentAngle = atan2(transform.b, transform.a)
         let aDuration = animated ? duration : 0
         UIView.animate(withDuration: aDuration, animations: {
-            self.transform = self.transform.concatenating(CGAffineTransform(rotationAngle: angleWithType))
+            self.transform = self.transform.rotated(by: angleWithType - currentAngle)
         }, completion: completion)
     }
 
@@ -425,7 +426,7 @@ public extension UIView {
         duration: TimeInterval = 1,
         completion: ((Bool) -> Void)? = nil) {
         if animated {
-            UIView.animate(withDuration: duration, delay: 0, options: .curveLinear, animations: { () -> Void in
+            UIView.animate(withDuration: duration, delay: 0, options: .curveLinear, animations: { () in
                 self.transform = self.transform.scaledBy(x: offset.x, y: offset.y)
             }, completion: completion)
         } else {
@@ -609,7 +610,7 @@ public extension UIView {
     func ancestorView<T: UIView>(withClass _: T.Type) -> T? {
         return ancestorView(where: { $0 is T }) as? T
     }
-  
+
     /// SwifterSwift: Returns all the subviews of a given type recursively in the
     /// view hierarchy rooted on the view it its called.
     ///

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -1,4 +1,4 @@
-// UIViewExtensionsTests.swift - Copyright 2020 SwifterSwift
+// UIViewExtensionsTests.swift - Copyright 2022 SwifterSwift
 
 @testable import SwifterSwift
 import XCTest
@@ -254,47 +254,43 @@ final class UIViewExtensionsTests: XCTestCase {
 
     func testRotateByAngle() {
         let view1 = UIView()
-        let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(byAngle: 2, ofType: .radians, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view1.transform, transform1)
+        view1.rotate(byAngle: 1, ofType: .radians, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, CGAffineTransform(rotationAngle: 1), accuracy: 0.00001)
+        view1.rotate(byAngle: 1, ofType: .radians, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, CGAffineTransform(rotationAngle: 2), accuracy: 0.00001)
 
         let view2 = UIView()
-        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
         view2.rotate(byAngle: 90, ofType: .degrees, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view2.transform, transform2)
+        XCTAssertEqual(view2.transform, CGAffineTransform(rotationAngle: .pi / 2.0))
 
         let rotateExpectation = expectation(description: "view rotated")
-
         let view3 = UIView()
-        let transform3 = CGAffineTransform(rotationAngle: 2)
-
         view3.rotate(byAngle: 2, ofType: .radians, animated: true, duration: 0.5) { _ in
             rotateExpectation.fulfill()
         }
-        XCTAssertEqual(view3.transform, transform3)
+        XCTAssertEqual(view3.transform, CGAffineTransform(rotationAngle: 2))
         waitForExpectations(timeout: 0.5)
     }
 
     func testRotateToAngle() {
         let view1 = UIView()
-        let transform1 = CGAffineTransform(rotationAngle: 2)
-        view1.rotate(toAngle: 2, ofType: .radians, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view1.transform, transform1)
+        view1.rotate(toAngle: 1, ofType: .radians, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, CGAffineTransform(rotationAngle: 1))
+        view1.rotate(toAngle: 0, ofType: .radians, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view1.transform, CGAffineTransform(rotationAngle: 0))
 
         let view2 = UIView()
-        let transform2 = CGAffineTransform(rotationAngle: .pi * 90.0 / 180.0)
         view2.rotate(toAngle: 90, ofType: .degrees, animated: false, duration: 0, completion: nil)
-        XCTAssertEqual(view2.transform, transform2)
+        XCTAssertEqual(view2.transform, CGAffineTransform(rotationAngle: .pi / 2.0))
+        view2.rotate(toAngle: 30, ofType: .degrees, animated: false, duration: 0, completion: nil)
+        XCTAssertEqual(view2.transform, CGAffineTransform(rotationAngle: .pi / 6.0), accuracy: 0.00001)
 
         let rotateExpectation = expectation(description: "view rotated")
-
         let view3 = UIView()
-        let transform3 = CGAffineTransform(rotationAngle: 2)
-
         view3.rotate(toAngle: 2, ofType: .radians, animated: true, duration: 0.5) { _ in
             rotateExpectation.fulfill()
         }
-        XCTAssertEqual(view3.transform, transform3)
+        XCTAssertEqual(view3.transform, CGAffineTransform(rotationAngle: 2))
         waitForExpectations(timeout: 0.5)
     }
 
@@ -313,7 +309,7 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(view1.transform, view2.transform)
         XCTAssertEqual(view1.transform, view3.transform)
     }
-  
+
     #if os(tvOS)
     func testLoadFromNib() {
         let bundle = Bundle(for: UIViewExtensionsTests.self)
@@ -474,28 +470,28 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(buttonSubview.ancestorView(withClass: UITableViewCell.self), tableViewCell)
         XCTAssertEqual(buttonSubview.ancestorView(withClass: UITableView.self), tableView)
     }
-  
-  func testSubviewsOfType() {
-      // Test view with subviews with no subviews
-      XCTAssertEqual(UIView().subviews(ofType: UILabel.self), [])
-          
-      // Test view with subviews that have subviews
-      let parentView = UIView()
-    
-      let childView = UIView()
-      let childViewSubViews = [UILabel(), UIButton(), UITextView(), UILabel(), UIImageView()]
-      childView.addSubviews(childViewSubViews)
-    
-      let childView2 = UIView()
-      let childView2SubViews = [UISegmentedControl(), UILabel(), UITextView(), UIImageView()]
-      childView2.addSubviews(childView2SubViews)
-    
-      parentView.addSubviews([childView, childView2])
-    
-      let expected = [childViewSubViews[0], childViewSubViews[3], childView2SubViews[1]]
-      XCTAssertEqual(parentView.subviews(ofType: UILabel.self), expected)
-      XCTAssertEqual(parentView.subviews(ofType: UITableViewCell.self), [])
-  }
+
+    func testSubviewsOfType() {
+        // Test view with subviews with no subviews
+        XCTAssertEqual(UIView().subviews(ofType: UILabel.self), [])
+
+        // Test view with subviews that have subviews
+        let parentView = UIView()
+
+        let childView = UIView()
+        let childViewSubViews = [UILabel(), UIButton(), UITextView(), UILabel(), UIImageView()]
+        childView.addSubviews(childViewSubViews)
+
+        let childView2 = UIView()
+        let childView2SubViews = [UISegmentedControl(), UILabel(), UITextView(), UIImageView()]
+        childView2.addSubviews(childView2SubViews)
+
+        parentView.addSubviews([childView, childView2])
+
+        let expected = [childViewSubViews[0], childViewSubViews[3], childView2SubViews[1]]
+        XCTAssertEqual(parentView.subviews(ofType: UILabel.self), expected)
+        XCTAssertEqual(parentView.subviews(ofType: UITableViewCell.self), [])
+    }
 
     func testFindConstraint() {
         let view = UIView()

--- a/Tests/XCTest/XCTestExtensions.swift
+++ b/Tests/XCTest/XCTestExtensions.swift
@@ -1,4 +1,4 @@
-// XCTestExtensions.swift - Copyright 2020 SwifterSwift
+// XCTestExtensions.swift - Copyright 2022 SwifterSwift
 
 #if canImport(XCTest)
 import XCTest
@@ -42,6 +42,34 @@ public func XCTAssertEqual(_ expression1: @autoclosure () throws -> Color,
     XCTAssertEqual(green1, green2, accuracy: accuracy, message(), file: file, line: line)
     XCTAssertEqual(blue1, blue2, accuracy: accuracy, message(), file: file, line: line)
     XCTAssertEqual(alpha1, alpha2, accuracy: accuracy, message(), file: file, line: line)
+}
+#endif
+
+#if canImport(CoreGraphics)
+/// SwifterSwift: Asserts that the RGBA values of two `CGAffineTransform`s are equal within a certain accuracy.
+/// - Parameters:
+///   - expression1: A `CGAffineTransform`.
+///   - expression2: A `CGAffineTransform`.
+///   - accuracy: Describes the maximum difference between `expression1` and `expression2` for these values to be considered equal.
+///   - message: An optional description of the failure.
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+public func XCTAssertEqual(_ expression1: @autoclosure () throws -> CGAffineTransform,
+                           _ expression2: @autoclosure () throws -> CGAffineTransform,
+                           accuracy: CGFloat,
+                           _ message: @autoclosure () -> String = "",
+                           file: StaticString = #file,
+                           line: UInt = #line) {
+    var transform1: CGAffineTransform!
+    XCTAssertNoThrow(transform1 = try expression1(), message(), file: file, line: line)
+    var transform2: CGAffineTransform!
+    XCTAssertNoThrow(transform2 = try expression2(), message(), file: file, line: line)
+    XCTAssertEqual(transform1.a, transform2.a, accuracy: accuracy, message(), file: file, line: line)
+    XCTAssertEqual(transform1.b, transform2.b, accuracy: accuracy, message(), file: file, line: line)
+    XCTAssertEqual(transform1.c, transform2.c, accuracy: accuracy, message(), file: file, line: line)
+    XCTAssertEqual(transform1.d, transform2.d, accuracy: accuracy, message(), file: file, line: line)
+    XCTAssertEqual(transform1.tx, transform2.tx, accuracy: accuracy, message(), file: file, line: line)
+    XCTAssertEqual(transform1.ty, transform2.ty, accuracy: accuracy, message(), file: file, line: line)
 }
 #endif
 


### PR DESCRIPTION
Fixes #935 by getting the current angle of the transform and then rotating.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
