### PR TITLE
Added method for toggling between values for Equatable and CaseIterable types 🚀

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/CaseIterableExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/CaseIterableExtensions.swift
@@ -1,0 +1,47 @@
+// CaseIterableExtensions.swift - Copyright 2023 SwifterSwift
+
+import Foundation
+
+public extension CaseIterable where Self: Equatable, AllCases == [Self] {
+    
+    /// SwifterSwift: Sets the value to next available case from given array.
+    ///
+    ///     enum ShuffleMode: CaseIterable {
+    ///        case off, songs, albums
+    ///     }
+    ///
+    ///     var mode: ShuffleMode = .off
+    ///     mode.toggle() // .songs
+    ///
+    ///     var mode: ShuffleMode = .albums
+    ///     mode.toggle() // .off
+    ///
+    ///     var mode: ShuffleMode = .albums
+    ///     mode.toggle(cycle: false) // .albums
+    ///
+    ///     var mode: ShuffleMode = .albums
+    ///     mode.toggle(between: [.songs, .albums]) // .songs
+    ///
+    /// - Parameters:
+    ///    - cases: Array of values that can be assigned to the caller.
+    ///    If empty array is passed the possible values will be taken from `allCases` array.
+    ///    - cycle: Indicates whether the value should be modified if it's already at the end of `values` array.
+    ///
+    mutating func toggle(
+        between values: [Self] = Self.allCases,
+        cycle: Bool = false
+    ) {
+        guard var index = values.firstIndex(of: self) else {
+            fatalError("Case \(self) must be included in `values` array.")
+        }
+        if index < (values.count - 1) {
+            index += 1
+        }
+        else {
+            if !cycle { return }
+            index = 0
+        }
+        self = values[index]
+    }
+    
+}

--- a/Sources/SwifterSwift/SwiftStdlib/EquatableExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/EquatableExtensions.swift
@@ -1,36 +1,39 @@
-// CaseIterableExtensions.swift - Copyright 2023 SwifterSwift
+// EquatableExtensions.swift - Copyright 2023 SwifterSwift
 
 import Foundation
 
-public extension CaseIterable where Self: Equatable, AllCases == [Self] {
+public extension Equatable {
     
-    /// SwifterSwift: Sets the value to next available case from `allCases` array.
+    /// SwifterSwift: Sets the value to next available value from given array.
     ///
-    ///     enum ShuffleMode: CaseIterable {
+    ///     enum ShuffleMode {
     ///        case off, songs, albums
     ///     }
     ///
+    ///     let values: [ShuffleMode] = [.off, .songs, .albums]
+    ///
     ///     var mode: ShuffleMode = .off
-    ///     mode.toggle() // .songs
+    ///     mode.toggle(between: values) // .songs
     ///
     ///     var mode: ShuffleMode = .albums
-    ///     mode.toggle() // .off
+    ///     mode.toggle(between: values) // .off
     ///
     ///     var mode: ShuffleMode = .albums
-    ///     mode.toggle(cycle: false) // .albums
+    ///     mode.toggle(between: values, cycle: false) // .albums
     ///
     ///     var mode: ShuffleMode = .albums
     ///     mode.toggle(between: [.songs, .albums]) // .songs
     ///
     /// - Parameters:
+    ///    - cases: Array of values that can be assigned to the caller.
     ///    - cycle: Indicates whether the value should be modified if it's already at the end of `values` array.
     ///
     mutating func toggle(
+        between values: [Self],
         cycle: Bool = false
     ) {
-        let values = Self.allCases
         guard var index = values.firstIndex(of: self) else {
-            fatalError("Case \(self) must be included in `values` array.")
+            fatalError("Value \(self) must be included in `values` array.")
         }
         if index < (values.count - 1) {
             index += 1

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -583,6 +583,10 @@
 		B0B7427D2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */; };
 		B0B7427E2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */; };
 		B0B7427F2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */; };
+		B0B742812AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B742802AD41B7B00EBF1D6 /* EquatableExtensions.swift */; };
+		B0B742822AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B742802AD41B7B00EBF1D6 /* EquatableExtensions.swift */; };
+		B0B742832AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B742802AD41B7B00EBF1D6 /* EquatableExtensions.swift */; };
+		B0B742842AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B742802AD41B7B00EBF1D6 /* EquatableExtensions.swift */; };
 		B22EB2B720E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
 		B22EB2B920E9E814001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */; };
 		B22EB2BB20E9E81C001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
