### PR TITLE
[FIX] - Updated DigestExtensions to compile on Xcode 14 Beta

### DIFF
--- a/Sources/SwifterSwift/CryptoKit/DigestExtensions.swift
+++ b/Sources/SwifterSwift/CryptoKit/DigestExtensions.swift
@@ -11,7 +11,7 @@ public extension Digest {
     /// SwifterSwift: Hexadecimal value string (read-only, Complexity: O(N), _N_ being the amount of bytes.)
     var hexString: String {
         var result = ""
-        for byte in self {
+        for byte in self.makeIterator() {
             result += String(format: "%02X", byte)
         }
         return result


### PR DESCRIPTION
Updated `.hexString` in `DigestExtensions`, with a workaround for a compile-time error on Xcode 14 Beta.

Refer to the issue:  https://github.com/SwifterSwift/SwifterSwift/issues/1042
Refer to the bug: https://github.com/apple/swift/issues/60958


## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
