### PR TITLE
Improved extension methods for Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **UIView**
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
   - Added `makeCircle(diameter:)` method to make the view circular. [#1165](https://github.com/SwifterSwift/SwifterSwift/pull/1165) by [happyduck-git](https://github.com/happyduck-git)
+- **Sequence**
+  - Added `product()` for calculating the product of all `Numeric` elements. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
+  - Added `product(for:)` for calculating the product of the `Numeric` property for all elements in `Sequence`. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
+  - Added `contains(_:matchedBy:)` to allow checking for values with a matcher that compares values.
+
+### Changed
+- **Sequence**
+    - `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `product(for:)`, `first(where:equals:)` now receive functions as parameters. This change maintains compatibility with KeyPath while making the methods more flexible. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
+    - `contains(_:)` for both `Element: Hashable` and `Element: Equatable` now can receive any type that conforms to `Sequence`, not just `Array`. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
 
 ### Fixed
 - **UIImageView**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Changed
 - **Sequence**
     - `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `product(for:)`, `first(where:equals:)` now receive functions as parameters. This change maintains compatibility with KeyPath while making the methods more flexible. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
-    - `contains(_:)` for both `Element: Hashable` and `Element: Equatable` now can receive any type that conforms to `Sequence`, not just `Array`. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
+    - `contains(_:)` for `Element: Hashable` now can receive any type that conforms to `Sequence`, not just `Array`. [#1167](https://github.com/SwifterSwift/SwifterSwift/pull/1167)[MartonioJunior](https://github.com/MartonioJunior)
 
 ### Fixed
 - **UIImageView**

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -240,31 +240,31 @@ public extension Sequence {
 }
 
 public extension Sequence where Element: Equatable {
-    /// SwifterSwift: Check if array contains an array of elements.
+    /// SwifterSwift: Check if sequence contains elements of another sequence.
     ///
     ///        [1, 2, 3, 4, 5].contains([1, 2]) -> true
     ///        [1.2, 2.3, 4.5, 3.4, 4.5].contains([2, 6]) -> false
     ///        ["h", "e", "l", "l", "o"].contains(["l", "o"]) -> true
     ///
-    /// - Parameter elements: array of elements to check.
+    /// - Parameter elements: sequence of elements to check.
     /// - Returns: true if array contains all given items.
     /// - Complexity: _O(m·n)_, where _m_ is the length of `elements` and _n_ is the length of this sequence.
-    func contains(_ elements: [Element]) -> Bool {
+    func contains<T: Sequence>(_ elements: T) -> Bool where Element == T.Element {
         return elements.allSatisfy { contains($0) }
     }
 }
 
 public extension Sequence where Element: Hashable {
-    /// SwifterSwift: Check if array contains an array of elements.
+    /// SwifterSwift: Check if sequence contains elements of another sequence.
     ///
     ///        [1, 2, 3, 4, 5].contains([1, 2]) -> true
     ///        [1.2, 2.3, 4.5, 3.4, 4.5].contains([2, 6]) -> false
     ///        ["h", "e", "l", "l", "o"].contains(["l", "o"]) -> true
     ///
-    /// - Parameter elements: array of elements to check.
+    /// - Parameter elements: sequence of elements to check.
     /// - Returns: true if array contains all given items.
     /// - Complexity: _O(m + n)_, where _m_ is the length of `elements` and _n_ is the length of this sequence.
-    func contains(_ elements: [Element]) -> Bool {
+    func contains<T: Sequence>(_ elements: T) -> Bool where Element == T.Element {
         let set = Set(self)
         return elements.allSatisfy { set.contains($0) }
     }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -105,6 +105,23 @@ public extension Sequence {
     func filtered<T>(_ isIncluded: (Element) throws -> Bool, map transform: (Element) throws -> T) rethrows -> [T] {
         return try lazy.filter(isIncluded).map(transform)
     }
+    
+    /// SwifterSwift: Contains operations based on matching function
+    ///
+    ///      ["James", "Wade", "Bryant"].contains([4,5], for: { $0.count == $1 }) -> true
+    ///
+    /// - Parameters:
+    ///   - elements: sequence of elements to compare to.
+    ///   - matcher: how should the elements be mapped and compared.
+    /// - Returns: true when `elements` are matched in sequence.
+    func contains<T: Sequence>(
+        _ elements: T,
+        matchedBy matcher: (Element, T.Element) throws -> Bool
+    ) rethrows -> Bool {
+        return try elements.allSatisfy { value in
+            try contains(where: { try matcher($0, value) })
+        }
+    }
 
     /// SwifterSwift: Get the only element based on a condition.
     ///

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -326,11 +326,11 @@ public extension Sequence where Element: Hashable {
 // MARK: - Methods (AdditiveArithmetic)
 
 public extension Sequence where Element: AdditiveArithmetic {
-    /// SwifterSwift: Sum of all elements in array.
+    /// SwifterSwift: Sum of all elements in sequence.
     ///
     ///        [1, 2, 3, 4, 5].sum() -> 15
     ///
-    /// - Returns: sum of the array's elements.
+    /// - Returns: sum of the sequence's elements.
     func sum() -> Element {
         return reduce(.zero, +)
     }
@@ -343,6 +343,6 @@ public extension Sequence where Element: Numeric {
     ///
     ///        [1, 2, 3, 4, 5].product() -> 120
     ///
-    /// - Returns: product of the array's elements.
+    /// - Returns: product of the sequence's elements.
     func product() -> Element { reduce(1, *) }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -242,6 +242,16 @@ public extension Sequence {
         // Inspired by: https://swiftbysundell.com/articles/reducers-in-swift/
         return reduce(.zero) { $0 + map($1) }
     }
+    
+    /// SwifterSwift: Product of all elements in array.
+    ///
+    ///        ["James", "Wade", "Bryant"].product(for: \.count) -> 120
+    ///
+    /// - Parameter keyPath: Key path of the `Numeric` property.
+    /// - Returns: product of the array's elements.
+    func product<T: Numeric>(for map: (Element) -> T) -> T {
+        reduce(1) { $0 * map($1) }
+    }
 
     /// SwifterSwift: Returns the first element of the sequence with having the value by given map function equals to given
     /// `value`.
@@ -324,4 +334,15 @@ public extension Sequence where Element: AdditiveArithmetic {
     func sum() -> Element {
         return reduce(.zero, +)
     }
+}
+
+// MARK: - Methods (Numeric)
+
+public extension Sequence where Element: Numeric {
+    /// SwifterSwift: Product of all elements in array.
+    ///
+    ///        [1, 2, 3, 4, 5].product() -> 120
+    ///
+    /// - Returns: product of the array's elements.
+    func product() -> Element { reduce(1, *) }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -267,16 +267,16 @@ public extension Sequence {
 }
 
 public extension Sequence where Element: Equatable {
-    /// SwifterSwift: Check if sequence contains elements of another sequence.
+    /// SwifterSwift: Check if sequence contains an array of elements.
     ///
     ///        [1, 2, 3, 4, 5].contains([1, 2]) -> true
     ///        [1.2, 2.3, 4.5, 3.4, 4.5].contains([2, 6]) -> false
     ///        ["h", "e", "l", "l", "o"].contains(["l", "o"]) -> true
     ///
-    /// - Parameter elements: sequence of elements to check.
+    /// - Parameter elements: array of elements to check.
     /// - Returns: true if array contains all given items.
     /// - Complexity: _O(m·n)_, where _m_ is the length of `elements` and _n_ is the length of this sequence.
-    func contains<T: Sequence>(_ elements: T) -> Bool where Element == T.Element {
+    func contains(_ elements: [Element]) -> Bool {
         return elements.allSatisfy { contains($0) }
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -161,57 +161,57 @@ public extension Sequence {
         return (matching, nonMatching)
     }
 
-    /// SwifterSwift: Return a sorted array based on a key path and a compare function.
+    /// SwifterSwift: Return a sorted array based on a map function and a compare function.
     ///
-    /// - Parameter keyPath: Key path to sort by.
+    /// - Parameter map: Function that defines the property to sort by.
     /// - Parameter compare: Comparison function that will determine the ordering.
     /// - Returns: The sorted array.
-    func sorted<T>(by keyPath: KeyPath<Element, T>, with compare: (T, T) -> Bool) -> [Element] {
-        return sorted { compare($0[keyPath: keyPath], $1[keyPath: keyPath]) }
+    func sorted<T>(by map: (Element) -> T, with compare: (T, T) -> Bool) -> [Element] {
+        return sorted { compare(map($0), map($1)) }
     }
 
-    /// SwifterSwift: Return a sorted array based on a key path.
+    /// SwifterSwift: Return a sorted array based on a map function.
     ///
-    /// - Parameter keyPath: Key path to sort by. The key path type must be Comparable.
+    /// - Parameter map: Function that defines the property to sort by. The output type must be Comparable.
     /// - Returns: The sorted array.
-    func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
-        return sorted { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
+    func sorted<T: Comparable>(by map: (Element) -> T) -> [Element] {
+        return sorted { map($0) < map($1) }
     }
 
-    /// SwifterSwift: Returns a sorted sequence based on two key paths. The second one will be used in case the values
+    /// SwifterSwift: Returns a sorted sequence based on two map functions. The second one will be used in case the values
     /// of the first one match.
     ///
     /// - Parameters:
-    ///     - keyPath1: Key path to sort by. Must be Comparable.
-    ///     - keyPath2: Key path to sort by in case the values of `keyPath1` match. Must be Comparable.
-    func sorted<T: Comparable, U: Comparable>(by keyPath1: KeyPath<Element, T>,
-                                              and keyPath2: KeyPath<Element, U>) -> [Element] {
+    ///     - map1: Map function to sort by. Output type must be Comparable.
+    ///     - map2: Map function to sort by in case the values of `map1` match. Output type must be Comparable.
+    func sorted<T: Comparable, U: Comparable>(by map1: (Element) -> T,
+                                              and map2: (Element) -> U) -> [Element] {
         return sorted {
-            if $0[keyPath: keyPath1] != $1[keyPath: keyPath1] {
-                return $0[keyPath: keyPath1] < $1[keyPath: keyPath1]
+            if map1($0) != map1($1) {
+                return map1($0) < map1($1)
             }
-            return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
+            return map2($0) < map2($1)
         }
     }
 
-    /// SwifterSwift: Returns a sorted sequence based on three key paths. Whenever the values of one key path match, the
+    /// SwifterSwift: Returns a sorted sequence based on three map functions. Whenever the values of one map function match, the
     /// next one will be used.
     ///
     /// - Parameters:
-    ///     - keyPath1: Key path to sort by. Must be Comparable.
-    ///     - keyPath2: Key path to sort by in case the values of `keyPath1` match. Must be Comparable.
-    ///     - keyPath3: Key path to sort by in case the values of `keyPath1` and `keyPath2` match. Must be Comparable.
-    func sorted<T: Comparable, U: Comparable, V: Comparable>(by keyPath1: KeyPath<Element, T>,
-                                                             and keyPath2: KeyPath<Element, U>,
-                                                             and keyPath3: KeyPath<Element, V>) -> [Element] {
+    ///     - map1: Map function to sort by. Output type must be Comparable.
+    ///     - map2: Map function to sort by in case the values of `map1` match. Output type must be Comparable.
+    ///     - map3: Map function to sort by in case the values of `map1` and `map2` match. Output type must be Comparable.
+    func sorted<T: Comparable, U: Comparable, V: Comparable>(by map1: (Element) -> T,
+                                                             and map2: (Element) -> U,
+                                                             and map3: (Element) -> V) -> [Element] {
         return sorted {
-            if $0[keyPath: keyPath1] != $1[keyPath: keyPath1] {
-                return $0[keyPath: keyPath1] < $1[keyPath: keyPath1]
+            if map1($0) != map1($1) {
+                return map1($0) < map1($1)
             }
-            if $0[keyPath: keyPath2] != $1[keyPath: keyPath2] {
-                return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
+            if map2($0) != map2($1) {
+                return map2($0) < map2($1)
             }
-            return $0[keyPath: keyPath3] < $1[keyPath: keyPath3]
+            return map3($0) < map3($1)
         }
     }
 
@@ -219,23 +219,23 @@ public extension Sequence {
     ///
     ///     ["James", "Wade", "Bryant"].sum(for: \.count) -> 15
     ///
-    /// - Parameter keyPath: Key path of the `AdditiveArithmetic` property.
-    /// - Returns: The sum of the `AdditiveArithmetic` properties at `keyPath`.
-    func sum<T: AdditiveArithmetic>(for keyPath: KeyPath<Element, T>) -> T {
+    /// - Parameter map: Getter for  the `AdditiveArithmetic` property.
+    /// - Returns: The sum of the `AdditiveArithmetic` properties at `map`.
+    func sum<T: AdditiveArithmetic>(for map: (Element) -> T) -> T {
         // Inspired by: https://swiftbysundell.com/articles/reducers-in-swift/
-        return reduce(.zero) { $0 + $1[keyPath: keyPath] }
+        return reduce(.zero) { $0 + map($1) }
     }
 
-    /// SwifterSwift: Returns the first element of the sequence with having property by given key path equals to given
+    /// SwifterSwift: Returns the first element of the sequence with having the value by given map function equals to given
     /// `value`.
     ///
     /// - Parameters:
-    ///   - keyPath: The `KeyPath` of property for `Element` to compare.
+    ///   - map: Function for `Element` to compare.
     ///   - value: The value to compare with `Element` property.
-    /// - Returns: The first element of the collection that has property by given key path equals to given `value` or
+    /// - Returns: The first element of the collection that has property by given map function equals to given `value` or
     /// `nil` if there is no such element.
-    func first<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
-        return first { $0[keyPath: keyPath] == value }
+    func first<T: Equatable>(where map: (Element) throws -> T, equals value: T) rethrows -> Element? {
+        return try first { try map($0) == value }
     }
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -339,7 +339,7 @@ public extension Sequence where Element: AdditiveArithmetic {
 // MARK: - Methods (Numeric)
 
 public extension Sequence where Element: Numeric {
-    /// SwifterSwift: Product of all elements in array.
+    /// SwifterSwift: Product of all elements in sequence.
     ///
     ///        [1, 2, 3, 4, 5].product() -> 120
     ///

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -95,6 +95,15 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(tuple.nonMatching, [1, 3, 5])
         XCTAssertEqual(tuple.1, [1, 3, 5])
     }
+    
+    func testContainsMatcher() {
+        XCTAssert([String]().contains([], matchedBy: {_,_ in true}))
+        XCTAssertFalse([String]().contains([1, 2], matchedBy: { $0.count == $1 }))
+        XCTAssert((["A", "Po", "Joe"] as [String]).contains([1, 2], matchedBy: { $0.count == $1 }))
+        XCTAssert((["A", "Po", "Joe"] as [String]).contains([2, 3], matchedBy: { $0.count == $1 }))
+        XCTAssert((["A", "Po", "Joe"] as [String]).contains([1, 3], matchedBy: { $0.count == $1 }))
+        XCTAssertFalse((["A", "Po", "Joe"] as [String]).contains([4, 5], matchedBy: { $0.count == $1 }))
+    }
 
     func testContainsEquatable() {
         XCTAssert([TestValue]().contains([]))

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -139,7 +139,7 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].sum(), 17)
     }
 
-    func testKeyPathSum() {
+    func testMapFunctionSum() {
         XCTAssertEqual(["James", "Wade", "Bryant"].sum(for: \.count), 15)
         XCTAssertEqual(["a", "b", "c", "d"].sum(for: \.count), 4)
     }
@@ -162,7 +162,7 @@ final class SequenceExtensionsTests: XCTestCase {
         // Comparable version
         XCTAssertEqual(array.sorted(by: \String.count), ["Wade", "James", "Bryant"])
 
-        // Testing optional keyPath
+        // Testing optional map function
         let optionalCompare = { (char1: Character?, char2: Character?) -> Bool in
             guard let char1 = char1, let char2 = char2 else { return false }
             return char1 < char2
@@ -172,7 +172,7 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
     }
 
-    func testSortedByTwoKeyPaths() {
+    func testSortedByTwoMapFunctions() {
         let people = [
             SimplePerson(forename: "Tom", surname: "James", age: 32),
             SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
@@ -186,7 +186,7 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(people.sorted(by: \.surname, and: \.age), expectedResult)
     }
 
-    func testSortedByThreeKeyPaths() {
+    func testSortedByThreeMapFunctions() {
         let people = [
             SimplePerson(forename: "Tom", surname: "James", age: 32),
             SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
@@ -202,7 +202,7 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(people.sorted(by: \.surname, and: \.forename, and: \.age), expectedResult)
     }
 
-    func testFirstByKeyPath() {
+    func testFirstByMapFunction() {
         let array1 = [
             Person(name: "John", age: 30, location: Location(city: "Boston")),
             Person(name: "Jan", age: 22, location: nil),

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -143,8 +143,18 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(["James", "Wade", "Bryant"].sum(for: \.count), 15)
         XCTAssertEqual(["a", "b", "c", "d"].sum(for: \.count), 4)
     }
+    
+    func testProduct() {
+        XCTAssertEqual([1, 2, 3, 4, 5].product(), 120)
+        XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].product(), 236.4768, accuracy: 0.001)
+    }
 
-    func testKeyPathSorted() {
+    func testMapFunctionProduct() {
+        XCTAssertEqual(["James", "Wade", "Bryant"].product(for: \.count), 120)
+        XCTAssertEqual(["a", "b", "c", "d"].product(for: \.count), 1)
+    }
+
+    func testMapFunctionSorted() {
         let array = ["James", "Wade", "Bryant"]
         XCTAssertEqual(array.sorted(by: \String.count, with: <), ["Wade", "James", "Bryant"])
         XCTAssertEqual(array.sorted(by: \String.count, with: >), ["Bryant", "James", "Wade"])


### PR DESCRIPTION
:rocket:
<!--- Provide a general summary of your changes in the Title above -->
Was packaging up some utility methods and discovered this package, so I decided to send them here as contributions.
I may have some more later down the line, but for now here's the summary:
- Added `product` methods for multiplying elements and properties in a sequence
- Added `contains` that matches and compares the fields.
- Since Swift 5.2, you can pass `KeyPath` expressions as functions, so methods in Sequence now are more flexible to allow for any mapping function to be used.
- Changed `contains` parameter to be generic for any type conforming to `Sequence` 

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 5.6.
- [ ] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
