### PR TITLE
Feature Extend a property backgroundViewColor for UIStackView to set its background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
+- **UIStackView**
+  - Added `backgroundViewColor` to add background color. [#1127](https://github.com/SwifterSwift/SwifterSwift/pull/1127) by [WZBbiao](https://github.com/WZBbiao)
 
 ### Changed
 - **UIButton**:

--- a/Sources/SwifterSwift/UIKit/UIStackViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIStackViewExtensions.swift
@@ -14,7 +14,7 @@ public extension UIStackView {
             if #available(iOS 14.0, *) {
                 return backgroundColor
             } else {
-               return subviews.first(where: { $0 is BackgroundView })?.backgroundColor
+                return subviews.first(where: { $0 is BackgroundView })?.backgroundColor
             }
         }
         set {
@@ -55,13 +55,13 @@ public extension UIStackView {
         spacing: CGFloat = 0.0,
         alignment: UIStackView.Alignment = .fill,
         distribution: UIStackView.Distribution = .fill) {
-        self.init(arrangedSubviews: arrangedSubviews)
-        self.axis = axis
-        self.spacing = spacing
-        self.alignment = alignment
-        self.distribution = distribution
-    }
-
+            self.init(arrangedSubviews: arrangedSubviews)
+            self.axis = axis
+            self.spacing = spacing
+            self.alignment = alignment
+            self.distribution = distribution
+        }
+    
     /// SwifterSwift: Adds array of views to the end of the arrangedSubviews array.
     ///
     /// - Parameter views: views array.
@@ -70,7 +70,7 @@ public extension UIStackView {
             addArrangedSubview(view)
         }
     }
-
+    
     /// SwifterSwift: Removes all views in stack’s array of arranged subviews.
     func removeArrangedSubviews() {
         for view in arrangedSubviews {
@@ -99,7 +99,7 @@ public extension UIStackView {
             else { return }
             removeArrangedSubview(view1)
             insertArrangedSubview(view1, at: view2Index)
-
+            
             removeArrangedSubview(view2)
             insertArrangedSubview(view2, at: view1Index)
         }

--- a/Sources/SwifterSwift/UIKit/UIStackViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIStackViewExtensions.swift
@@ -14,12 +14,7 @@ public extension UIStackView {
             if #available(iOS 14.0, *) {
                 return backgroundColor
             } else {
-                for subview in subviews {
-                    if subview is BackgroundView {
-                        return subview.backgroundColor
-                    }
-                }
-                return nil
+               return subviews.first(where: { $0 is BackgroundView })?.backgroundColor
             }
         }
         set {

--- a/Sources/SwifterSwift/UIKit/UIStackViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIStackViewExtensions.swift
@@ -6,6 +6,44 @@ import UIKit
 // MARK: - Initializers
 
 public extension UIStackView {
+    private class BackgroundView: UIView { }
+    
+    /// SwifterSwift: Add background color to UIStackView
+    var backgroundViewColor: UIColor? {
+        get {
+            if #available(iOS 14.0, *) {
+                return backgroundColor
+            } else {
+                for subview in subviews {
+                    if subview is BackgroundView {
+                        return subview.backgroundColor
+                    }
+                }
+                return nil
+            }
+        }
+        set {
+            if #available(iOS 14.0, *) {
+                backgroundColor = newValue
+            } else {
+                if let existingBackgroundView = subviews.first(where: { $0 is BackgroundView }) {
+                    existingBackgroundView.backgroundColor = newValue
+                } else {
+                    let backgroundView = BackgroundView()
+                    backgroundView.backgroundColor = newValue
+                    insertSubview(backgroundView, at: 0)
+                    backgroundView.translatesAutoresizingMaskIntoConstraints = false
+                    NSLayoutConstraint.activate([
+                        backgroundView.topAnchor.constraint(equalTo: topAnchor),
+                        backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                        backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                        backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor)
+                    ])
+                }
+            }
+        }
+    }
+    
     /// SwifterSwift: Initialize an UIStackView with an array of UIView and common parameters.
     ///
     ///     let stackView = UIStackView(arrangedSubviews: [UIView(), UIView()], axis: .vertical)

--- a/Tests/UIKitTests/UIStackViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIStackViewExtensionsTests.swift
@@ -88,6 +88,21 @@ final class UIStackViewExtensionsTest: XCTestCase {
         XCTAssertEqual(stack.arrangedSubviews.firstIndex(of: view4), 0)
         waitForExpectations(timeout: 1.0)
     }
+    
+    func testBackgroundViewColor() {
+        let stack = UIStackView()
+        stack.backgroundViewColor = nil
+        XCTAssertNil(stack.backgroundViewColor)
+        
+        stack.backgroundViewColor = .red
+        XCTAssertNotNil(stack.backgroundViewColor)
+        
+        XCTAssertEqual(stack.backgroundViewColor!, UIColor.red)
+        
+        if #available(iOS 14, *) {
+            XCTAssertEqual(stack.backgroundColor!, UIColor.red)
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
In versions below iOS 14, UIStackView is a non-rendering component, that is, the background color cannot be set through the backgroundColor property. Extend a property backgroundViewColor for UIStackView to set its background color.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
