### PR TITLE
Added mapping functions to `Sequence` as alternatives to `KeyPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ## Upcoming Release
 ### Added
-- **Sequence**
-    - `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `first(where:equals:)` now have alternatives that receive functions as parameters. This change maintains compatibility with KeyPath while making the methods more flexible. [#1170](https://github.com/SwifterSwift/SwifterSwift/pull/1170) by [MartonioJunior](https://github.com/MartonioJunior)
-
-### Added
 - **NSView**
   - Added `addArrangedSubviews(_ views: )` to add an array of views to the end of the arrangedSubviews array. [#1181](https://github.com/SwifterSwift/SwifterSwift/pull/1181) by [Roman Podymov](https://github.com/RomanPodymov)
   - Added `removeArrangedSubviews` to remove all views in stack’s array of arranged subviews. [#1181](https://github.com/SwifterSwift/SwifterSwift/pull/1181) by [Roman Podymov](https://github.com/RomanPodymov)
+- **Sequence**
+    - `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `first(where:equals:)` now have alternatives that receive functions as parameters. This change maintains compatibility with KeyPath while making the methods more flexible. [#1170](https://github.com/SwifterSwift/SwifterSwift/pull/1170) by [MartonioJunior](https://github.com/MartonioJunior)
+
+### Changed
+- **Sequence**
+    - `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `first(where:equals:)` now have alternatives that receive functions as parameters. This change maintains compatibility with KeyPath while making the methods more flexible. [#1170](https://github.com/SwifterSwift/SwifterSwift/pull/1170) by [MartonioJunior](https://github.com/MartonioJunior)
 
 ## [v6.1.1](https://github.com/SwifterSwift/SwifterSwift/releases/tag/6.1.1)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
 ## Upcoming Release
+### Added
+- **Sequence**
+    - `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `first(where:equals:)` now have alternatives that receive functions as parameters. This change maintains compatibility with KeyPath while making the methods more flexible. [#1170](https://github.com/SwifterSwift/SwifterSwift/pull/1170) by [MartonioJunior](https://github.com/MartonioJunior)
 
 ### Added
 - **NSView**

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -170,12 +170,29 @@ public extension Sequence {
         return sorted { compare($0[keyPath: keyPath], $1[keyPath: keyPath]) }
     }
 
+    /// SwifterSwift: Return a sorted array based on a map function and a compare function.
+    ///
+    /// - Parameter map: Function that defines the property to sort by.
+    /// - Parameter compare: Comparison function that will determine the ordering.
+    /// - Returns: The sorted array.
+    func sorted<T>(by map: (Element) throws -> T, with compare: (T, T) -> Bool) rethrows -> [Element] {
+        return try sorted { compare(try map($0), try map($1)) }
+    }
+
     /// SwifterSwift: Return a sorted array based on a key path.
     ///
     /// - Parameter keyPath: Key path to sort by. The key path type must be Comparable.
     /// - Returns: The sorted array.
     func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
         return sorted { $0[keyPath: keyPath] < $1[keyPath: keyPath] }
+    }
+
+    /// SwifterSwift: Return a sorted array based on a map function.
+    ///
+    /// - Parameter map: Function that defines the property to sort by. The output type must be Comparable.
+    /// - Returns: The sorted array.
+    func sorted<T: Comparable>(by map: (Element) throws -> T) rethrows -> [Element] {
+        return try sorted { try map($0) < map($1) }
     }
 
     /// SwifterSwift: Returns a sorted sequence based on two key paths. The second one will be used in case the values
@@ -194,7 +211,23 @@ public extension Sequence {
         }
     }
 
-    /// SwifterSwift: Returns a sorted sequence based on three key paths. Whenever the values of one key path match, the
+    /// SwifterSwift: Returns a sorted sequence based on two map functions. The second one will be used in case the values
+    /// of the first one match.
+    ///
+    /// - Parameters:
+    ///     - map1: Map function to sort by. Output type must be Comparable.
+    ///     - map2: Map function to sort by in case the values of `map1` match. Output type must be Comparable.
+    func sorted<T: Comparable, U: Comparable>(by map1: (Element) throws -> T,
+                                              and map2: (Element) throws -> U) rethrows -> [Element] {
+        return try sorted {
+            if try map1($0) != map1($1) {
+                return try map1($0) < map1($1)
+            }
+            return try map2($0) < map2($1)
+        }
+    }
+
+    /// SwifterSwift: Returns a sorted sequence based on three map functions. Whenever the values of one map function match, the
     /// next one will be used.
     ///
     /// - Parameters:
@@ -212,6 +245,27 @@ public extension Sequence {
                 return $0[keyPath: keyPath2] < $1[keyPath: keyPath2]
             }
             return $0[keyPath: keyPath3] < $1[keyPath: keyPath3]
+        }
+    }
+
+    /// SwifterSwift: Returns a sorted sequence based on three map functions. Whenever the values of one map function match, the
+    /// next one will be used.
+    ///
+    /// - Parameters:
+    ///     - map1: Map function to sort by. Output type must be Comparable.
+    ///     - map2: Map function to sort by in case the values of `map1` match. Output type must be Comparable.
+    ///     - map3: Map function to sort by in case the values of `map1` and `map2` match. Output type must be Comparable.
+    func sorted<T: Comparable, U: Comparable, V: Comparable>(by map1: (Element) throws -> T,
+                                                             and map2: (Element) throws -> U,
+                                                             and map3: (Element) throws -> V) rethrows -> [Element] {
+        return try sorted {
+            if try map1($0) != map1($1) {
+                return try map1($0) < map1($1)
+            }
+            if try map2($0) != map2($1) {
+                return try map2($0) < map2($1)
+            }
+            return try map3($0) < map3($1)
         }
     }
 
@@ -236,6 +290,17 @@ public extension Sequence {
         reduce(1) { $0 * map($1) }
     }
 
+    /// SwifterSwift: Sum of a `AdditiveArithmetic` property of each `Element` in a `Sequence`.
+    ///
+    ///     ["James", "Wade", "Bryant"].sum(for: \.count) -> 15
+    ///
+    /// - Parameter map: Getter for  the `AdditiveArithmetic` property.
+    /// - Returns: The sum of the `AdditiveArithmetic` properties at `map`.
+    func sum<T: AdditiveArithmetic>(for map: (Element) throws -> T) rethrows -> T {
+        // Inspired by: https://swiftbysundell.com/articles/reducers-in-swift/
+        return try reduce(.zero) { try $0 + map($1) }
+    }
+
     /// SwifterSwift: Returns the first element of the sequence with having property by given key path equals to given
     /// `value`.
     ///
@@ -246,6 +311,18 @@ public extension Sequence {
     /// `nil` if there is no such element.
     func first<T: Equatable>(where keyPath: KeyPath<Element, T>, equals value: T) -> Element? {
         return first { $0[keyPath: keyPath] == value }
+    }
+
+    /// SwifterSwift: Returns the first element of the sequence with having property by given key path equals to given
+    /// `value`.
+    ///
+    /// - Parameters:
+    ///   - map: Function for `Element` to compare.
+    ///   - value: The value to compare with `Element` property.
+    /// - Returns: The first element of the collection that has property by given map function equals to given `value` or
+    /// `nil` if there is no such element.
+    func first<T: Equatable>(where map: (Element) throws -> T, equals value: T) rethrows -> Element? {
+        return try first { try map($0) == value }
     }
 }
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -220,10 +220,10 @@ public extension Sequence {
     func sorted<T: Comparable, U: Comparable>(by map1: (Element) throws -> T,
                                               and map2: (Element) throws -> U) rethrows -> [Element] {
         return try sorted {
-            let value10 = map1($0)
-            let value11 = map1($1)
-            if try value10 != value11 {
-                return try value10 < value11
+            let value10 = try map1($0)
+            let value11 = try map1($1)
+            if value10 != value11 {
+                return value10 < value11
             }
             return try map2($0) < map2($1)
         }
@@ -261,16 +261,16 @@ public extension Sequence {
                                                              and map2: (Element) throws -> U,
                                                              and map3: (Element) throws -> V) rethrows -> [Element] {
         return try sorted {
-            let value10 = map1($0)
-            let value11 = map1($1)
-            if try value10 != value11 {
-                return try value10 < value11
+            let value10 = try map1($0)
+            let value11 = try map1($1)
+            if value10 != value11 {
+                return value10 < value11
             }
             
-            let value20 = map2($0)
-            let value21 = map2($1)
-            if try value20 != value21 {
-                return try value20 < value21
+            let value20 = try map2($0)
+            let value21 = try map2($1)
+            if value20 != value21 {
+                return value20 < value21
             }
             return try map3($0) < map3($1)
         }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -220,8 +220,10 @@ public extension Sequence {
     func sorted<T: Comparable, U: Comparable>(by map1: (Element) throws -> T,
                                               and map2: (Element) throws -> U) rethrows -> [Element] {
         return try sorted {
-            if try map1($0) != map1($1) {
-                return try map1($0) < map1($1)
+            let value10 = map1($0)
+            let value11 = map1($1)
+            if try value10 != value11 {
+                return try value10 < value11
             }
             return try map2($0) < map2($1)
         }

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -229,7 +229,7 @@ public extension Sequence {
         }
     }
 
-    /// SwifterSwift: Returns a sorted sequence based on three map functions. Whenever the values of one map function match, the
+    /// SwifterSwift: Returns a sorted sequence based on three key paths. Whenever the values of one key path match, the
     /// next one will be used.
     ///
     /// - Parameters:

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -261,11 +261,16 @@ public extension Sequence {
                                                              and map2: (Element) throws -> U,
                                                              and map3: (Element) throws -> V) rethrows -> [Element] {
         return try sorted {
-            if try map1($0) != map1($1) {
-                return try map1($0) < map1($1)
+            let value10 = map1($0)
+            let value11 = map1($1)
+            if try value10 != value11 {
+                return try value10 < value11
             }
-            if try map2($0) != map2($1) {
-                return try map2($0) < map2($1)
+            
+            let value20 = map2($0)
+            let value21 = map2($1)
+            if try value20 != value21 {
+                return try value20 < value21
             }
             return try map3($0) < map3($1)
         }

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -134,7 +134,12 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(["James", "Wade", "Bryant"].sum(for: \.count), 15)
         XCTAssertEqual(["a", "b", "c", "d"].sum(for: \.count), 4)
     }
-
+    
+    func testMapFunctionSum() {
+        XCTAssertEqual(["James", "Wade", "Bryant"].sum(for: { $0.count }), 15)
+        XCTAssertEqual(["a", "b", "c", "d"].sum(for: { $0.count }), 4)
+    }
+    
     func testProduct() {
         XCTAssertEqual([1, 2, 3, 4, 5].product(), 120)
         XCTAssertEqual([1.2, 2.3, 3.4, 4.5, 5.6].product(), 236.4768, accuracy: 0.001)
@@ -162,6 +167,24 @@ final class SequenceExtensionsTests: XCTestCase {
         let array2 = ["James", "Wade", "Bryant", ""]
         XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
     }
+    
+    func testMapFunctionSorted() {
+        let array = ["James", "Wade", "Bryant"]
+        XCTAssertEqual(array.sorted(by: { $0.count }, with: <), ["Wade", "James", "Bryant"])
+        XCTAssertEqual(array.sorted(by: { $0.count }, with: >), ["Bryant", "James", "Wade"])
+
+        // Comparable version
+        XCTAssertEqual(array.sorted(by: { $0.count }), ["Wade", "James", "Bryant"])
+
+        // Testing optional map function
+        let optionalCompare = { (char1: Character?, char2: Character?) -> Bool in
+            guard let char1 = char1, let char2 = char2 else { return false }
+            return char1 < char2
+        }
+
+        let array2 = ["James", "Wade", "Bryant", ""]
+        XCTAssertEqual(array2.sorted(by: \String.first, with: optionalCompare), ["Bryant", "James", "Wade", ""])
+    }
 
     func testSortedByTwoKeyPaths() {
         let people = [
@@ -175,6 +198,20 @@ final class SequenceExtensionsTests: XCTestCase {
             SimplePerson(forename: "Angeline", surname: "Wade", age: 57)
         ]
         XCTAssertEqual(people.sorted(by: \.surname, and: \.age), expectedResult)
+    }
+    
+    func testSortedByTwoMapFunctions() {
+        let people = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Max", surname: "James", age: 34)
+        ]
+        let expectedResult = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57)
+        ]
+        XCTAssertEqual(people.sorted(by: { $0.surname }, and: { $0.age }), expectedResult)
     }
 
     func testSortedByThreeKeyPaths() {
@@ -192,6 +229,22 @@ final class SequenceExtensionsTests: XCTestCase {
         ]
         XCTAssertEqual(people.sorted(by: \.surname, and: \.forename, and: \.age), expectedResult)
     }
+    
+    func testSortedByThreeMapFunctions() {
+        let people = [
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 82)
+        ]
+        let expectedResult = [
+            SimplePerson(forename: "Max", surname: "James", age: 34),
+            SimplePerson(forename: "Tom", surname: "James", age: 32),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 57),
+            SimplePerson(forename: "Angeline", surname: "Wade", age: 82)
+        ]
+        XCTAssertEqual(people.sorted(by: { $0.surname }, and: { $0.forename }, and: { $0.age }), expectedResult)
+    }
 
     func testFirstByKeyPath() {
         let array1 = [
@@ -205,6 +258,22 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(first30Age, array1.first)
 
         let missingPerson = array1.first(where: \.name, equals: "Tom")
+
+        XCTAssertNil(missingPerson)
+    }
+    
+    func testFirstByMapFunction() {
+        let array1 = [
+            Person(name: "John", age: 30, location: Location(city: "Boston")),
+            Person(name: "Jan", age: 22, location: nil),
+            Person(name: "Roman", age: 30, location: Location(city: "Moscow"))
+        ]
+
+        let first30Age = array1.first(where: { $0.age }, equals: 30)
+
+        XCTAssertEqual(first30Age, array1.first)
+
+        let missingPerson = array1.first(where: { $0.name }, equals: "Tom")
 
         XCTAssertNil(missingPerson)
     }


### PR DESCRIPTION
🚀

<!--- Provide a general summary of your changes in the Title above -->
Methods with mapping alternatives: `sorted(by:)`, `sorted(by:with:)`, `sorted(by:and:)`, `sorted(by:and:and:)`, `sum(for:)`, `first(where:equals:)`. All of this keeps compatibility as passing a `KeyPath` will make the code opt for the KeyPath version of the method. (Standalone PR as requested on #1167)

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [X] New extensions are written in Swift 5.6.
- [X] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [X] I have added tests for new extensions, and they passed.
- [X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [X] All extensions are declared as **public**.
- [X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
