### PR TITLE
remove the same function withoutDuplicates() in Array Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 
 ### Fixed
 - **Examples** : Added "import Foundation" to Foundation Extension Playground page for Date() extension to work properly on Mac
+- **Array**
+  - `init(unsafeUninitializedCapacity:initializedWith:)` initializedCount should be eaqule to the number of successfully initialized elements, Ensure that the Array properly release allocated memory in case of an error.[#1222](https://github.com/SwifterSwift/SwifterSwift/pull/1222) by [fallwd](https://github.com/fallwd)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Deprecated
 
 ### Removed
+- **Array**
+  - Remove duplicate method `withoutDuplicates()` of array extension  [#1224](https://github.com/SwifterSwift/SwifterSwift/pull/1224) by [fallwd](https://github.com/fallwd)
 
 ## [v7.0.0](https://github.com/SwifterSwift/SwifterSwift/releases/tag/7.0.0)
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rouge (2.0.7)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -13,8 +13,8 @@ public extension Array {
         try self.init(unsafeUninitializedCapacity: count) { buffer, initializedCount in
             for index in 0..<count {
                 try buffer.baseAddress?.advanced(by: index).initialize(to: element(index))
+                initializedCount += 1
             }
-            initializedCount = count
         }
     }
 }

--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -114,22 +114,6 @@ public extension Array where Element: Equatable {
         return self
     }
 
-    /// SwifterSwift: Return array with all duplicate elements removed.
-    ///
-    ///     [1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates() -> [1, 2, 3, 4, 5])
-    ///     ["h", "e", "l", "l", "o"].withoutDuplicates() -> ["h", "e", "l", "o"])
-    ///
-    /// - Returns: an array of unique elements.
-    ///
-    func withoutDuplicates() -> [Element] {
-        // Thanks to https://github.com/sairamkotha for improving the method
-        return reduce(into: [Element]()) {
-            if !$0.contains($1) {
-                $0.append($1)
-            }
-        }
-    }
-
     /// SwifterSwift: Returns an array with all duplicate elements removed using KeyPath to compare.
     ///
     /// - Parameter path: Key path to compare, the value must be Equatable.

--- a/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ArrayExtensionsTests.swift
@@ -90,11 +90,6 @@ final class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(array, [1, 2, 3, 4, 5])
     }
 
-    func testWithoutDuplicates() {
-        XCTAssertEqual([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates(), [1, 2, 3, 4, 5])
-        XCTAssertEqual(["h", "e", "l", "l", "o"].withoutDuplicates(), ["h", "e", "l", "o"])
-    }
-
     func testWithoutDuplicatesUsingKeyPath() {
         let array = [
             Person(name: "Wade", age: 20, location: Location(city: "London")),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x] New extensions are written in Swift 5.6.
- [x ] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [x ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x ] All extensions are declared as **public**.
- [x ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
