### PR TITLE
Deprecate `String.init(randomOfLength:)` in favor of `String.random(ofLength:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Font**
   - Renamed `Font` typealias to `SFFont` to fix namespace conflicts with swiftUI's `Font` Type. [#1055](https://github.com/SwifterSwift/SwifterSwift/pull/1055) by [MussaCharles](https://github.com/MussaCharles)
 
+### Deprecated
+- **String**
+  - `init(randomOfLength:)` deprecated in favor of `String.random(ofLength:)`. [#1115](https://github.com/SwifterSwift/SwifterSwift/issues/1115) by [guykogus](https://github.com/guykogus)
+
 ### Added
 - **UIButton**
   - Added `setBackgroundColor(_:for:)` method for setting background color for the specified UI state. [#1041](https://github.com/SwifterSwift/SwifterSwift/pull/1041) by [TwizzyIndy](https://github.com/TwizzyIndy)

--- a/Sources/SwifterSwift/SwiftStdlib/Deprecated/StringDeprecated.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/Deprecated/StringDeprecated.swift
@@ -1,0 +1,29 @@
+//
+//  StringDeprecated.swift
+//  SwifterSwift
+//
+//  Created by Guy Kogus on 19/6/23.
+//  Copyright © 2023 SwifterSwift
+//
+
+extension String {
+    /// SwifterSwift: Create a new random string of given length.
+    ///
+    ///        String(randomOfLength: 10) -> "gY8r3MHvlQ"
+    ///
+    /// - Parameter length: number of characters in string.
+    @available(*, deprecated, message: "Use String.random(ofLength:) instead.")
+    init(randomOfLength length: Int) {
+        guard length > 0 else {
+            self.init()
+            return
+        }
+
+        let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var randomString = ""
+        for _ in 1...length {
+            randomString.append(base.randomElement()!)
+        }
+        self = randomString
+    }
+}

--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -1157,25 +1157,6 @@ public extension String {
         self.init(str)
     }
     #endif
-
-    /// SwifterSwift: Create a new random string of given length.
-    ///
-    ///		String(randomOfLength: 10) -> "gY8r3MHvlQ"
-    ///
-    /// - Parameter length: number of characters in string.
-    init(randomOfLength length: Int) {
-        guard length > 0 else {
-            self.init()
-            return
-        }
-
-        let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        var randomString = ""
-        for _ in 1...length {
-            randomString.append(base.randomElement()!)
-        }
-        self = randomString
-    }
 }
 
 #if !os(Linux)

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -625,6 +625,10 @@
 		D951E8B023D04E4600F2CD0B /* DecodableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D951E8AE23D04E4600F2CD0B /* DecodableExtensionsTests.swift */; };
 		D951E8B123D04E4600F2CD0B /* DecodableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D951E8AE23D04E4600F2CD0B /* DecodableExtensionsTests.swift */; };
 		D9F36CF623521F440057258F /* MKMapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F36CF523521F440057258F /* MKMapViewTests.swift */; };
+		E4452E622A40D366004C6EA8 /* StringDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4452E612A40D366004C6EA8 /* StringDeprecated.swift */; };
+		E4452E632A40D366004C6EA8 /* StringDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4452E612A40D366004C6EA8 /* StringDeprecated.swift */; };
+		E4452E642A40D366004C6EA8 /* StringDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4452E612A40D366004C6EA8 /* StringDeprecated.swift */; };
+		E4452E652A40D366004C6EA8 /* StringDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4452E612A40D366004C6EA8 /* StringDeprecated.swift */; };
 		E5E5EB3A2350EED400B04C42 /* CAGradientLayerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */; };
 		E5E5EB3D2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */; };
 		F850972424AF72690007F74D /* MyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36CB6424AC9909007727DA /* MyViewController.swift */; };
@@ -935,6 +939,7 @@
 		D951E8A923D04DBE00F2CD0B /* DecodableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableExtensions.swift; sourceTree = "<group>"; };
 		D951E8AE23D04E4600F2CD0B /* DecodableExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableExtensionsTests.swift; sourceTree = "<group>"; };
 		D9F36CF523521F440057258F /* MKMapViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKMapViewTests.swift; sourceTree = "<group>"; };
+		E4452E612A40D366004C6EA8 /* StringDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringDeprecated.swift; sourceTree = "<group>"; };
 		E5E5EB392350EED400B04C42 /* CAGradientLayerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensions.swift; sourceTree = "<group>"; };
 		E5E5EB3C2350F40200B04C42 /* CAGradientLayerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAGradientLayerExtensionsTests.swift; sourceTree = "<group>"; };
 		F854D2A42423AE92003A08A9 /* CGAffineTransformExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensions.swift; sourceTree = "<group>"; };
@@ -1528,6 +1533,7 @@
 			isa = PBXGroup;
 			children = (
 				B2A0DAB52336D5A6002B0BC5 /* StdlibDeprecated.swift */,
+				E4452E612A40D366004C6EA8 /* StringDeprecated.swift */,
 			);
 			path = Deprecated;
 			sourceTree = "<group>";
@@ -2110,6 +2116,7 @@
 				07B7F1931F5EB42000E6F910 /* UIBarButtonItemExtensions.swift in Sources */,
 				07B7F1A21F5EB42000E6F910 /* UITabBarExtensions.swift in Sources */,
 				07B7F1A61F5EB42000E6F910 /* UIViewControllerExtensions.swift in Sources */,
+				E4452E622A40D366004C6EA8 /* StringDeprecated.swift in Sources */,
 				07B7F2311F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F20D1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
 				07B7F19D1F5EB42000E6F910 /* UISearchBarExtensions.swift in Sources */,
@@ -2206,6 +2213,7 @@
 				07B7F1F91F5EB43C00E6F910 /* ArrayExtensions.swift in Sources */,
 				07B7F1B61F5EB42000E6F910 /* UIStoryboardExtensions.swift in Sources */,
 				07B7F1B01F5EB42000E6F910 /* UINavigationBarExtensions.swift in Sources */,
+				E4452E632A40D366004C6EA8 /* StringDeprecated.swift in Sources */,
 				07B7F1AA1F5EB42000E6F910 /* UIButtonExtensions.swift in Sources */,
 				07B7F2091F5EB43C00E6F910 /* URLExtensions.swift in Sources */,
 				D951E8AB23D04DCA00F2CD0B /* DecodableExtensions.swift in Sources */,
@@ -2326,6 +2334,7 @@
 				07B7F1D21F5EB42200E6F910 /* UIViewControllerExtensions.swift in Sources */,
 				07B7F22B1F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F1E91F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
+				E4452E642A40D366004C6EA8 /* StringDeprecated.swift in Sources */,
 				07B7F1F61F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F22D1F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				116090B124187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
@@ -2388,6 +2397,7 @@
 				07B7F2231F5EB44600E6F910 /* CGSizeExtensions.swift in Sources */,
 				664CB9792171899800FC87B4 /* BinaryFloatingPointExtensions.swift in Sources */,
 				9D806A632258D503008E500A /* SCNPlaneExtensions.swift in Sources */,
+				E4452E652A40D366004C6EA8 /* StringDeprecated.swift in Sources */,
 				07B7F1E11F5EB43B00E6F910 /* OptionalExtensions.swift in Sources */,
 				9D9784DE1FCAE42600D988E7 /* StringProtocolExtensions.swift in Sources */,
 				658A02F5270F01D300DBA951 /* MKMultiPointExtensions.swift in Sources */,

--- a/Tests/SwiftStdlibTests/StringExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/StringExtensionsTests.swift
@@ -706,18 +706,6 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertNil(String(base64: "hello"))
     }
 
-    func testInitRandomOfLength() {
-        let str1 = String(randomOfLength: 10)
-        XCTAssertEqual(str1.count, 10)
-
-        let str2 = String(randomOfLength: 10)
-        XCTAssertEqual(str2.count, 10)
-
-        XCTAssertNotEqual(str1, str2)
-
-        XCTAssertEqual(String(randomOfLength: 0), "")
-    }
-
     func testBold() {
         #if canImport(Foundation) && os(macOS)
         let boldString = "hello".bold


### PR DESCRIPTION
🚀
Closes #1052 

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
