### PR TITLE
Fixed `String.subscript(safe:)` to correctly check for valid ranges of different types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Add `@available(macOS 13.0)` to fix compilation on macOS. [#1059](https://github.com/SwifterSwift/SwifterSwift/issues/1059) by [guykogus](https://github.com/guykogus)
 - **NotificationCenter**
   - Fixed warning in `observeOnce` that about capture in sendable closure.
+- **String**
+  - Fixed `subscript(safe:)` to correctly check for valid ranges of different types. [#1114](https://github.com/SwifterSwift/SwifterSwift/issues/1114) by [guykogus](https://github.com/guykogus)
 
 ## [v5.3.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/5.3.0)
 ### Breaking Change

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -622,19 +622,74 @@ public extension String {
     ///        "Hello World!"[safe: 6..<11] -> "World"
     ///        "Hello World!"[safe: 21..<110] -> nil
     ///
+    /// - Parameter range: Range expression.
+    subscript(safe range: Range<Int>) -> String? {
+        guard range.lowerBound >= 0,
+              range.upperBound <= count else {
+            return nil
+        }
+
+        return String(self[range])
+    }
+
+    /// SwifterSwift: Safely subscript string within a given range.
+    ///
     ///        "Hello World!"[safe: 6...11] -> "World!"
     ///        "Hello World!"[safe: 21...110] -> nil
     ///
     /// - Parameter range: Range expression.
-    subscript<R>(safe range: R) -> String? where R: RangeExpression, R.Bound == Int {
-        let range = range.relative(to: Int.min..<Int.max)
+    subscript(safe range: ClosedRange<Int>) -> String? {
         guard range.lowerBound >= 0,
-            let lowerIndex = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex),
-            let upperIndex = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex) else {
+              range.upperBound < count else {
             return nil
         }
 
-        return String(self[lowerIndex..<upperIndex])
+        return String(self[range])
+    }
+
+    /// SwifterSwift: Safely subscript string within a given range.
+    ///
+    ///        "Hello World!"[safe: ..<5] -> "Hello"
+    ///        "Hello World!"[safe: ..<(-110)] -> nil
+    ///
+    /// - Parameter range: Range expression.
+    subscript(safe range: PartialRangeUpTo<Int>) -> String? {
+        guard range.upperBound >= 0,
+              range.upperBound <= count else {
+            return nil
+        }
+
+        return String(self[range])
+    }
+
+    /// SwifterSwift: Safely subscript string within a given range.
+    ///
+    ///        "Hello World!"[safe: ...10] -> "Hello World"
+    ///        "Hello World!"[safe: ...110] -> nil
+    ///
+    /// - Parameter range: Range expression.
+    subscript(safe range: PartialRangeThrough<Int>) -> String? {
+        guard range.upperBound >= 0,
+              range.upperBound < count else {
+            return nil
+        }
+
+        return String(self[range])
+    }
+
+    /// SwifterSwift: Safely subscript string within a given range.
+    ///
+    ///        "Hello World!"[safe: 6...] -> "World!"
+    ///        "Hello World!"[safe: 50...] -> nil
+    ///
+    /// - Parameter range: Range expression.
+    subscript(safe range: PartialRangeFrom<Int>) -> String? {
+        guard range.lowerBound >= 0,
+              range.lowerBound < count else {
+            return nil
+        }
+
+        return String(self[range])
     }
 
     #if os(iOS) || os(macOS)

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -360,6 +360,24 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(str[safe: 11...11], "!")
         XCTAssertNil(str[safe: 11...12])
 
+        XCTAssertNil(str[safe: ...(-1)])
+        XCTAssertEqual(str[safe: ...0], "H")
+        XCTAssertEqual(str[safe: ...4], "Hello")
+        XCTAssertEqual(str[safe: ...11], "Hello world!")
+        XCTAssertNil(str[safe: ...12])
+
+        XCTAssertNil(str[safe: ..<(-1)])
+        XCTAssertEqual(str[safe: ..<0], "")
+        XCTAssertEqual(str[safe: ..<5], "Hello")
+        XCTAssertEqual(str[safe: ..<12], "Hello world!")
+        XCTAssertNil(str[safe: ..<13])
+
+        XCTAssertNil(str[safe: (-1)...])
+        XCTAssertEqual(str[safe: 0...], "Hello world!")
+        XCTAssertEqual(str[safe: 6...], "world!")
+        XCTAssertEqual(str[safe: 11...], "!")
+        XCTAssertNil(str[safe: 12...])
+
         let oneCharStr = "a"
         XCTAssertEqual(oneCharStr[safe: 0..<0], "")
         XCTAssertEqual(oneCharStr[safe: 0..<1], "a")


### PR DESCRIPTION
🚀
Fixes #1071

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
