### PR TITLE
Fix UIView.GradientDirection access level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ## Upcoming Release
 
+### Fixed
+- `UIView.GradientDirection` initializer and constants had access level `internal` instead of `public`. [#1152](https://github.com/SwifterSwift/SwifterSwift/pull/1152) by [guykogus](https://github.com/guykogus)
+
 ## [v6.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/6.0.0)
 ### Breaking Change
 - **Minimum deployment target**

--- a/Examples/Examples.playground/Pages/03-UIKitExtensions.xcplaygroundpage/Contents.swift
+++ b/Examples/Examples.playground/Pages/03-UIKitExtensions.xcplaygroundpage/Contents.swift
@@ -97,9 +97,12 @@ view.backgroundColor = UIColor.red
 
 // Set some or all corners radiuses of view.
 view.roundCorners([.bottomLeft, .topRight], radius: 30)
-view.cornerRadius = 30
+view.layerCornerRadius = 30
 
 // Add shadow to view
 view.addShadow(ofColor: .black, radius: 3, opacity: 0.5)
+
+// Add gradient
+view.addGradient(colors: [.red], direction: .rightToLeft)
 
 //: [Next](@next)

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
                 swiftSettings: [
                     .enableUpcomingFeature("ConciseMagicFile"),
                     .enableUpcomingFeature("ExistentialAny"),
-                    .enableUpcomingFeature("ForwardTrailingClosures"),
+                    .enableUpcomingFeature("ForwardTrailingClosures")
                 ]),
         .testTarget(
             name: "SwifterSwiftTests",
@@ -30,6 +30,6 @@ let package = Package(
             swiftSettings: [
                 .enableUpcomingFeature("ConciseMagicFile"),
                 .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("ForwardTrailingClosures"),
+                .enableUpcomingFeature("ForwardTrailingClosures")
             ])
     ])

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -52,17 +52,22 @@ public extension UIView {
 
     /// SwifterSwift: Add gradient directions
     struct GradientDirection {
-        static let topToBottom = GradientDirection(startPoint: CGPoint(x: 0.5, y: 0.0),
-                                                   endPoint: CGPoint(x: 0.5, y: 1.0))
-        static let bottomToTop = GradientDirection(startPoint: CGPoint(x: 0.5, y: 1.0),
-                                                   endPoint: CGPoint(x: 0.5, y: 0.0))
-        static let leftToRight = GradientDirection(startPoint: CGPoint(x: 0.0, y: 0.5),
-                                                   endPoint: CGPoint(x: 1.0, y: 0.5))
-        static let rightToLeft = GradientDirection(startPoint: CGPoint(x: 1.0, y: 0.5),
-                                                   endPoint: CGPoint(x: 0.0, y: 0.5))
+        public static let topToBottom = GradientDirection(startPoint: CGPoint(x: 0.5, y: 0.0),
+                                                          endPoint: CGPoint(x: 0.5, y: 1.0))
+        public static let bottomToTop = GradientDirection(startPoint: CGPoint(x: 0.5, y: 1.0),
+                                                          endPoint: CGPoint(x: 0.5, y: 0.0))
+        public static let leftToRight = GradientDirection(startPoint: CGPoint(x: 0.0, y: 0.5),
+                                                          endPoint: CGPoint(x: 1.0, y: 0.5))
+        public static let rightToLeft = GradientDirection(startPoint: CGPoint(x: 1.0, y: 0.5),
+                                                          endPoint: CGPoint(x: 0.0, y: 0.5))
 
-        let startPoint: CGPoint
-        let endPoint: CGPoint
+        public let startPoint: CGPoint
+        public let endPoint: CGPoint
+
+        public init(startPoint: CGPoint, endPoint: CGPoint) {
+            self.startPoint = startPoint
+            self.endPoint = endPoint
+        }
     }
 }
 


### PR DESCRIPTION
🚀
Fixes #1151

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
