### PR TITLE
Added `pairs` function to Collection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Collection**
   - Added `fullRange` to get the entire range of indices in a collection. [#902](https://github.com/SwifterSwift/SwifterSwift/pull/902) by [guykogus](https://github.com/guykogus)
   - Moved `indices(of:)` from `RandomAccessCollection` to find the indices of an element. [#863](https://github.com/SwifterSwift/SwifterSwift/pull/863) by [guykogus](https://github.com/guykogus)
+  - Added `pairs` to generate unique pair of elements in a collection
+        [#1094](https://github.com/SwifterSwift/SwifterSwift/pull/1094) by [boudhayan](https://github.com/boudhayan)
 - **UIViewController**:
   - Added `instantiate(from:bundle:identifier:)` function to `UIViewController` to make it easier to instantiate it from storyboard. [#860](https://github.com/SwifterSwift/SwifterSwift/pull/860) by [VatoKo](https://github.com/VatoKo)
 - **String**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Collection**
   - Added `fullRange` to get the entire range of indices in a collection. [#902](https://github.com/SwifterSwift/SwifterSwift/pull/902) by [guykogus](https://github.com/guykogus)
   - Moved `indices(of:)` from `RandomAccessCollection` to find the indices of an element. [#863](https://github.com/SwifterSwift/SwifterSwift/pull/863) by [guykogus](https://github.com/guykogus)
-  - Added `pairs` to generate unique pair of elements in a collection
+  - Added `adjacentPairs` to generate unique pair of elements in a collection
         [#1094](https://github.com/SwifterSwift/SwifterSwift/pull/1094) by [boudhayan](https://github.com/boudhayan)
 - **UIViewController**:
   - Added `instantiate(from:bundle:identifier:)` function to `UIViewController` to make it easier to instantiate it from storyboard. [#860](https://github.com/SwifterSwift/SwifterSwift/pull/860) by [VatoKo](https://github.com/VatoKo)

--- a/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
@@ -96,7 +96,7 @@ public extension Collection {
     ///        }
     ///
     ///
-    /// - Returns: a sequence with tuple(unique pair) as Element type.
+    /// - Returns: a sequence of adjacent pairs of elements from this collection.
     func adjacentPairs() -> AnySequence<(Element, Element)> {
         guard var index1 = index(startIndex, offsetBy: 0, limitedBy: endIndex),
               var index2 = index(index1, offsetBy: 1, limitedBy: endIndex) else {

--- a/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
@@ -87,6 +87,39 @@ public extension Collection {
             start = end
         }
     }
+    
+    /// SwifterSwift: Unique pair of elements in a collection.
+    ///
+    ///        let array = [1, 2, 3]
+    ///        for (first, second) in array.pairs() {
+    ///            print(first, second) // print: (1, 2) (1, 3) (2, 3)
+    ///        }
+    ///
+    ///
+    /// - Returns: a sequence with tuple(unique pair) as Element type.
+    func pairs() -> AnySequence<(Element, Element)> {
+        guard var index1 = index(startIndex, offsetBy: 0, limitedBy: endIndex),
+              var index2 = index(index1, offsetBy: 1, limitedBy: endIndex) else {
+            return AnySequence {
+                EmptyCollection.Iterator()
+            }
+        }
+        return AnySequence {
+            AnyIterator {
+                if index1 >= endIndex || index2 >= endIndex {
+                    return nil
+                }
+                defer {
+                    index2 = self.index(after: index2)
+                    if index2 >= endIndex {
+                        index1 = self.index(after: index1)
+                        index2 = self.index(after:index1)
+                    }
+                }
+                return (self[index1], self[index2])
+            }
+        }
+    }
 }
 
 // MARK: - Methods (Equatable)

--- a/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CollectionExtensions.swift
@@ -97,7 +97,7 @@ public extension Collection {
     ///
     ///
     /// - Returns: a sequence with tuple(unique pair) as Element type.
-    func pairs() -> AnySequence<(Element, Element)> {
+    func adjacentPairs() -> AnySequence<(Element, Element)> {
         guard var index1 = index(startIndex, offsetBy: 0, limitedBy: endIndex),
               var index2 = index(index1, offsetBy: 1, limitedBy: endIndex) else {
             return AnySequence {

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -143,10 +143,7 @@ final class CollectionExtensionsTests: XCTestCase {
     }
     
     func testAdjacentPairsWithOddNumberOfElementsInCollection() {
-        var pairs: [(Int, Int)] = []
-        for (first, second) in [1, 2, 3].adjacentPairs() {
-            pairs.append((first, second))
-        }
+        let pairs = Array([1, 2, 3].adjacentPairs())
         XCTAssertEqual(pairs.count, 3)
         XCTAssertEqual(pairs[0].0, 1)
         XCTAssertEqual(pairs[0].1, 2)
@@ -157,21 +154,14 @@ final class CollectionExtensionsTests: XCTestCase {
     }
     
     func testAdjacentPairsWithEvenNumberOfElementsInCollection() {
-        var pairs: [(Int, Int)] = []
-        for (first, second) in [1, 2].adjacentPairs() {
-            pairs.append((first, second))
-        }
+        let pairs: [(Int, Int)] = Array([1, 2].adjacentPairs())
         XCTAssertEqual(pairs.count, 1)
         XCTAssertEqual(pairs[0].0, 1)
         XCTAssertEqual(pairs[0].1, 2)
     }
     
     func testAdjacentPairsWithEmptyCollection() {
-        var pairs: [(Int, Int)] = []
-        let array: [Int] = []
-        for (first, second) in array.adjacentPairs() {
-            pairs.append((first, second))
-        }
+        let pairs = Array([Int]().adjacentPairs())
         XCTAssertEqual(pairs.count, 0)
     }
 }

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -142,7 +142,7 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual([Int]().average(), 0)
     }
     
-    func testPairs() {
+    func testPairsWithOddNumberOfElementsInCollection() {
         var pairs: [(Int, Int)] = []
         for (first, second) in [1, 2, 3].pairs() {
             pairs.append((first, second))
@@ -154,5 +154,24 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual(pairs[1].1, 3)
         XCTAssertEqual(pairs[2].0, 2)
         XCTAssertEqual(pairs[2].1, 3)
+    }
+    
+    func testPairsWithEvenNumberOfElementsInCollection() {
+        var pairs: [(Int, Int)] = []
+        for (first, second) in [1, 2].pairs() {
+            pairs.append((first, second))
+        }
+        XCTAssertEqual(pairs.count, 1)
+        XCTAssertEqual(pairs[0].0, 1)
+        XCTAssertEqual(pairs[0].1, 2)
+    }
+    
+    func testPairsWithEmptyCollection() {
+        var pairs: [(Int, Int)] = []
+        let array: [Int] = []
+        for (first, second) in array.pairs() {
+            pairs.append((first, second))
+        }
+        XCTAssertEqual(pairs.count, 0)
     }
 }

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -141,4 +141,18 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual([1, 2, 3, 4, 5].average(), 3)
         XCTAssertEqual([Int]().average(), 0)
     }
+    
+    func testPairs() {
+        var pairs: [(Int, Int)] = []
+        for (first, second) in [1, 2, 3].pairs() {
+            pairs.append((first, second))
+        }
+        XCTAssertEqual(pairs.count, 3)
+        XCTAssertEqual(pairs[0].0, 1)
+        XCTAssertEqual(pairs[0].1, 2)
+        XCTAssertEqual(pairs[1].0, 1)
+        XCTAssertEqual(pairs[1].1, 3)
+        XCTAssertEqual(pairs[2].0, 2)
+        XCTAssertEqual(pairs[2].1, 3)
+    }
 }

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -154,7 +154,7 @@ final class CollectionExtensionsTests: XCTestCase {
     }
     
     func testAdjacentPairsWithEvenNumberOfElementsInCollection() {
-        let pairs: [(Int, Int)] = Array([1, 2].adjacentPairs())
+        let pairs = Array([1, 2].adjacentPairs())
         XCTAssertEqual(pairs.count, 1)
         XCTAssertEqual(pairs[0].0, 1)
         XCTAssertEqual(pairs[0].1, 2)

--- a/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CollectionExtensionsTests.swift
@@ -142,9 +142,9 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual([Int]().average(), 0)
     }
     
-    func testPairsWithOddNumberOfElementsInCollection() {
+    func testAdjacentPairsWithOddNumberOfElementsInCollection() {
         var pairs: [(Int, Int)] = []
-        for (first, second) in [1, 2, 3].pairs() {
+        for (first, second) in [1, 2, 3].adjacentPairs() {
             pairs.append((first, second))
         }
         XCTAssertEqual(pairs.count, 3)
@@ -156,9 +156,9 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual(pairs[2].1, 3)
     }
     
-    func testPairsWithEvenNumberOfElementsInCollection() {
+    func testAdjacentPairsWithEvenNumberOfElementsInCollection() {
         var pairs: [(Int, Int)] = []
-        for (first, second) in [1, 2].pairs() {
+        for (first, second) in [1, 2].adjacentPairs() {
             pairs.append((first, second))
         }
         XCTAssertEqual(pairs.count, 1)
@@ -166,10 +166,10 @@ final class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual(pairs[0].1, 2)
     }
     
-    func testPairsWithEmptyCollection() {
+    func testAdjacentPairsWithEmptyCollection() {
         var pairs: [(Int, Int)] = []
         let array: [Int] = []
-        for (first, second) in array.pairs() {
+        for (first, second) in array.adjacentPairs() {
             pairs.append((first, second))
         }
         XCTAssertEqual(pairs.count, 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a new function `pairs` to the collection extension to generate unique pairs of elements.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