@@ -933,6 +937,7 @@
 		A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensionsTests.swift; sourceTree = "<group>"; };
 		B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseIterableExtensions.swift; sourceTree = "<group>"; };
 		B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaseIterableExtensionsTests.swift; sourceTree = "<group>"; };
+		B0B742802AD41B7B00EBF1D6 /* EquatableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableExtensions.swift; sourceTree = "<group>"; };
 		B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionExtensions.swift; sourceTree = "<group>"; };
 		B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionTests.swift; sourceTree = "<group>"; };
 		B2A0DAB52336D5A6002B0BC5 /* StdlibDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdlibDeprecated.swift; sourceTree = "<group>"; };
@@ -1049,6 +1054,7 @@
 				664CB9752171899800FC87B4 /* BinaryFloatingPointExtensions.swift */,
 				D5FD5283270853B30073F831 /* BinaryIntegerExtensions.swift */,
 				07B7F1671F5EB41600E6F910 /* BoolExtensions.swift */,
+				B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */,
 				07B7F1681F5EB41600E6F910 /* CharacterExtensions.swift */,
 				07B7F1691F5EB41600E6F910 /* CollectionExtensions.swift */,
 				7832C2AE209BB19300224EED /* ComparableExtensions.swift */,
@@ -1056,9 +1062,12 @@
 				58CAE62828CF2935001935A2 /* DefaultStringInterpolationExtensions.swift */,
 				07B7F16E1F5EB41600E6F910 /* DictionaryExtensions.swift */,
 				07B7F16F1F5EB41600E6F910 /* DoubleExtensions.swift */,
+				B0B742802AD41B7B00EBF1D6 /* EquatableExtensions.swift */,
 				07B7F1701F5EB41600E6F910 /* FloatExtensions.swift */,
 				07B7F1711F5EB41600E6F910 /* FloatingPointExtensions.swift */,
 				07B7F1721F5EB41600E6F910 /* IntExtensions.swift */,
+				C7E027C32360942000F1061E /* KeyedDecodingContainerExtensions.swift */,
+				B2A0DABF2336DA87002B0BC5 /* MutableCollectionExtensions.swift */,
 				07B7F1741F5EB41600E6F910 /* OptionalExtensions.swift */,
 				B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */,
 				18C8E5DD2074C58100F8AF51 /* SequenceExtensions.swift */,
@@ -1066,9 +1075,6 @@
 				07B7F1761F5EB41600E6F910 /* SignedNumericExtensions.swift */,
 				07B7F1771F5EB41600E6F910 /* StringExtensions.swift */,
 				9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */,
-				B2A0DABF2336DA87002B0BC5 /* MutableCollectionExtensions.swift */,
-				C7E027C32360942000F1061E /* KeyedDecodingContainerExtensions.swift */,
-				B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */,
 			);
 			path = SwiftStdlib;
 			sourceTree = "<group>";
@@ -2350,6 +2356,7 @@
 				07B7F19E1F5EB42000E6F910 /* UISegmentedControlExtensions.swift in Sources */,
 				07B7F20F1F5EB43C00E6F910 /* DataExtensions.swift in Sources */,
 				0DAEBCE024B0045F00F61684 /* HKActivitySummaryExtensions.swift in Sources */,
+				B0B742812AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */,
 				9E3CA2672ABE0D7100FA4626 /* FutureExtensions.swift in Sources */,
 				07B7F19C1F5EB42000E6F910 /* UINavigationItemExtensions.swift in Sources */,
 				9D806A5B2258D2B8008E500A /* SCNMaterialExtensions.swift in Sources */,
