### PR TITLE
Calculate ceil and floor using built-in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Examples** : Added "import Foundation" to Foundation Extension Playground page for Date() extension to work properly on Mac
 - **Array**
   - `init(unsafeUninitializedCapacity:initializedWith:)` initializedCount should be eaqule to the number of successfully initialized elements, Ensure that the Array properly release allocated memory in case of an error.[#1222](https://github.com/SwifterSwift/SwifterSwift/pull/1222) by [fallwd](https://github.com/fallwd)
+- **FloatingPoint**
+  - Calculate `ceil` and `floor` using `rounded(_:)` instead of the `Foundation` functions. [#1231](https://github.com/SwifterSwift/SwifterSwift/pull/1231) by [guykogus](https://github.com/guykogus)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 - **Array**
   - `init(unsafeUninitializedCapacity:initializedWith:)` initializedCount should be eaqule to the number of successfully initialized elements, Ensure that the Array properly release allocated memory in case of an error.[#1222](https://github.com/SwifterSwift/SwifterSwift/pull/1222) by [fallwd](https://github.com/fallwd)
 - **FloatingPoint**
-  - Calculate `ceil` and `floor` using `rounded(_:)` instead of the `Foundation` functions. [#1231](https://github.com/SwifterSwift/SwifterSwift/pull/1231) by [guykogus](https://github.com/guykogus)
+  - Calculate `ceil` and `floor` using `rounded(_:)`, and `√` using `squareRoot()`, instead of using `Foundation` functions. [#1231](https://github.com/SwifterSwift/SwifterSwift/pull/1231) by [guykogus](https://github.com/guykogus)
 
 ### Deprecated
 

--- a/Sources/SwifterSwift/SwiftStdlib/FloatingPointExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/FloatingPointExtensions.swift
@@ -77,7 +77,7 @@ prefix operator √
 /// - Returns: square root of given float.
 public prefix func √ <T>(float: T) -> T where T: FloatingPoint {
     // http://nshipster.com/swift-operators/
-    return sqrt(float)
+    return float.squareRoot()
 }
 
 // swiftlint:enable identifier_name

--- a/Sources/SwifterSwift/SwiftStdlib/FloatingPointExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/FloatingPointExtensions.swift
@@ -1,9 +1,5 @@
 // FloatingPointExtensions.swift - Copyright 2025 SwifterSwift
 
-#if canImport(Foundation)
-import Foundation
-#endif
-
 // MARK: - Properties
 
 public extension FloatingPoint {
@@ -22,24 +18,20 @@ public extension FloatingPoint {
         return self < 0
     }
 
-    #if canImport(Foundation)
     /// SwifterSwift: Ceil of number.
     var ceil: Self {
-        return Foundation.ceil(self)
+        return rounded(.up)
     }
-    #endif
+
+    /// SwifterSwift: Floor of number.
+    var floor: Self {
+        return rounded(.down)
+    }
 
     /// SwifterSwift: Radian value of degree input.
     var degreesToRadians: Self {
         return Self.pi * self / Self(180)
     }
-
-    #if canImport(Foundation)
-    /// SwifterSwift: Floor of number.
-    var floor: Self {
-        return Foundation.floor(self)
-    }
-    #endif
 
     /// SwifterSwift: Degree value of radian input.
     var radiansToDegrees: Self {

--- a/Tests/SwiftStdlibTests/FloatingPointExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/FloatingPointExtensionsTests.swift
@@ -30,18 +30,56 @@ final class FloatingPointExtensionsTests: XCTestCase {
     }
 
     func testCeil() {
-        XCTAssertEqual(Float(9.3).ceil, Float(10.0))
-        XCTAssertEqual(Double(9.3).ceil, Double(10.0))
+        XCTAssertEqual(Float(-1.0).ceil, Float(-1.0))
+        XCTAssertEqual(Float(-0.75).ceil, Float(0.0))
+        XCTAssertEqual(Float(-0.5).ceil, Float(0.0))
+        XCTAssertEqual(Float(-0.25).ceil, Float(0.0))
+        XCTAssertEqual(Float(-0.0).ceil, Float(0.0))
+        XCTAssertEqual(Float(0.0).ceil, Float(0.0))
+        XCTAssertEqual(Float(0.25).ceil, Float(1.0))
+        XCTAssertEqual(Float(0.5).ceil, Float(1.0))
+        XCTAssertEqual(Float(0.75).ceil, Float(1.0))
+        XCTAssertEqual(Float(1.0).ceil, Float(1.0))
+
+        XCTAssertEqual(Double(-1.0).ceil, Double(-1.0))
+        XCTAssertEqual(Double(-0.75).ceil, Double(0.0))
+        XCTAssertEqual(Double(-0.5).ceil, Double(0.0))
+        XCTAssertEqual(Double(-0.25).ceil, Double(0.0))
+        XCTAssertEqual(Double(-0.0).ceil, Double(0.0))
+        XCTAssertEqual(Double(0.0).ceil, Double(0.0))
+        XCTAssertEqual(Double(0.25).ceil, Double(1.0))
+        XCTAssertEqual(Double(0.5).ceil, Double(1.0))
+        XCTAssertEqual(Double(0.75).ceil, Double(1.0))
+        XCTAssertEqual(Double(1.0).ceil, Double(1.0))
+    }
+
+    func testFloor() {
+        XCTAssertEqual(Float(-1.0).floor, Float(-1.0))
+        XCTAssertEqual(Float(-0.75).floor, Float(-1.0))
+        XCTAssertEqual(Float(-0.5).floor, Float(-1.0))
+        XCTAssertEqual(Float(-0.25).floor, Float(-1.0))
+        XCTAssertEqual(Float(-0.0).floor, Float(0.0))
+        XCTAssertEqual(Float(0.0).floor, Float(0.0))
+        XCTAssertEqual(Float(0.25).floor, Float(0.0))
+        XCTAssertEqual(Float(0.5).floor, Float(0.0))
+        XCTAssertEqual(Float(0.75).floor, Float(0.0))
+        XCTAssertEqual(Float(1.0).floor, Float(1.0))
+
+        XCTAssertEqual(Double(-1.0).floor, Double(-1.0))
+        XCTAssertEqual(Double(-0.75).floor, Double(-1.0))
+        XCTAssertEqual(Double(-0.5).floor, Double(-1.0))
+        XCTAssertEqual(Double(-0.25).floor, Double(-1.0))
+        XCTAssertEqual(Double(-0.0).floor, Double(0.0))
+        XCTAssertEqual(Double(0.0).floor, Double(0.0))
+        XCTAssertEqual(Double(0.25).floor, Double(0.0))
+        XCTAssertEqual(Double(0.5).floor, Double(0.0))
+        XCTAssertEqual(Double(0.75).floor, Double(0.0))
+        XCTAssertEqual(Double(1.0).floor, Double(1.0))
     }
 
     func testDegreesToRadians() {
         XCTAssertEqual(Float(180).degreesToRadians, Float.pi)
         XCTAssertEqual(Double(180).degreesToRadians, Double.pi)
-    }
-
-    func testFloor() {
-        XCTAssertEqual(Float(9.3).floor, Float(9.0))
-        XCTAssertEqual(Double(9.3).floor, Double(9.0))
     }
 
     func testRadiansToDegrees() {


### PR DESCRIPTION
🚀
Instead of using the Math functions (by importing Foundation) we can use `rounded(_:)`.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
