### PR TITLE
fix nearestTenMinutes behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Fixed
 - **Date**
-  - fixed incorrect calculation in `nearestTenMinutes` , to align with other `nearest*` date calculations.  [#1034](https://github.com/SwifterSwift/SwifterSwift/pull/1034) by [mmdock](https://github.com/mmdock)
+  - Fixed incorrect calculation in `nearestTenMinutes` to align with other `nearest*` date calculations. [#1034](https://github.com/SwifterSwift/SwifterSwift/pull/1034) by [mmdock](https://github.com/mmdock)
 
 ## [v5.3.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/5.3.0)
 ### Breaking Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ## Upcoming Release
 
+### Fixed
+- **Date**
+  - fixed incorrect calculation in `nearestTenMinutes` , to align with other `nearest*` date calculations.  [#1034](https://github.com/SwifterSwift/SwifterSwift/pull/1034) by [mmdock](https://github.com/mmdock)
+
 ## [v5.3.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/5.3.0)
 ### Breaking Change
 - **Sequence**

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -401,7 +401,7 @@ public extension Date {
             [.year, .month, .day, .hour, .minute, .second, .nanosecond],
             from: self)
         let min = components.minute!
-        components.minute? = min % 10 < 6 ? min - min % 10 : min + 10 - (min % 10)
+        components.minute? = min % 10 < 5 ? min - min % 10 : min + 10 - (min % 10)
         components.second = 0
         components.nanosecond = 0
         return calendar.date(from: components)!

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -398,8 +398,11 @@ final class DateExtensionsTests: XCTestCase {
         let date3 = date.adding(.minute, value: 7) // adding 7 minutes
         XCTAssertEqual(date3.nearestFiveMinutes, date3.adding(.minute, value: -2))
 
-        let date4 = date.adding(.hour, value: 1).adding(.minute, value: 2) // adding 1 hour and 2 minutes
-        XCTAssertEqual(date4.nearestFiveMinutes, date.adding(.hour, value: 1))
+        let date4 = date.adding(.minute, value: 2)
+        XCTAssertEqual(date4.nearestFiveMinutes, date)
+        
+        let date5 = date.adding(.minute, value: 3)
+        XCTAssertEqual(date5.nearestFiveMinutes, date.adding(.minute, value: 5))
     }
 
     func testNearestTenMinutes() {
@@ -414,6 +417,9 @@ final class DateExtensionsTests: XCTestCase {
 
         let date4 = date.adding(.hour, value: 1).adding(.minute, value: 2) // adding 1 hour and 2 minutes
         XCTAssertEqual(date4.nearestTenMinutes, date.adding(.hour, value: 1))
+        
+        let date5 = date.adding(.minute, value: 5) // adding 5 minutes
+        XCTAssertEqual(date5.nearestTenMinutes, date.adding(.minute, value: 10))
     }
 
     func testNearestQuarterHour() {
@@ -428,6 +434,12 @@ final class DateExtensionsTests: XCTestCase {
 
         let date4 = date.adding(.hour, value: 1).adding(.minute, value: 2) // adding 1 hour and 2 minutes
         XCTAssertEqual(date4.nearestQuarterHour, date.adding(.hour, value: 1))
+        
+        let date5 = date.adding(.minute, value: 8) // adding 8 minutes
+        XCTAssertEqual(date5.nearestQuarterHour, date.adding(.minute, value: 15))
+        
+        let date6 = date.adding(.minute, value: 7) // adding 7 minutes
+        XCTAssertEqual(date6.nearestQuarterHour, date)
     }
 
     func testNearestHalfHour() {
@@ -442,6 +454,9 @@ final class DateExtensionsTests: XCTestCase {
 
         let date4 = date.adding(.hour, value: 1).adding(.minute, value: 2) // adding 1 hour and 2 minutes
         XCTAssertEqual(date4.nearestHalfHour, date.adding(.hour, value: 1))
+        
+        let date5 = date.adding(.minute, value: 15) // adding 15 minutes
+        XCTAssertEqual(date5.nearestHalfHour, date.adding(.minute, value: 30))
     }
 
     func testNearestHour() {
@@ -453,6 +468,9 @@ final class DateExtensionsTests: XCTestCase {
 
         let date3 = date.adding(.minute, value: 34) // adding 34 minutes
         XCTAssertEqual(date3.nearestHour, date.adding(.hour, value: 1))
+        
+        let date4 = date.adding(.minute, value: 30) // adding 30 minutes
+        XCTAssertEqual(date4.nearestHour, date.adding(.hour, value: 1))
     }
 
     func testUnixTimestamp() {


### PR DESCRIPTION
fix nearestTenMinutes rounding behavior to behavior like nearestHalfHour

<img width="399" alt="Screen Shot 2022-08-09 at 12 01 57 PM" src="https://user-images.githubusercontent.com/2423465/183740196-bdba1a2c-75d9-4010-a54c-acf7990f182e.png">

As can be seen in the screenshot, nearestTenMinutes, if the minute is halfway of the target interval period (aka multiple of 5 that ends in 5), rounds down.  nearestHalfHour, rounds up when the minute is halfway between a period range

This PR aligns behavior expectations on similarly named computed variables