@@ -2425,6 +2432,7 @@
 				F8DED22624EAA2070068F758 /* UIScrollViewExtensions.swift in Sources */,
 				07B7F1BC1F5EB42000E6F910 /* UIViewControllerExtensions.swift in Sources */,
 				58CAE62A28CF2935001935A2 /* DefaultStringInterpolationExtensions.swift in Sources */,
+				B0B742822AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */,
 				F8A710EA23BF3F7300112DAD /* EdgeInsetsExtensions.swift in Sources */,
 				07B7F2371F5EB45200E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F1FB1F5EB43C00E6F910 /* CharacterExtensions.swift in Sources */,
@@ -2527,6 +2535,7 @@
 				07B7F1CE1F5EB42200E6F910 /* UITabBarExtensions.swift in Sources */,
 				F8A710EB23BF3F7400112DAD /* EdgeInsetsExtensions.swift in Sources */,
 				664CB9782171899800FC87B4 /* BinaryFloatingPointExtensions.swift in Sources */,
+				B0B742832AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */,
 				07B7F1D21F5EB42200E6F910 /* UIViewControllerExtensions.swift in Sources */,
 				07B7F22B1F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F1E91F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
@@ -2629,6 +2638,7 @@
 				9D806A4E2258CFF8008E500A /* SCNSphereExtensions.swift in Sources */,
 				07B7F1E21F5EB43B00E6F910 /* SignedIntegerExtensions.swift in Sources */,
 				F887E93C2505AB87006CB4F7 /* FontExtensions.swift in Sources */,
+				B0B742842AD41B7B00EBF1D6 /* EquatableExtensions.swift in Sources */,
 				07B7F1E51F5EB43B00E6F910 /* URLExtensions.swift in Sources */,
 				077BA0921F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
 				07B7F1DF1F5EB43B00E6F910 /* IntExtensions.swift in Sources */,

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -576,6 +576,13 @@
 		A9AEB78620283ACC0021AACF /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */; };
 		A9AEB78720283ACC0021AACF /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */; };
 		A9AEB78820283ACD0021AACF /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */; };
+		B09DA5322AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */; };
+		B09DA5332AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */; };
+		B09DA5342AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */; };
+		B09DA5352AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */; };
+		B0B7427D2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */; };
+		B0B7427E2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */; };
+		B0B7427F2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */; };
 		B22EB2B720E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
 		B22EB2B920E9E814001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */; };
 		B22EB2BB20E9E81C001EAE70 /* RangeReplaceableCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */; };
@@ -924,6 +931,8 @@
 		9E9F42B529872F5F00A0BD60 /* URLSessionExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionExtensionsTests.swift; sourceTree = "<group>"; };
 		A94AA78620280F9100E229A5 /* FileManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensions.swift; sourceTree = "<group>"; };
 		A94AA7882028193A00E229A5 /* FileManagerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerExtensionsTests.swift; sourceTree = "<group>"; };
+		B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseIterableExtensions.swift; sourceTree = "<group>"; };
+		B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaseIterableExtensionsTests.swift; sourceTree = "<group>"; };
 		B22EB2B620E9E720001EAE70 /* RangeReplaceableCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionExtensions.swift; sourceTree = "<group>"; };
 		B22EB2B820E9E814001EAE70 /* RangeReplaceableCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReplaceableCollectionTests.swift; sourceTree = "<group>"; };
 		B2A0DAB52336D5A6002B0BC5 /* StdlibDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdlibDeprecated.swift; sourceTree = "<group>"; };
@@ -1059,6 +1068,7 @@
 				9D9784DA1FCAE3D200D988E7 /* StringProtocolExtensions.swift */,
 				B2A0DABF2336DA87002B0BC5 /* MutableCollectionExtensions.swift */,
 				C7E027C32360942000F1061E /* KeyedDecodingContainerExtensions.swift */,
