### PR TITLE
Add `method` operator to URLRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **URL**
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLRequest**
-  - Added `method()` operator to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT)
+  - Added `method()` to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT)
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIStackView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **URL**
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLRequest**
-  - Added `method()` to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT)
+  - Added `method()` to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT) [#1133](https://github.com/SwifterSwift/SwifterSwift/pull/1133) by [Ricardo Rauber](https://github.com/ricardorauber)
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIStackView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Fixed compilation error for `setColors(background:selectedBackground:item:selectedItem:)` when targeting visionOS platform. [#1126](https://github.com/SwifterSwift/SwifterSwift/pull/1126) by [MarcoEidinger](https://github.com/MarcoEidinger)
 - **URL**
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
+- **URLRequest**
+  - Added `method()` operator to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT)
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIStackView**

--- a/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
@@ -47,4 +47,21 @@ public extension URLRequest {
     }
 }
 
+// MARK: - Operators
+
+public extension URLRequest {
+    /// SwifterSwift: Duplicates the request and modifies the HTTP method (verb) for the request (i.e.: GET, POST, PUT)
+    ///
+    ///     let request = URLRequest(url: url)
+    ///         .method("post")
+    ///
+    /// - Parameter methodString: The method as a String value
+    /// - Returns: The modified request
+    func method(_ methodString: String) -> Self {
+        var request = self
+        request.httpMethod = methodString.uppercased()
+        return request
+    }
+}
+
 #endif

--- a/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
@@ -47,7 +47,7 @@ public extension URLRequest {
     }
 }
 
-// MARK: - Operators
+// MARK: - Methods
 
 public extension URLRequest {
     /// SwifterSwift: Duplicates the request and modifies the HTTP method (verb) for the request (i.e.: GET, POST, PUT)

--- a/Tests/FoundationTests/URLRequestExtensionsTests.swift
+++ b/Tests/FoundationTests/URLRequestExtensionsTests.swift
@@ -62,6 +62,16 @@ final class URLRequestExtensionsTests: XCTestCase {
         let planetaryRequest = URLRequest(url: components!.url!)
         XCTAssertEqual(planetaryRequest.curlString, planetaryNASAcURL)
     }
+    
+    // MARK: - Operators
+    
+    func testMethod() throws {
+        let url = URL(string: "https://api.server.com/")!
+        let request = URLRequest(url: url)
+            .method("post")
+        XCTAssertEqual(request.url, url)
+        XCTAssertEqual(request.httpMethod, "POST")
+    }
 }
 
 #endif

--- a/Tests/FoundationTests/URLRequestExtensionsTests.swift
+++ b/Tests/FoundationTests/URLRequestExtensionsTests.swift
@@ -63,7 +63,7 @@ final class URLRequestExtensionsTests: XCTestCase {
         XCTAssertEqual(planetaryRequest.curlString, planetaryNASAcURL)
     }
     
-    // MARK: - Operators
+    // MARK: - Methods
     
     func testMethod() throws {
         let url = URL(string: "https://api.server.com/")!


### PR DESCRIPTION
I have a bunch of operators to handle `URLRequest` creation in an easy way. This one is the first of them, to set the `httpMethod`. My idea is to make a PR for each of the operators so in the end we could create requests like this:

```swift
let request = URLRequest(url: url)
    .method("post")
    .authorization(token: token)
    .header(name: "something", value: "interesting")
    .jsonBody(parameters)
```

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
