### PR TITLE
add a more simple conversion between string and double.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `imageForFocused`, `titleColorForFocused`, `titleForFocused`, `attributedTitleForFocused` to handle focused state. [#1063](https://github.com/SwifterSwift/SwifterSwift/pull/1063) by [Roman Podymov](https://github.com/RomanPodymov)
 - **Array**
   - Added `init(count:element:)` initializer for creating an array of a given size with a closure. [#1051](https://github.com/SwifterSwift/SwifterSwift/pull/1051) by [viktart](https://github.com/viktart)
+- **String**
+  - Added a simpler conversion between String and Double. [#1064](https://github.com/SwifterSwift/SwifterSwift/pull/1064) by [westfort4july](https://github.com/westfort4July)
 
 ### Changed
 - **UIButton**:

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -473,6 +473,9 @@ public extension String {
 
     #if canImport(Foundation)
     /// SwifterSwift: Double value from string (if applicable).
+    /// ⚠️ this method will returns nil if the decimal has more than one digits and the device's Settings -> Region is set to some countries(ex Cambodia):
+    /// let doubleInCambodia = "8.32".double(locale: Locale(identifier: "km_KH"))
+    /// doubleInCambodia = nil
     ///
     /// - Parameter locale: Locale (default is Locale.current)
     /// - Returns: Optional Double value from given string.
@@ -482,6 +485,14 @@ public extension String {
         formatter.allowsFloats = true
         return formatter.number(from: self)?.doubleValue
     }
+    
+    /// SwifterSwift: Double value from string.
+    ///
+    /// - Returns: Optional Double value from given string.
+    func doubleValue() -> Double? {
+        return Double(self)
+    }
+    
     #endif
 
     #if canImport(CoreGraphics) && canImport(Foundation)

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -288,6 +288,20 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNil("8s".double())
         #endif
     }
+    
+    func testDoubleValue() {
+        XCTAssertNotNil("8".doubleValue())
+        XCTAssertEqual("8".doubleValue(), 8)
+
+        XCTAssertNotNil("8.23".doubleValue())
+        XCTAssertEqual("8.23".doubleValue(), 8.23)
+
+        #if os(Linux)
+        XCTAssertEqual("8s".doubleValue(), 8)
+        #else
+        XCTAssertNil("8s".doubleValue())
+        #endif
+    }
 
     func testCgFloat() {
         #if !os(Linux)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