+				B09DA5312AD3F74C003E72C8 /* CaseIterableExtensions.swift */,
 			);
 			path = SwiftStdlib;
 			sourceTree = "<group>";
@@ -1071,6 +1081,7 @@
 				664CB97A21718B1D00FC87B4 /* BinaryFloatingPointExtensionsTests.swift */,
 				D5FD5288270858400073F831 /* BinaryIntegerExtensionsTests.swift */,
 				07C50CFB1F5EB03200F46E5A /* BoolExtensionsTests.swift */,
+				B0B7427C2AD415D300EBF1D6 /* CaseIterableExtensionsTests.swift */,
 				07C50CFC1F5EB03200F46E5A /* CharacterExtensionsTests.swift */,
 				07C50CFD1F5EB03200F46E5A /* CollectionExtensionsTests.swift */,
 				7832C2B3209BB32500224EED /* ComparableExtensionsTests.swift */,
@@ -2260,6 +2271,7 @@
 				07B7F1981F5EB42000E6F910 /* UIImageViewExtensions.swift in Sources */,
 				42F53FEC2039C5AC0070DC11 /* UIStackViewExtensions.swift in Sources */,
 				F887E9392505AB87006CB4F7 /* FontExtensions.swift in Sources */,
+				B09DA5322AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */,
 				7832C2AF209BB19300224EED /* ComparableExtensions.swift in Sources */,
 				664CB9762171899800FC87B4 /* BinaryFloatingPointExtensions.swift in Sources */,
 				074C8D81224F86450050F040 /* MKMapViewExtensions.swift in Sources */,
@@ -2407,6 +2419,7 @@
 				F8C1AE70225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */,
 				07B7F1A91F5EB42000E6F910 /* UIBarButtonItemExtensions.swift in Sources */,
 				07B7F1B81F5EB42000E6F910 /* UITabBarExtensions.swift in Sources */,
+				B09DA5332AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */,
 				664CB96E2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */,
 				734308082108E4630029CD16 /* CGVectorExtensions.swift in Sources */,
 				F8DED22624EAA2070068F758 /* UIScrollViewExtensions.swift in Sources */,
@@ -2518,6 +2531,7 @@
 				07B7F22B1F5EB45100E6F910 /* CGSizeExtensions.swift in Sources */,
 				07B7F1E91F5EB43B00E6F910 /* CharacterExtensions.swift in Sources */,
 				E4452E642A40D366004C6EA8 /* StringDeprecated.swift in Sources */,
+				B09DA5342AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */,
 				07B7F1F61F5EB43B00E6F910 /* StringExtensions.swift in Sources */,
 				07B7F22D1F5EB45100E6F910 /* NSAttributedStringExtensions.swift in Sources */,
 				116090B124187D5C00DDCD01 /* CGRectExtensions.swift in Sources */,
@@ -2579,6 +2593,7 @@
 				9E9F42B429872E9400A0BD60 /* URLSessionExtensions.swift in Sources */,
 				07B7F2231F5EB44600E6F910 /* CGSizeExtensions.swift in Sources */,
 				664CB9792171899800FC87B4 /* BinaryFloatingPointExtensions.swift in Sources */,
+				B09DA5352AD3F74C003E72C8 /* CaseIterableExtensions.swift in Sources */,
 				9D806A632258D503008E500A /* SCNPlaneExtensions.swift in Sources */,
 				E4452E652A40D366004C6EA8 /* StringDeprecated.swift in Sources */,
 				07B7F1E11F5EB43B00E6F910 /* OptionalExtensions.swift in Sources */,
@@ -2737,6 +2752,7 @@
 				734307FB2108C85B0029CD16 /* CGVectorExtensionsTests.swift in Sources */,
 				9DC29CF42349E80F00F5CAAD /* UIColorExtensionsTests.swift in Sources */,
 				07C50D2B1F5EB04600F46E5A /* UIAlertControllerExtensionsTests.swift in Sources */,
