### PR TITLE
Fix testInitAsyncThrows

### DIFF
--- a/Sources/SwifterSwift/Foundation/NSRegularExpressionExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/NSRegularExpressionExtensions.swift
@@ -32,11 +32,11 @@ public extension NSRegularExpression {
         enumerateMatches(in: string,
                          options: options,
                          range: NSRange(range, in: string)) { result, flags, stop in
-            var shouldStop = false
-            block(result, flags, &shouldStop)
-            if shouldStop {
-                stop.pointee = true
-            }
+                var shouldStop = false
+                block(result, flags, &shouldStop)
+                if shouldStop {
+                    stop.pointee = true
+                }
         }
     }
     #else
@@ -48,11 +48,11 @@ public extension NSRegularExpression {
         enumerateMatches(in: string,
                          options: options,
                          range: NSRange(range, in: string)) { result, flags, stop in
-            var shouldStop = false
-            block(result, flags, &shouldStop)
-            if shouldStop {
-                stop.pointee = true
-            }
+                var shouldStop = false
+                block(result, flags, &shouldStop)
+                if shouldStop {
+                    stop.pointee = true
+                }
         }
     }
     #endif

--- a/Tests/CombineTests/FutureExtensionsTests.swift
+++ b/Tests/CombineTests/FutureExtensionsTests.swift
@@ -40,11 +40,12 @@ final class FutureExtensionsTests: XCTestCase {
 
     func testInitAsyncThrows() {
         let expect = expectation(description: "testInitAsyncThrows")
+        // swiftformat:disable all
+        let failureType = (any Error).self
+        // swiftformat:enable all
 
         cancellable = Just(100)
-            .mapError { _ in
-                FutureExtensionsTestsError.error
-            }
+            .setFailureType(to: failureType)
             .flatMap { [weak self] value in
                 Future<Int, any Error> {
                     try await self?.doSomethingThrows(value: value, shouldThrow: true) ?? 0
@@ -53,9 +54,7 @@ final class FutureExtensionsTests: XCTestCase {
             .catch { error in
                 XCTAssertEqual(error as? FutureExtensionsTestsError, FutureExtensionsTestsError.error)
                 return Just(200)
-                    .mapError { _ in
-                        FutureExtensionsTestsError.error
-                    }
+                    .setFailureType(to: failureType)
             }
             .sink(receiveCompletion: { _ in
 

--- a/Tests/CombineTests/FutureExtensionsTests.swift
+++ b/Tests/CombineTests/FutureExtensionsTests.swift
@@ -42,7 +42,9 @@ final class FutureExtensionsTests: XCTestCase {
         let expect = expectation(description: "testInitAsyncThrows")
 
         cancellable = Just(100)
-            .setFailureType(to: (any Error).self)
+            .mapError { _ in
+                FutureExtensionsTestsError.error
+            }
             .flatMap { [weak self] value in
                 Future<Int, any Error> {
                     try await self?.doSomethingThrows(value: value, shouldThrow: true) ?? 0
@@ -51,7 +53,9 @@ final class FutureExtensionsTests: XCTestCase {
             .catch { error in
                 XCTAssertEqual(error as? FutureExtensionsTestsError, FutureExtensionsTestsError.error)
                 return Just(200)
-                    .setFailureType(to: (any Error).self)
+                    .mapError { _ in
+                        FutureExtensionsTestsError.error
+                    }
             }
             .sink(receiveCompletion: { _ in
 

--- a/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
+++ b/Tests/FoundationTests/NSAttributedStringExtensionsTests.swift
@@ -23,14 +23,14 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
 
         let sizedAttributes = NSAttributedString(string: "Bolded", attributes: [.font: SFFont.systemFont(ofSize: 12)])
             .bolded.attributes
-        XCTAssertEqual((sizedAttributes[.font] as? SFFont), SFFont.boldSystemFont(ofSize: 12))
+        XCTAssertEqual(sizedAttributes[.font] as? SFFont, SFFont.boldSystemFont(ofSize: 12))
         #endif
     }
 
     func testUnderlined() {
         #if !os(Linux)
         let attributes = NSAttributedString(string: "Underlined").underlined.attributes
-        XCTAssertEqual((attributes[.underlineStyle] as? NSUnderlineStyle.RawValue), NSUnderlineStyle.single.rawValue)
+        XCTAssertEqual(attributes[.underlineStyle] as? NSUnderlineStyle.RawValue, NSUnderlineStyle.single.rawValue)
         #endif
     }
 
@@ -42,7 +42,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         let sizedAttributes = NSAttributedString(
             string: "Italicized",
             attributes: [.font: SFFont.systemFont(ofSize: 12)]).italicized.attributes
-        XCTAssertEqual((sizedAttributes[.font] as? UIFont), UIFont.italicSystemFont(ofSize: 12))
+        XCTAssertEqual(sizedAttributes[.font] as? UIFont, UIFont.italicSystemFont(ofSize: 12))
         #endif
     }
 
@@ -50,7 +50,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
         #if !os(macOS) && !os(Linux)
         let attributes = NSAttributedString(string: "Struck through").struckthrough.attributes
         XCTAssertEqual(
-            (attributes[.strikethroughStyle] as? NSUnderlineStyle.RawValue),
+            attributes[.strikethroughStyle] as? NSUnderlineStyle.RawValue,
             NSUnderlineStyle.single.rawValue)
         #endif
     }
@@ -236,7 +236,7 @@ final class NSAttributedStringExtensionsTests: XCTestCase {
                         passed = false
                     }
                 }
-            }
+        }
 
         XCTAssert(passed)
         #endif

--- a/Tests/FoundationTests/NSRegularExpressionExtensionsTests.swift
+++ b/Tests/FoundationTests/NSRegularExpressionExtensionsTests.swift
@@ -18,10 +18,10 @@ final class NSRegularExpressionExtensionsTests: XCTestCase {
         regularExpression.enumerateMatches(in: string,
                                            options: [],
                                            range: string.startIndex..<string.endIndex) { result, _, _ in
-            XCTAssertEqual(
-                String(self.string[Range(result!.range, in: self.string)!]),
-                self.searchString)
-            count += 1
+                XCTAssertEqual(
+                    String(self.string[Range(result!.range, in: self.string)!]),
+                    self.searchString)
+                count += 1
         }
         XCTAssertEqual(count, expectedMatches)
 
@@ -30,11 +30,11 @@ final class NSRegularExpressionExtensionsTests: XCTestCase {
         regularExpression.enumerateMatches(in: string,
                                            options: [],
                                            range: string.startIndex..<string.endIndex) { result, _, stop in
-            XCTAssertEqual(
-                String(self.string[Range(result!.range, in: self.string)!]),
-                self.searchString)
-            count += 1
-            stop = count >= max
+                XCTAssertEqual(
+                    String(self.string[Range(result!.range, in: self.string)!]),
+                    self.searchString)
+                count += 1
+                stop = count >= max
         }
         XCTAssertEqual(count, max)
     }


### PR DESCRIPTION
🚀
Hello.
Thank you for SwifterSwift.
Fix #1156.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
