### PR TITLE
Modify Implementation of `DefaultStringInterpolation.appendInterpolation(_:placeholder:where:)`

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/DefaultStringInterpolationExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/DefaultStringInterpolationExtensions.swift
@@ -33,10 +33,10 @@ public extension DefaultStringInterpolation {
     {
         switch value {
         case .some(let value) where try predicate?(value) != false:
-            appendLiteral("\(value)")
+            appendInterpolation(value)
 
         default:
-            appendLiteral(placeholder())
+            appendInterpolation(placeholder())
         }
     }
 }


### PR DESCRIPTION
Use `appendInterpolation(_:)` instead of `appendLiteral(_:)` for better handling interpolation behavior.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