+				B0B7427D2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */,
 				9D806A7E2258F41B008E500A /* SCNMaterialExtensionsTests.swift in Sources */,
 				9D806A8F2258FAA0008E500A /* SCNCapsuleExtensionsTests.swift in Sources */,
 				07C50D5E1F5EB05000F46E5A /* DoubleExtensionsTests.swift in Sources */,
@@ -2761,6 +2777,7 @@
 				D5FD528E27085D820073F831 /* BinaryIntegerExtensionsTests.swift in Sources */,
 				9D806A9C2258FE9D008E500A /* SCNShapeExtensionsTests.swift in Sources */,
 				07C50D481F5EB04700F46E5A /* UILabelExtensionsTests.swift in Sources */,
+				B0B7427E2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */,
 				9D806A942258FCCE008E500A /* SCNConeExtensionsTests.swift in Sources */,
 				07C50D701F5EB05100F46E5A /* OptionalExtensionsTests.swift in Sources */,
 				07C50D6E1F5EB05100F46E5A /* IntExtensionsTests.swift in Sources */,
@@ -2916,6 +2933,7 @@
 				07C50D831F5EB05800F46E5A /* CGSizeExtensionsTests.swift in Sources */,
 				B22EB2BE20E9EA20001EAE70 /* RangeReplaceableCollectionTests.swift in Sources */,
 				748B192123B4F4FA0030FABB /* SKProductTests.swift in Sources */,
+				B0B7427F2AD415D400EBF1D6 /* CaseIterableExtensionsTests.swift in Sources */,
 				077BA0BB1F6BEA6B00D9C4AC /* UserDefaultsExtensionsTests.swift in Sources */,
 				D951E8B123D04E4600F2CD0B /* DecodableExtensionsTests.swift in Sources */,
 				784C75392051BE1D001C48DD /* MKPolylineTests.swift in Sources */,

--- a/Tests/SwiftStdlibTests/CaseIterableExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/CaseIterableExtensionsTests.swift
@@ -1,0 +1,51 @@
+// CaseIterableExtensionsTests.swift - Copyright 2023 SwifterSwift
+
+@testable import SwifterSwift
+import XCTest
+
+final class CaseIterableExtensionsTests: XCTestCase {
+    
+    private enum Test: CaseIterable {
+        case test1, test2, test3
+    }
+    
+    func testNextCase() {
+        var value: Test = .test1
+        value.toggle()
+        
+        XCTAssert(
+            value == .test2,
+            "value was not increased after running `toggle()`"
+        )
+    }
+    
+    func testWithLimit() {
+        var value: Test = .test3
+        value.toggle(cycle: false)
+        
+        XCTAssert(
+            value == .test3,
+            "value should not change after reaching last case when running `toggle(cycle: false)`"
+        )
+    }
+    
+    func testWithoutLimit() {
+        var value: Test = .test3
+        value.toggle(cycle: true)
+        
+        XCTAssert(
+            value == .test1,
+            "value should be changed to first case after reaching last case when running `toggle(cycle: true)`"
+        )
+    }
+    
+    func testAvailableCases() {
+        var value: Test = .test1
+        value.toggle(between: [.test1, .test3])
+        XCTAssert(
+            value == .test3,
+            "value should be changed to next case from given cases array."
+        )
+    }
+    
+}


### PR DESCRIPTION
The method below allows to easily change value of the caller to the next available case.

Example usage would look like this:
```
         enum ShuffleMode: CaseIterable {
            case off, songs, albums
         }
    
         var mode: ShuffleMode = .off
         mode.toggle() // .songs

         var mode: ShuffleMode = .albums
         mode.toggle(between: [.songs, .albums]) // .songs
```

The only requirement for this method is that the caller conforms to `Equatable`. When conforming to `CaseIterable` another method is available that passes `allCases` as the parameter for `values`.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
