### PR TITLE
Add `header(name:, value:)` method to URLRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLRequest**
   - Added `method()` to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT) [#1133](https://github.com/SwifterSwift/SwifterSwift/pull/1133) by [Ricardo Rauber](https://github.com/ricardorauber)
-  - Added `header(name:, value:)` to duplicate the request and set a header with key and value. It will use String(describing: value) as the value should be a string
+  - Added `header(name:, value:)` to duplicate the request and set a header with key and value. It will use String(describing: value) as the value should be a string [#1134](https://github.com/SwifterSwift/SwifterSwift/pull/1134) by [Ricardo Rauber](https://github.com/ricardorauber)
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIStackView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLRequest**
   - Added `method()` to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT) [#1133](https://github.com/SwifterSwift/SwifterSwift/pull/1133) by [Ricardo Rauber](https://github.com/ricardorauber)
+  - Added `header(name:, value:)` to duplicate the request and set a header with key and value. It will use String(describing: value) as the value should be a string
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIStackView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `allQueryParameters`, `appendingQueryParameters(_:)` and `appendQueryParameters(_:)` for using `URLQueryItem`, as an addition to the `[String: String]` variants, to handle `nil`-value query parameters. [#1116](https://github.com/SwifterSwift/SwifterSwift/issues/1116) by [guykogus](https://github.com/guykogus)
 - **URLRequest**
   - Added `method()` to duplicate the request and modify the HTTP method (verb) for the request (i.e.: GET, POST, PUT) [#1133](https://github.com/SwifterSwift/SwifterSwift/pull/1133) by [Ricardo Rauber](https://github.com/ricardorauber)
-  - Added `header(name:, value:)` to duplicate the request and set a header with key and value. It will use String(describing: value) as the value should be a string [#1134](https://github.com/SwifterSwift/SwifterSwift/pull/1134) by [Ricardo Rauber](https://github.com/ricardorauber)
+  - Added `header(name:, value:)` to duplicate the request and set a header with key and value. [#1134](https://github.com/SwifterSwift/SwifterSwift/pull/1134) by [Ricardo Rauber](https://github.com/ricardorauber)
 - **URLSession**
   - Added `dataSync(for:)` to make requests synchronously. [#1076](https://github.com/SwifterSwift/SwifterSwift/pull/1076) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIStackView**

--- a/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
@@ -62,6 +62,21 @@ public extension URLRequest {
         request.httpMethod = methodString.uppercased()
         return request
     }
+    
+    /// SwifterSwift: Duplicates the request and set a header with key and value. It will use String(describing: value) as the value should be a string
+    ///
+    ///     let request = URLRequest(url: url)
+    ///         .header(name: "something", value: "interesting")
+    ///
+    /// - Parameters:
+    ///   - name: The name of the header
+    ///   - value: The value of the header
+    /// - Returns: The modified request
+    func header(name: String, value: Any) -> Self {
+        var request = self
+        request.setValue(String(describing: value), forHTTPHeaderField: name)
+        return request
+    }
 }
 
 #endif

--- a/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/URLRequestExtensions.swift
@@ -63,18 +63,18 @@ public extension URLRequest {
         return request
     }
     
-    /// SwifterSwift: Duplicates the request and set a header with key and value. It will use String(describing: value) as the value should be a string
+    /// SwifterSwift: Duplicates the request and set a header with key and value
     ///
     ///     let request = URLRequest(url: url)
-    ///         .header(name: "something", value: "interesting")
+    ///         .header(name: "Content-Type", value: "application/json")
     ///
     /// - Parameters:
     ///   - name: The name of the header
     ///   - value: The value of the header
     /// - Returns: The modified request
-    func header(name: String, value: Any) -> Self {
+    func header(name: String, value: String) -> Self {
         var request = self
-        request.setValue(String(describing: value), forHTTPHeaderField: name)
+        request.setValue(value, forHTTPHeaderField: name)
         return request
     }
 }

--- a/Tests/FoundationTests/URLRequestExtensionsTests.swift
+++ b/Tests/FoundationTests/URLRequestExtensionsTests.swift
@@ -72,6 +72,16 @@ final class URLRequestExtensionsTests: XCTestCase {
         XCTAssertEqual(request.url, url)
         XCTAssertEqual(request.httpMethod, "POST")
     }
+    
+    func testHeader() throws {
+        let url = URL(string: "https://api.server.com/")!
+        let request = URLRequest(url: url)
+            .header(name: "Content-Type", value: "application/json")
+            .header(name: "Number", value: 10)
+        XCTAssertNotNil(request.allHTTPHeaderFields)
+        XCTAssertEqual(request.allHTTPHeaderFields!["Content-Type"]!, "application/json")
+        XCTAssertEqual(Int(request.allHTTPHeaderFields!["Number"]!), 10)
+    }
 }
 
 #endif

--- a/Tests/FoundationTests/URLRequestExtensionsTests.swift
+++ b/Tests/FoundationTests/URLRequestExtensionsTests.swift
@@ -77,7 +77,7 @@ final class URLRequestExtensionsTests: XCTestCase {
         let url = URL(string: "https://api.server.com/")!
         let request = URLRequest(url: url)
             .header(name: "Content-Type", value: "application/json")
-            .header(name: "Number", value: 10)
+            .header(name: "Number", value: "10")
         XCTAssertNotNil(request.allHTTPHeaderFields)
         XCTAssertEqual(request.allHTTPHeaderFields!["Content-Type"]!, "application/json")
         XCTAssertEqual(Int(request.allHTTPHeaderFields!["Number"]!), 10)


### PR DESCRIPTION
Following the idea of the [#1133](https://github.com/SwifterSwift/SwifterSwift/pull/1133), this PR adds a method to URLRequest to set a header.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
