### PR TITLE
Fixed additional compilation errors for Xcode 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Fixed
 - **Xcode 16**
   - Fixed compilation errors, warnings and tests. [#1197](https://github.com/SwifterSwift/SwifterSwift/pull/1197) by [guykogus](https://github.com/guykogus)
+  - Fixed additional compilation errors [#1202](https://github.com/SwifterSwift/SwifterSwift/pull/1202) by [denandreychuk](https://github.com/denandreychuk)
 
 ### Removed
 - **CAGradientLayer**

--- a/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
+++ b/Sources/SwifterSwift/CoreAnimation/CATransform3DExtensions.swift
@@ -2,7 +2,7 @@
 
 // swiftlint:disable identifier_name
 
-#if canImport(QuartzCore)
+#if canImport(QuartzCore) && !os(watchOS)
 
 import QuartzCore
 


### PR DESCRIPTION
https://github.com/SwifterSwift/SwifterSwift/pull/1197 does not fix all Xcode 16 compilation errors. The library compiles when directly open in Xcode, but not when integrated through Cocoapods. This PR address this errors 