### PR TITLE
Moves blur function to UIView, as it is not only for UIImageView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
 ## Upcoming Release
+### Deprecated
+- **UIImageView**
+  - `blurred(withStyle:)` should have copied the image view and blurred the new instance, but instead it performed the same functionality as `blur(withStyle:)`, making the outcome unexpected as well as being obsolete. [#1161](https://github.com/SwifterSwift/SwifterSwift/pull/1161) by [guykogus](https://github.com/guykogus)
 
 ### Added
 - **Measurement**
@@ -11,7 +14,10 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
 
 ### Fixed
-- `UIView.GradientDirection` initializer and constants had access level `internal` instead of `public`. [#1152](https://github.com/SwifterSwift/SwifterSwift/pull/1152) by [guykogus](https://github.com/guykogus)
+- **UIImageView**
+  - Moved `blur(withStyle:)` from `UIImageView` to `UIView`, as it can be performed on all views. [#1161](https://github.com/SwifterSwift/SwifterSwift/pull/1161) by [guykogus](https://github.com/guykogus)
+- **UIView**
+  - `GradientDirection` initializer and constants had access level `internal` instead of `public`. [#1152](https://github.com/SwifterSwift/SwifterSwift/pull/1152) by [guykogus](https://github.com/guykogus)
 
 ## [v6.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/6.0.0)
 ### Breaking Change

--- a/Sources/SwifterSwift/UIKit/Deprecated/UIImageViewDeprecated.swift
+++ b/Sources/SwifterSwift/UIKit/Deprecated/UIImageViewDeprecated.swift
@@ -1,0 +1,24 @@
+// UIImageViewDeprecated.swift - Copyright 2023 SwifterSwift
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+// MARK: - Methods
+
+public extension UIImageView {
+    /// SwifterSwift: Blurred version of an image view.
+    ///
+    /// - Parameter style: UIBlurEffectStyle (default is .light).
+    /// - Returns: blurred version of self.
+    @available(
+        *,
+        deprecated,
+        message: "Use UIView.blur() instead. This method incorrectly does the same thing, as it doesn't copy the image view.")
+    func blurred(withStyle style: UIBlurEffect.Style = .light) -> UIImageView {
+        let imgView = self
+        imgView.blur(withStyle: style)
+        return imgView
+    }
+}
+
+#endif

--- a/Sources/SwifterSwift/UIKit/UIImageViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIImageViewExtensions.swift
@@ -35,28 +35,6 @@ public extension UIImageView {
             }
         }.resume()
     }
-
-    /// SwifterSwift: Make image view blurry.
-    ///
-    /// - Parameter style: UIBlurEffectStyle (default is .light).
-    func blur(withStyle style: UIBlurEffect.Style = .light) {
-        let blurEffect = UIBlurEffect(style: style)
-        let blurEffectView = UIVisualEffectView(effect: blurEffect)
-        blurEffectView.frame = bounds
-        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight] // for supporting device rotation
-        addSubview(blurEffectView)
-        clipsToBounds = true
-    }
-
-    /// SwifterSwift: Blurred version of an image view.
-    ///
-    /// - Parameter style: UIBlurEffectStyle (default is .light).
-    /// - Returns: blurred version of self.
-    func blurred(withStyle style: UIBlurEffect.Style = .light) -> UIImageView {
-        let imgView = self
-        imgView.blur(withStyle: style)
-        return imgView
-    }
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -304,6 +304,18 @@ public extension UIView {
         subviews.forEach { addSubview($0) }
     }
 
+    /// SwifterSwift: Make the view blurry.
+    ///
+    /// - Parameter style: UIBlurEffectStyle (default is .light).
+    func blur(withStyle style: UIBlurEffect.Style = .light) {
+        let blurEffect = UIBlurEffect(style: style)
+        let blurEffectView = UIVisualEffectView(effect: blurEffect)
+        blurEffectView.frame = bounds
+        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight] // for supporting device rotation
+        addSubview(blurEffectView)
+        clipsToBounds = true
+    }
+
     /// SwifterSwift: Fade in view.
     ///
     /// - Parameters:

--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -672,6 +672,9 @@
 		F8A710F123BF3F8600112DAD /* EdgeInsetsExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A710ED23BF3F8200112DAD /* EdgeInsetsExtensionsTests.swift */; };
 		F8B4DFB3291EA77C0011BD90 /* HKActivitySummaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAEBCE224B0079700F61684 /* HKActivitySummaryExtensionsTests.swift */; };
 		F8B4DFB4291EA7880011BD90 /* HKActivitySummaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAEBCDF24B0045F00F61684 /* HKActivitySummaryExtensions.swift */; };
+		F8BE7E082B3B161F00179B35 /* UIImageViewDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BE7E072B3B161F00179B35 /* UIImageViewDeprecated.swift */; };
+		F8BE7E092B3B161F00179B35 /* UIImageViewDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BE7E072B3B161F00179B35 /* UIImageViewDeprecated.swift */; };
+		F8BE7E0A2B3B161F00179B35 /* UIImageViewDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BE7E072B3B161F00179B35 /* UIImageViewDeprecated.swift */; };
 		F8C1AE6F225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
 		F8C1AE70225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
 		F8C1AE71225B7F990045D5A0 /* NSRegularExpressionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */; };
