### PR TITLE
Update ArrayExtensions.swift

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ArrayExtensions.swift
@@ -58,7 +58,7 @@ public extension Array {
     ///   - keyPath: keyPath indicating the property that the array should be sorted by
     /// - Returns: sorted array.
     func sorted<T: Hashable>(like otherArray: [T], keyPath: KeyPath<Element, T>) -> [Element] {
-        let dict = otherArray.enumerated().reduce(into: [:]) { $0[$1.element] = $1.offset }
+        let dict = Dictionary(uniqueKeysWithValues: otherArray.enumerated().map { ($1, $0) })
         return sorted {
             guard let thisIndex = dict[$0[keyPath: keyPath]] else { return false }
             guard let otherIndex = dict[$1[keyPath: keyPath]] else { return true }


### PR DESCRIPTION
For creating a dictionary.Dictionary(uniqueKeysWithValues:) is more efficient than reduce(into:) to. i used time profile  and found a significant improvement.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ x] New extensions are written in Swift 5.6.
- [ x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
