### PR TITLE
Date Extension

### DIFF
--- a/Examples/Examples.playground/Pages/02-FoundationExtensions.xcplaygroundpage/Contents.swift
+++ b/Examples/Examples.playground/Pages/02-FoundationExtensions.xcplaygroundpage/Contents.swift
@@ -44,3 +44,6 @@ Date().dayName(ofStyle: .full)
 Date().monthName(ofStyle: .threeLetters)
 
 //: [Next](@next)
+
+let formattedDateTime = Date().getFormatDate(format: .fullDateTime)
+print(formattedDateTime) // Example output: 2023-06-29 14:30:00

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -43,6 +43,27 @@ public extension Date {
         /// SwifterSwift: Full month name.
         case full
     }
+    
+    /// SwifterSwift: we have three predefined cases (fullDateTime, shortDate, time) that represent commonly used date formats.
+    enum DateFormat {
+        case fullDateTime
+        case shortDate
+        case time
+        case custom(String)
+        
+        var getString: String {
+            switch self {
+            case .fullDateTime:
+                return "yyyy-MM-dd HH:mm:ss"
+            case .shortDate:
+                return "yyyy-MM-dd"
+            case .time:
+                return "HH:mm:ss"
+            case .custom(let customFormat):
+                return customFormat
+            }
+        }
+    }
 }
 
 // MARK: - Properties
@@ -1028,6 +1049,15 @@ public extension Date {
         formatter.dateFormat = "yyyyMMdd"
         guard let date = formatter.date(from: String(value)) else { return nil }
         self = date
+    }
+    
+    /// SwifterSwift: Get formatted date in string to display.
+    ///  We have added getString property in enum instead of here because it will help to achieve SOLID `O` principle which is open to extend and close to modify.
+    /// - Parameter format:
+    func getFormatDate(format: DateFormat) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = format.getString
+        return dateFormatter.string(from: self)
     }
 }
 


### PR DESCRIPTION
[✓] Date format enum added so anyone can add his own format and getFormatDate will behave like that [✓] Here we have achieved 1 solid principle as Open for extension and close for modification, so our function will never modify only we need update enum.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