@@ -947,6 +950,7 @@
 		F88C491824AF73A400BA0503 /* TestStoryboard-tvOS.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "TestStoryboard-tvOS.storyboard"; sourceTree = "<group>"; };
 		F8A710E823BF3EF100112DAD /* EdgeInsetsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetsExtensions.swift; sourceTree = "<group>"; };
 		F8A710ED23BF3F8200112DAD /* EdgeInsetsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetsExtensionsTests.swift; sourceTree = "<group>"; };
+		F8BE7E072B3B161F00179B35 /* UIImageViewDeprecated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewDeprecated.swift; sourceTree = "<group>"; };
 		F8C1AE6E225B7F990045D5A0 /* NSRegularExpressionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRegularExpressionExtensions.swift; sourceTree = "<group>"; };
 		F8C1AE73225B871F0045D5A0 /* NSRegularExpressionExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRegularExpressionExtensionsTests.swift; sourceTree = "<group>"; };
 		F8E62DA324D0187000BF35AE /* XCTestExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestExtensionsTests.swift; sourceTree = "<group>"; };
@@ -1174,6 +1178,7 @@
 		07B7F1791F5EB41600E6F910 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				F8BE7E062B3B161F00179B35 /* Deprecated */,
 				07B7F17C1F5EB41600E6F910 /* UIAlertControllerExtensions.swift */,
 				07A1C446224FFDE4003272E4 /* UIApplicationExtensions.swift */,
 				07B7F17D1F5EB41600E6F910 /* UIBarButtonItemExtensions.swift */,
@@ -1597,6 +1602,14 @@
 				CAC5EBC42125270A00AB27EC /* UITableViewHeaderFooterView.xib */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		F8BE7E062B3B161F00179B35 /* Deprecated */ = {
+			isa = PBXGroup;
+			children = (
+				F8BE7E072B3B161F00179B35 /* UIImageViewDeprecated.swift */,
+			);
+			path = Deprecated;
 			sourceTree = "<group>";
 		};
 		F8E62DA224D0184E00BF35AE /* XCTestTests */ = {
@@ -2245,6 +2258,7 @@
 				664CB96D2171863B00FC87B4 /* BidirectionalCollectionExtensions.swift in Sources */,
 				07B7F1951F5EB42000E6F910 /* UICollectionViewExtensions.swift in Sources */,
 				07B7F1A31F5EB42000E6F910 /* UITableViewExtensions.swift in Sources */,
+				F8BE7E082B3B161F00179B35 /* UIImageViewDeprecated.swift in Sources */,
 				17A4B79326CCFFAE007D299F /* SKSpriteNodeExtensions.swift in Sources */,
 				077BA08F1F6BE83600D9C4AC /* UserDefaultsExtensions.swift in Sources */,
 				07B7F1A11F5EB42000E6F910 /* UISwitchExtensions.swift in Sources */,
@@ -2375,6 +2389,7 @@
 				734308082108E4630029CD16 /* CGVectorExtensions.swift in Sources */,
 				F8DED22624EAA2070068F758 /* UIScrollViewExtensions.swift in Sources */,
 				07B7F1BC1F5EB42000E6F910 /* UIViewControllerExtensions.swift in Sources */,
+				F8BE7E092B3B161F00179B35 /* UIImageViewDeprecated.swift in Sources */,
 				58CAE62A28CF2935001935A2 /* DefaultStringInterpolationExtensions.swift in Sources */,
 				F8A710EA23BF3F7300112DAD /* EdgeInsetsExtensions.swift in Sources */,
 				07B7F2371F5EB45200E6F910 /* CGSizeExtensions.swift in Sources */,
@@ -2465,6 +2480,7 @@
 				D951E8AC23D04DCA00F2CD0B /* DecodableExtensions.swift in Sources */,
 				9D806A882258F624008E500A /* SCNGeometryExtensions.swift in Sources */,
 				07B7F1CC1F5EB42200E6F910 /* UIStoryboardExtensions.swift in Sources */,
+				F8BE7E0A2B3B161F00179B35 /* UIImageViewDeprecated.swift in Sources */,
 				9D806A6C2258DC3E008E500A /* SCNShapeExtensions.swift in Sources */,
 				07B7F1C61F5EB42200E6F910 /* UINavigationBarExtensions.swift in Sources */,
 				F87AA5D724125808005F5B28 /* NotificationCenterExtensions.swift in Sources */,

--- a/Tests/UIKitTests/UIImageViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIImageViewExtensionsTests.swift
@@ -36,24 +36,6 @@ final class UIImageViewExtensionsTests: XCTestCase {
         XCTAssertNil(failImageView.image)
         waitForExpectations(timeout: 15)
     }
-
-    func testBlur() {
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 50, height: 100))
-        imageView.blur(withStyle: .dark)
-
-        let blurView = imageView.subviews.first as? UIVisualEffectView
-        XCTAssertNotNil(blurView)
-        XCTAssertNotNil(blurView?.effect)
-        XCTAssertEqual(blurView?.frame, imageView.bounds)
-        XCTAssertEqual(blurView?.autoresizingMask, [.flexibleWidth, .flexibleHeight])
-        XCTAssert(imageView.clipsToBounds)
-    }
-
-    func testBlurred() {
-        let imageView = UIImageView()
-        let blurredImageView = imageView.blurred(withStyle: .extraLight)
-        XCTAssertEqual(blurredImageView, imageView)
-    }
 }
 
 #endif

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -209,6 +209,18 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(view.subviews.count, 2)
     }
 
+    func testBlur() {
+        let imageView = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 100))
+        imageView.blur(withStyle: .dark)
+
+        let blurView = imageView.subviews.first as? UIVisualEffectView
+        XCTAssertNotNil(blurView)
+        XCTAssertNotNil(blurView?.effect)
+        XCTAssertEqual(blurView?.frame, imageView.bounds)
+        XCTAssertEqual(blurView?.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+        XCTAssert(imageView.clipsToBounds)
+    }
+
     func testFadeIn() {
         let view1 = UIView()
         view1.isHidden = true


### PR DESCRIPTION
🚀

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
