### PR TITLE
Remove warning in NotificationCenterExtensions.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Fixed incorrect calculation in `nearestTenMinutes` to align with other `nearest*` date calculations. [#1034](https://github.com/SwifterSwift/SwifterSwift/pull/1034) by [mmdock](https://github.com/mmdock)
 - **Digest**
   - `DigestExtensions.swift` would not compile on Xcode 14 due to an `ambiguous use of 'makeIterator()'` error. [#1042](https://github.com/SwifterSwift/SwifterSwift/issues/1042) by [theedov](https://github.com/theedov)
-
+- **NotificationCenter**
+  - Fixed warning in `observeOnce` that about capture in sendable closure.
 ---
 
 ## [v5.3.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/5.3.0)

--- a/Sources/SwifterSwift/Foundation/NotificationCenterExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NotificationCenterExtensions.swift
@@ -26,8 +26,11 @@ public extension NotificationCenter {
                      queue: OperationQueue? = nil,
                      using block: @escaping (_ notification: Notification) -> Void) {
         var handler: NSObjectProtocol!
-        handler = addObserver(forName: name, object: obj, queue: queue) { [unowned self] in
+        let removeObserver = { [unowned self] in
             self.removeObserver(handler!)
+        }
+        handler = addObserver(forName: name, object: obj, queue: queue) {
+            removeObserver()
             block($0)
         }
     }


### PR DESCRIPTION
<img width="794" alt="스크린샷 2023-03-31 오후 7 52 59" src="https://user-images.githubusercontent.com/50410213/229103766-6dac813a-9f11-426d-92cf-accbe0135078.png">

Fixed warning in `observeOnce` that about capture in sendable closure.


## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
