### PR TITLE
Add Tap Action Extension to UIView

### DIFF
--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -239,6 +239,21 @@ public extension UIView {
             frame.origin.y = newValue
         }
     }
+
+    /// A private struct to organize associated object keys for UIView extensions.
+    private struct AssociatedKeys {
+        static var tapActionKey: UInt8 = 0
+    }
+
+    /// A closure to be executed when the view is tapped.
+    private var tapAction: ((UIView) -> Void)? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.tapActionKey) as? (UIView) -> Void
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.tapActionKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
 }
 
 // MARK: - Methods
@@ -669,6 +684,31 @@ public extension UIView {
             }
         }
         return views
+    }
+
+    /// Adds a tap action to the UIView.
+    /// - Parameter action: A closure to be executed when view is tapped.
+    ///
+    /// - Example:
+    ///   ```swift
+    ///    @IBOutlet weak var imageView: UIImageView!
+    ///    imageView.onClick(action: onClickImage)
+    ///    ```
+    func onClick(action: @escaping (UIView) -> Void) {
+        isUserInteractionEnabled = true
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapAction))
+        addGestureRecognizer(tapGestureRecognizer)
+        self.tapAction = action
+    }
+}
+
+// MARK: - Private Methods
+
+private extension UIView {
+
+    /// Handles the tap action by executing the associated closure.
+    @objc func handleTapAction() {
+        tapAction?(self)
     }
 }
 


### PR DESCRIPTION
<!---  Introduces a convenient way to UIView for handling tap actions. The `onClick` function allows users to easily add tap gesture recognizers with custom actions to any UIView. -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x] New extensions are written in Swift 5.6.
- [x ] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [x ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
