### PR TITLE
Add makeCircle function inside UIViewExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `+=`, `-=`, `*=`, `/=` to add, subtract, multiply and divide measurements. [#1162](https://github.com/SwifterSwift/SwifterSwift/pull/1162) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIView**
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
-  
-    - Added `makeCircle()` method to make the view circular. [#1165](https://github.com/SwifterSwift/SwifterSwift/pull/1165) by [happyduck-git](https://github.com/happyduck-git)
+  - Added `makeCircle()` method to make the view circular. [#1165](https://github.com/SwifterSwift/SwifterSwift/pull/1165) by [happyduck-git](https://github.com/happyduck-git)
 
 ### Fixed
 - **UIImageView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `+=`, `-=`, `*=`, `/=` to add, subtract, multiply and divide measurements. [#1162](https://github.com/SwifterSwift/SwifterSwift/pull/1162) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIView**
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
+  
+    - Added `makeCircle()` method to make the view circular. [#]() by [happyduck-git](https://github.com/happyduck-git)
 
 ### Fixed
 - **UIImageView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIView**
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
   
-    - Added `makeCircle()` method to make the view circular. [#]() by [happyduck-git](https://github.com/happyduck-git)
+    - Added `makeCircle()` method to make the view circular. [#1165](https://github.com/SwifterSwift/SwifterSwift/pull/1165) by [happyduck-git](https://github.com/happyduck-git)
 
 ### Fixed
 - **UIImageView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `+=`, `-=`, `*=`, `/=` to add, subtract, multiply and divide measurements. [#1162](https://github.com/SwifterSwift/SwifterSwift/pull/1162) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIView**
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
-  - Added `makeCircle()` method to make the view circular. [#1165](https://github.com/SwifterSwift/SwifterSwift/pull/1165) by [happyduck-git](https://github.com/happyduck-git)
+  - Added `makeCircle(diameter:)` method to make the view circular. [#1165](https://github.com/SwifterSwift/SwifterSwift/pull/1165) by [happyduck-git](https://github.com/happyduck-git)
 
 ### Fixed
 - **UIImageView**

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -279,10 +279,10 @@ public extension UIView {
     /// 
     /// - Parameter diameter: This value will be set as the width and height of the view.
     func makeCircle(diameter: CGFloat) {
-        self.clipsToBounds = true
-        self.frame.size.height = length
-        self.frame.size.width = length
-        self.layer.cornerRadius = length / 2
+        clipsToBounds = true
+        bounds.size.height = diameter
+        bounds.size.width = diameter
+        layer.cornerRadius = diameter / 2
     }
 
     /// SwifterSwift: Add shadow to view.

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -274,6 +274,16 @@ public extension UIView {
         shape.path = maskPath.cgPath
         layer.mask = shape
     }
+    
+    /// SwifterSwift: Make the view circular.
+    /// 
+    /// - Parameter length: length of the view. This value will be set as width and height of the view.
+    func makeCircle(_ length: CGFloat) {
+        self.clipsToBounds = true
+        self.frame.size.height = length
+        self.frame.size.width = length
+        self.layer.cornerRadius = length / 2
+    }
 
     /// SwifterSwift: Add shadow to view.
     ///

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -278,7 +278,7 @@ public extension UIView {
     /// SwifterSwift: Make the view circular.
     /// 
     /// - Parameter diameter: This value will be set as the width and height of the view.
-    func makeCircle(_ length: CGFloat) {
+    func makeCircle(diameter: CGFloat) {
         self.clipsToBounds = true
         self.frame.size.height = length
         self.frame.size.width = length

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -277,7 +277,7 @@ public extension UIView {
     
     /// SwifterSwift: Make the view circular.
     /// 
-    /// - Parameter length: length of the view. This value will be set as width and height of the view.
+    /// - Parameter diameter: This value will be set as the width and height of the view.
     func makeCircle(_ length: CGFloat) {
         self.clipsToBounds = true
         self.frame.size.height = length

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -90,7 +90,7 @@ final class UIViewExtensionsTests: XCTestCase {
     }
     
     func testMakeCircle() {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
+        let view = UIView()
         view.makeCircle(100)
         XCTAssertEqual(view.frame.size.width, 100)
         XCTAssertEqual(view.frame.size.height, 100)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -88,6 +88,14 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssertEqual(view.layer.mask?.bounds, shape.bounds)
         XCTAssertEqual(view.layer.mask?.cornerRadius, shape.cornerRadius)
     }
+    
+    func testMakeCircle() {
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
+        view.makeCircle(100)
+        XCTAssertEqual(view.frame.size.width, 100)
+        XCTAssertEqual(view.frame.size.height, 100)
+        XCTAssertEqual(view.layer.cornerRadius, 50)
+    }
 
     func testShadowColor() {
         let frame = CGRect(x: 0, y: 0, width: 100, height: 100)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -91,7 +91,7 @@ final class UIViewExtensionsTests: XCTestCase {
     
     func testMakeCircle() {
         let view = UIView()
-        view.makeCircle(100)
+        view.makeCircle(diameter: 100)
         XCTAssertEqual(view.frame.size.width, 100)
         XCTAssertEqual(view.frame.size.height, 100)
         XCTAssertEqual(view.layer.cornerRadius, 50)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a function that makes a UIView instance a circular shape.
## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
