### PR TITLE
Fix: compilation errors for visionOS platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,14 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `init(count:element:)` initializer for creating an array of a given size with a closure. [#1051](https://github.com/SwifterSwift/SwifterSwift/pull/1051) by [viktart](https://github.com/viktart)
 - **DefaultStringInterpolation**
   - Added `appendInterpolation(_:placeholder:predicate:)` method for providing placeholder string if interpolated value is `nil` or the optional predicate closure returns `false`. [#1074](https://github.com/SwifterSwift/SwifterSwift/pull/1074) by [Shiva Huang](https://github.com/ShivaHuang)
+- **SFEdgeInsets** 
+  - Excluded type alias `SFEdgeInsets` when targeting visionOS platform. [#1126](https://github.com/SwifterSwift/SwifterSwift/pull/1126) by [MarcoEidinger](https://github.com/MarcoEidinger)
 - **String**
   - Added `formatLocalized(comment:arguments:)` method to format localized strings easily. [#1100](https://github.com/SwifterSwift/SwifterSwift/pull/1100) by [makcakir](https://github.com/makcakir)
+- **UIAlertController**
+  - Excluded `show(animated:vibrate:completion:)` when targeting visionOS platform. [#1126](https://github.com/SwifterSwift/SwifterSwift/pull/1126) by [MarcoEidinger](https://github.com/MarcoEidinger)
+- **UITabBar**
+  - Fixed compilation error for `setColors(background:selectedBackground:item:selectedItem:)` when targeting visionOS platform. [#1126](https://github.com/SwifterSwift/SwifterSwift/pull/1126) by [MarcoEidinger](https://github.com/MarcoEidinger)
 - **URL**
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLSession**

--- a/Sources/SwifterSwift/Shared/EdgeInsetsExtensions.swift
+++ b/Sources/SwifterSwift/Shared/EdgeInsetsExtensions.swift
@@ -1,6 +1,6 @@
 // EdgeInsetsExtensions.swift - Copyright 2020 SwifterSwift
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(visionOS) || os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
 /// SwifterSwift: EdgeInsets
 public typealias SFEdgeInsets = UIEdgeInsets

--- a/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIAlertControllerExtensions.swift
@@ -17,6 +17,7 @@ public extension UIAlertController {
     ///   - vibrate: set true to vibrate the device while presenting the alert (default is false).
     ///   - completion: an optional completion handler to be called after presenting alert controller (default is nil).
     @available(iOSApplicationExtension, unavailable)
+    @available(visionOS, unavailable)
     func show(animated: Bool = true, vibrate: Bool = false, completion: (() -> Void)? = nil) {
         #if targetEnvironment(macCatalyst)
         let window = UIApplication.shared.windows.last

--- a/Sources/SwifterSwift/UIKit/UITabBarExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UITabBarExtensions.swift
@@ -25,7 +25,9 @@ public extension UITabBar {
         tintColor = selectedItem ?? tintColor
         // shadowImage = UIImage()
         backgroundImage = UIImage()
+        #if !os(visionOS)
         isTranslucent = false
+        #endif
 
         // selectedBackgroundColor
         guard let barItems = items else {


### PR DESCRIPTION
I used Xcode 15 Beta 7 to detect compilation errors when trying to build product library `SwifterSwift` for Apple Vision Pro and the changes in this PR will fix the encountered compilation errors.

P.S.: This PR does not fix compilation errors for test target `SwifterSwiftTests` but this is also not relevant for consumers.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.0.
- [ ] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
