### PR TITLE
[fix] DigestExtensions to compile on Xcode 14 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ## Upcoming Release
 
+### Fixed
+- **Digest**
+  - `DigestExtensions.swift` would not compile on Xcode 14 due to an `ambiguous use of 'makeIterator()'` error. An updated implementation preserves functionality while disambiguating `makeIterator()`. [#1042](https://github.com/SwifterSwift/SwifterSwift/issues/1042) by [ianclawson](https://github.com/ianclawson)
+  
 ## [v5.3.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/5.3.0)
 ### Breaking Change
 - **Sequence**

--- a/Sources/SwifterSwift/CryptoKit/DigestExtensions.swift
+++ b/Sources/SwifterSwift/CryptoKit/DigestExtensions.swift
@@ -10,8 +10,9 @@ public extension Digest {
 
     /// SwifterSwift: Hexadecimal value string (read-only, Complexity: O(N), _N_ being the amount of bytes.)
     var hexString: String {
+        let bytes: [UInt8] = Array(makeIterator())
         var result = ""
-        for byte in self {
+        for byte in bytes {
             result += String(format: "%02X", byte)
         }
         return result


### PR DESCRIPTION
This PR updates `DigestExtensions#hexString` to disambiguate the use of `makeIterator`, which fixes a compile-time error when building the project in Xcode 14. 

Refer to the issue for more information: https://github.com/SwifterSwift/SwifterSwift/issues/1042

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
