### PR TITLE
Hotfix accuracy

### DIFF
--- a/Tests/UIKitTests/UIButtonExtensionsTests.swift
+++ b/Tests/UIKitTests/UIButtonExtensionsTests.swift
@@ -230,7 +230,7 @@ final class UIButtonExtensionsTests: XCTestCase {
         let highlightedBackgroundImage = button.backgroundImage(for: .highlighted)
         let averageColor = highlightedBackgroundImage!.averageColor()!
         
-        XCTAssertEqual(averageColor, color, accuracy: 1.0)
+        XCTAssertEqual(averageColor, color, accuracy: 0.0001)
     }
 }
 

--- a/Tests/UIKitTests/UIButtonExtensionsTests.swift
+++ b/Tests/UIKitTests/UIButtonExtensionsTests.swift
@@ -223,14 +223,14 @@ final class UIButtonExtensionsTests: XCTestCase {
     
     func testSetBackgroundColorForState() {
         let button = UIButton()
-        let color = UIColor.green
+        let color = UIColor.orange
         
         button.setBackgroundColor(color: color, forState: .highlighted)
         
         let highlightedBackgroundImage = button.backgroundImage(for: .highlighted)
         let averageColor = highlightedBackgroundImage!.averageColor()!
         
-        XCTAssertEqual(averageColor, color, accuracy: 0.0001)
+        XCTAssertEqual(averageColor, color, accuracy: 0.01)
     }
 }
 


### PR DESCRIPTION
🚀
<!--- Provide a general summary of your changes in the Title above -->
Hello.
Thank you for SwifterSwift.
Found out that if `accuracy == 1.0` then `UIColor.red == UIColor.green`. We should use a value close to 0.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
