### PR TITLE
Remove method that exists in stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 
 ### Removed
-- Sequence's `count(where:)` method, as it already exists in stdlib
+- Sequence's `count(where:)` method, as it already exists in stdlib. [#1221](https://github.com/SwifterSwift/SwifterSwift/pull/1221) by [vikingosegundo](https://github/vikingosegundo)
 
 
 ## [v7.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/7.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Removed
 - Sequence's `count(where:)` method, as it already exists in stdlib. [#1221](https://github.com/SwifterSwift/SwifterSwift/pull/1221) by [vikingosegundo](https://github.com/vikingosegundo)
 
-
 ## [v7.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/7.0.0)
 ### Fixed
 - **Xcode 16**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 
 ### Removed
+- Sequence's `count(where:)` method, as it already exists in stdlib
+
 
 ## [v7.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/7.0.0)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 
 ### Removed
-- Sequence's `count(where:)` method, as it already exists in stdlib. [#1221](https://github.com/SwifterSwift/SwifterSwift/pull/1221) by [vikingosegundo](https://github/vikingosegundo)
+- Sequence's `count(where:)` method, as it already exists in stdlib. [#1221](https://github.com/SwifterSwift/SwifterSwift/pull/1221) by [vikingosegundo](https://github.com/vikingosegundo)
 
 
 ## [v7.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/7.0.0)

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -44,20 +44,6 @@ public extension Sequence {
         return try filter { return try !condition($0) }
     }
 
-    /// SwifterSwift: Get element count based on condition.
-    ///
-    ///        [2, 2, 4, 7].count(where: {$0 % 2 == 0}) -> 3
-    ///
-    /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: number of times the condition evaluated to true.
-    func count(where condition: (Element) throws -> Bool) rethrows -> Int {
-        var count = 0
-        for element in self where try condition(element) {
-            count += 1
-        }
-        return count
-    }
-
     /// SwifterSwift: Iterate over a collection in reverse order. (right to left)
     ///
     ///        [0, 2, 4, 7].forEachReversed({ print($0)}) -> // Order of print: 7,4,2,0

--- a/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/SequenceExtensionsTests.swift
@@ -35,12 +35,6 @@ final class SequenceExtensionsTests: XCTestCase {
         XCTAssertEqual(output, [1, 3, 5])
     }
 
-    func testCountWhere() {
-        let array = [1, 1, 1, 1, 4, 4, 1, 1, 1]
-        let count = array.count { $0 % 2 == 0 }
-        XCTAssertEqual(count, 2)
-    }
-
     func testForEachReversed() {
         let input = [1, 2, 3, 4, 5]
         var output: [Int] = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x] New extensions are written in Swift 5.6.
- [ x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ x] I have added tests for new extensions, and they passed.
- [ x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ x] All extensions are declared as **public**.
- [ x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
