### PR TITLE
Reverse the parameters for the ~= String operator to not break the default implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Renamed `EdgeInsets` typealias to `SFEdgeInsets` to fix namespace conflicts with swiftUI's `EdgeInsets` Type. [#1055](https://github.com/SwifterSwift/SwifterSwift/pull/1055) by [MussaCharles](https://github.com/MussaCharles)
 - **Font**
   - Renamed `Font` typealias to `SFFont` to fix namespace conflicts with swiftUI's `Font` Type. [#1055](https://github.com/SwifterSwift/SwifterSwift/pull/1055) by [MussaCharles](https://github.com/MussaCharles)
+- **String**
+  - Reversed the parameters for the `~=` operator in order to not break the default implementation, which causes issues in `switch` statements, for example. [#1113](https://github.com/SwifterSwift/SwifterSwift/issues/1113) by [guykogus](https://github.com/guykogus)
 
 ### Added
 - **UIButton**

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -995,7 +995,7 @@ public extension String {
     ///   - rhs: Regex pattern to match against.
     /// - Returns: true if string matches the pattern.
     static func ~= (lhs: String, rhs: String) -> Bool {
-        return lhs.range(of: rhs, options: .regularExpression) != nil
+        return rhs.range(of: lhs, options: .regularExpression) != nil
     }
     #endif
 
@@ -1006,9 +1006,9 @@ public extension String {
     ///   - lhs: String to check on regex.
     ///   - rhs: Regex to match against.
     /// - Returns: `true` if there is at least one match for the regex in the string.
-    static func ~= (lhs: String, rhs: NSRegularExpression) -> Bool {
-        let range = NSRange(lhs.startIndex..<lhs.endIndex, in: lhs)
-        return rhs.firstMatch(in: lhs, range: range) != nil
+    static func ~= (lhs: NSRegularExpression, rhs: String) -> Bool {
+        let range = NSRange(rhs.startIndex..<rhs.endIndex, in: rhs)
+        return lhs.firstMatch(in: rhs, range: range) != nil
     }
     #endif
 

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -587,21 +587,32 @@ final class StringExtensionsTests: XCTestCase {
 
     #if canImport(Foundation)
     func testPatternMatchOperator() {
-        XCTAssert("123" ~= "\\d{3}")
-        XCTAssertFalse("dasda" ~= "\\d{3}")
-        XCTAssertFalse("notanemail.com" ~= emailPattern)
-        XCTAssert("email@mail.com" ~= emailPattern)
-        XCTAssert("hat" ~= "[a-z]at")
-        XCTAssertFalse("" ~= "[a-z]at")
-        XCTAssert("" ~= "[a-z]*")
-        XCTAssertFalse("" ~= "[0-9]+")
+        XCTAssert("\\d{3}" ~= "123")
+        XCTAssertFalse("\\d{3}" ~= "dasda")
+        XCTAssertFalse(emailPattern ~= "notanemail.com")
+        XCTAssert(emailPattern ~= "email@mail.com")
+        XCTAssert("[a-z]at" ~= "hat")
+        XCTAssertFalse("[a-z]at" ~= "")
+        XCTAssert("[a-z]*" ~= "")
+        XCTAssertFalse("[0-9]+" ~= "")
     }
     #endif
 
     func testRegexMatchOperator() throws {
         let regex = try NSRegularExpression(pattern: "\\d{3}")
-        XCTAssert("123" ~= regex)
-        XCTAssertFalse("abc" ~= regex)
+        XCTAssert(regex ~= "123")
+        XCTAssertFalse(regex ~= "abc")
+
+        // https://github.com/SwifterSwift/SwifterSwift/issues/1109
+        let codeString = "0"
+        switch codeString {
+        case "101":
+            XCTAssert(codeString == "101") //  Not pass here.
+        case "0":
+            XCTAssert(codeString == "0")
+        default:
+            XCTExpectFailure("Switch string value, not matching the correct result.")
+        }
     }
 
     func testPadStart() {

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -613,6 +613,17 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("[a-z]at" ~= "")
         XCTAssert("[a-z]*" ~= "")
         XCTAssertFalse("[0-9]+" ~= "")
+
+        // https://github.com/SwifterSwift/SwifterSwift/issues/1109
+        let codeString = "0"
+        switch codeString {
+        case "101":
+            XCTAssert(codeString == "101")
+        case "0":
+            XCTAssert(codeString == "0")
+        default:
+            XCTFail("Switch string value, not matching the correct result.")
+        }
     }
     #endif
 
@@ -620,17 +631,6 @@ final class StringExtensionsTests: XCTestCase {
         let regex = try NSRegularExpression(pattern: "\\d{3}")
         XCTAssert(regex ~= "123")
         XCTAssertFalse(regex ~= "abc")
-
-        // https://github.com/SwifterSwift/SwifterSwift/issues/1109
-        let codeString = "0"
-        switch codeString {
-        case "101":
-            XCTAssert(codeString == "101") //  Not pass here.
-        case "0":
-            XCTAssert(codeString == "0")
-        default:
-            XCTExpectFailure("Switch string value, not matching the correct result.")
-        }
     }
 
     func testPadStart() {


### PR DESCRIPTION
🚀
Fixes #1109, where performing `switch` on a `String` was broken because the order used in `~=` was reversed.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
