### PR TITLE
Add new toggle Function to Set Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ## Upcoming Release
 ### Added
-
+- **Set**
+  - Added `toggle(_ element: )` to toggles an element in the set —- adds it if absent, removes it if present. [#1181](https://github.com/SwifterSwift/SwifterSwift/pull/1199) by [Weiha](https://github.com/weihas)
+  
 ### Fixed
 - **Xcode 16**
   - Fixed compilation errors, warnings and tests. [#1197](https://github.com/SwifterSwift/SwifterSwift/pull/1197) by [guykogus](https://github.com/guykogus)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ let package = Package(
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift"><code>Optional extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/blob/master/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift"><code>RangeReplaceableCollection extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift"><code>Sequence extensions</code></a></li>
+<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SetExtensions.swift"><code>Set extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SignedIntegerExtensions.swift"><code>SignedInteger extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SignedNumericExtensions.swift"><code>SignedNumeric extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift"><code>String extensions</code></a></li>

--- a/README_CN.md
+++ b/README_CN.md
@@ -134,6 +134,7 @@ let package = Package(
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/OptionalExtensions.swift"><code>Optional extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/blob/master/Sources/SwifterSwift/SwiftStdlib/RangeReplaceableCollectionExtensions.swift"><code>RangeReplaceableCollection extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift"><code>Sequence extensions</code></a></li>
+<li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SetExtensions.swift"><code>Set extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SignedIntegerExtensions.swift"><code>SignedInteger extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/SignedNumericExtensions.swift"><code>SignedNumeric extensions</code></a></li>
 <li><a href="https://github.com/SwifterSwift/SwifterSwift/tree/master/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift"><code>String extensions</code></a></li>

--- a/Sources/SwifterSwift/SwiftStdlib/SetExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SetExtensions.swift
@@ -1,0 +1,20 @@
+// SetExtensions.swift - Copyright 2024 SwifterSwift
+
+public extension Set {
+    
+    /// SwifterSwift: Toggles an element in the set. If the element is present, it removes it; otherwise, it inserts it.
+    ///
+    ///     var set: Set<T> = [T1, T2, T3]
+    ///     set.toggle(T1) -> [T2, T3]
+    ///     set.toggle(T4) -> [T2, T3, T4]
+    ///     set.toggle(T1) -> [T1, T2, T3, T4]
+    ///
+    /// - Parameter element: The element to toggle in or out of the set.
+    mutating func toggle(_ element: Element) {
+        if contains(element) {
+            self.remove(element)
+        } else {
+            self.insert(element)
+        }
+    }
+}

--- a/Tests/SwiftStdlibTests/SetExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SetExtensionsTests.swift
@@ -1,0 +1,15 @@
+// SetExtensionsTests.swift - Copyright 2024 SwifterSwift
+
+import Foundation
+@testable import SwifterSwift
+import XCTest
+
+final class SetExtensionsTests: XCTestCase {
+    func testToggle() {
+        var numSet: Set<Int> = [1, 2, 3]
+        numSet.toggle(1)
+        XCTAssertEqual(numSet, [2, 3])
+        numSet.toggle(1)
+        XCTAssertEqual(numSet, [1, 2, 3])
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
