### PR TITLE
Minor changes in Optional Collection extensions. :rocket:

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
@@ -91,7 +91,7 @@ public extension Optional {
 public extension Optional where Wrapped: Collection {
     /// SwifterSwift: Check if optional is nil or empty collection.
     var isNilOrEmpty: Bool {
-        return (self == nil || self!.isEmpty)
+        return (self == nil || (self?.isEmpty ?? true))
     }
 
     /// SwifterSwift: Returns the collection only if it is not nil and not empty.

--- a/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
@@ -96,9 +96,7 @@ public extension Optional where Wrapped: Collection {
 
     /// SwifterSwift: Returns the collection only if it is not nil and not empty.
     var nonEmpty: Wrapped? {
-        guard let collection = self else { return nil }
-        guard !collection.isEmpty else { return nil }
-        return collection
+        return (self?.isEmpty ?? true) ? nil : self
     }
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
@@ -91,7 +91,7 @@ public extension Optional {
 public extension Optional where Wrapped: Collection {
     /// SwifterSwift: Check if optional is nil or empty collection.
     var isNilOrEmpty: Bool {
-        return (self == nil || (self?.isEmpty ?? true))
+        return self?.isEmpty ?? true
     }
 
     /// SwifterSwift: Returns the collection only if it is not nil and not empty.

--- a/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift
@@ -91,8 +91,7 @@ public extension Optional {
 public extension Optional where Wrapped: Collection {
     /// SwifterSwift: Check if optional is nil or empty collection.
     var isNilOrEmpty: Bool {
-        guard let collection = self else { return true }
-        return collection.isEmpty
+        return (self == nil || self!.isEmpty)
     }
 
     /// SwifterSwift: Returns the collection only if it is not nil and not empty.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have tested new extensions with existing test cases, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.

## Description
- Updated the `isNilOrEmpty` and `nonEmpty` boolean computed variables of Optional Collections.

- In existing implementation, it was using guard statements to unwrap optionals and check for nil. However, this is not efficient, considering the Collection (on which this is applied) can itself be very huge in terms of space. And assigning again the large amount of data in some temporary variable is an overhead and consumes extra O(n) space complexity. 

- Also, the collection could be multi-dimensional.

- My approach to this is simple, we do some checks directly on the collection not on temporary variables, considering we aren't using the temporary variable except for checking the nil and empty scenarios.

- I believe newer implementation is more readable and concise.

## Performance Impact

I created one playground page to test the performance gains comparing the older implementation and my newer implementation using the continuous clock ([reference](https://developer.apple.com/documentation/swift/clock/measure(_:)-2emvx?changes=_3)). On my performance tests, there was nearly an improvement of more than **90%**. I tested and calculated the average using various sample collection data.

[Code measuring the performance](https://github.com/SwifterSwift/SwifterSwift/files/11522139/TestPerformance.xcplaygroundpage.zip)

## Tests

Since I just updated the extensions so I used the existing test cases which were already implemented. All test cases were passed to 100%

## NOTE

- I was amazed to see such performance gains just by changing some checks. I hope this gets merged, so that anyone who is using those extensions can be benefited.

- Kindly, give some feedback, if we can improve it further.

- Just one request, please merge this PR, instead of committing as Co-author. This really helps me build my github profile.

-  Let's build SwifterSwift more efficient and better!  :rocket:


