### PR TITLE
Added `product()` and `product(for:)` methods to `Sequence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - Added `+=`, `-=`, `*=`, `/=` to add, subtract, multiply and divide measurements. [#1162](https://github.com/SwifterSwift/SwifterSwift/pull/1162) by [Roman Podymov](https://github.com/RomanPodymov)
 - **UIView**
   - Added `removeBlur()` method for removing the applied blur effect from the view. [#1159](https://github.com/SwifterSwift/SwifterSwift/pull/1159) by [regi93](https://github.com/regi93)
+- **Sequence**
+  - Added `product()` for calculating the product of all `Numeric` elements. [#1168](https://github.com/SwifterSwift/SwifterSwift/pull/1168)[MartonioJunior](https://github.com/MartonioJunior)
+  - Added `product(for:)` for calculating the product of the `Numeric` property for all elements in `Sequence`. [#1168](https://github.com/SwifterSwift/SwifterSwift/pull/1168)[MartonioJunior](https://github.com/MartonioJunior)
 
 ### Fixed
 - **UIImageView**

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -225,6 +225,16 @@ public extension Sequence {
         // Inspired by: https://swiftbysundell.com/articles/reducers-in-swift/
         return reduce(.zero) { $0 + $1[keyPath: keyPath] }
     }
+    
+    /// SwifterSwift: Product of all elements in sequence.
+    ///
+    ///        ["James", "Wade", "Bryant"].product(for: \.count) -> 120
+    ///
+    /// - Parameter map: Mapping function to `Numeric` value.
+    /// - Returns: product of the sequence's elements.
+    func product<T: Numeric>(for map: (Element) -> T) -> T {
+        reduce(1) { $0 * map($1) }
+    }
 
     /// SwifterSwift: Returns the first element of the sequence with having property by given key path equals to given
     /// `value`.
@@ -307,4 +317,15 @@ public extension Sequence where Element: AdditiveArithmetic {
     func sum() -> Element {
         return reduce(.zero, +)
     }
+}
+
+// MARK: - Methods (Numeric)
+
+public extension Sequence where Element: Numeric {
+    /// SwifterSwift: Product of all elements in sequence.
+    ///
+    ///        [1, 2, 3, 4, 5].product() -> 120
+    ///
+    /// - Returns: product of the sequence's elements.
+    func product() -> Element { reduce(1, *) }
 }

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -134,6 +134,16 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(["James", "Wade", "Bryant"].sum(for: \.count), 15)
         XCTAssertEqual(["a", "b", "c", "d"].sum(for: \.count), 4)
     }
+    
+    func testProduct() {
+        XCTAssertEqual([1, 2, 3, 4, 5].product(), 120)
+        XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].product(), 236.4768, accuracy: 0.001)
+    }
+
+    func testMapFunctionProduct() {
+        XCTAssertEqual(["James", "Wade", "Bryant"].product(for: \.count), 120)
+        XCTAssertEqual(["a", "b", "c", "d"].product(for: \.count), 1)
+    }
 
     func testKeyPathSorted() {
         let array = ["James", "Wade", "Bryant"]


### PR DESCRIPTION
🚀

Added `product()` and `product(for:)` methods for multiplying elements and properties in a sequence (standalone PR as requested on #1167).

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 5.6.
- [X] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
