### PR TITLE
Add UIView.separator extension with tests and changelog 🚀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 
 - **UIView**
-  - Added `separator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀
+  - Added `separator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀 [#1234](https://github.com/SwifterSwift/SwifterSwift/pull/1234) by [sangjin](https://github.com/SsangG77)
 
 
 ## Upcoming Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
 ## Upcoming Release
-
 ### Added
 - **UIView**
   - Added `addBottomSeparator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀 [#1234](https://github.com/SwifterSwift/SwifterSwift/pull/1234) by [sangjin](https://github.com/SsangG77)
-
 - **Android**
   - Added Android platform support. [#1230](https://github.com/SwifterSwift/SwifterSwift/pull/1230) by [Marc Prud'hommeaux](https://github.com/marcprux)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
-
-
 ## Upcoming Release
 
 ### Added
 - **UIView**
   - Added `addBottomSeparator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀 [#1234](https://github.com/SwifterSwift/SwifterSwift/pull/1234) by [sangjin](https://github.com/SsangG77)
 
-### Added
 - **Android**
   - Added Android platform support. [#1230](https://github.com/SwifterSwift/SwifterSwift/pull/1230) by [Marc Prud'hommeaux](https://github.com/marcprux)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 
 ### Added
-
 - **UIView**
-  - Added `separator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀 [#1234](https://github.com/SwifterSwift/SwifterSwift/pull/1234) by [sangjin](https://github.com/SsangG77)
+  - Added `addBottomSeparator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀 [#1234](https://github.com/SwifterSwift/SwifterSwift/pull/1234) by [sangjin](https://github.com/SsangG77)
 
 ### Added
 - **Android**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
+## [Unreleased]
+
+### Added
+
+- **UIView**
+  - Added `separator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀
+
+
 ## Upcoming Release
 ### Added
 - **Android**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 The changelog for **SwifterSwift**. Also see the [releases](https://github.com/SwifterSwift/SwifterSwift/releases) on GitHub.
 
-## [Unreleased]
+
+
+## Upcoming Release
 
 ### Added
 
 - **UIView**
   - Added `separator(color:height:spacing:)` method to easily insert a bottom line to a view. 🚀 [#1234](https://github.com/SwifterSwift/SwifterSwift/pull/1234) by [sangjin](https://github.com/SsangG77)
 
-
-## Upcoming Release
 ### Added
 - **Android**
   - Added Android platform support. [#1230](https://github.com/SwifterSwift/SwifterSwift/pull/1230) by [Marc Prud'hommeaux](https://github.com/marcprux)

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -700,6 +700,29 @@ public extension UIView {
         }
         return views
     }
+    
+    /// SwifterSwift: Adds a horizontal separator to the bottom of the view.
+    ///
+    ///     let view = UIView()
+    ///     view.addBottomSeparator(color: .lightGray, height: 1, spacing: 8)
+    ///
+    /// - Parameters:
+    ///   - color: The separator color. Default is `.black`.
+    ///   - height: The height of the separator. Default is `1`.
+    ///   - spacing: Spacing from the bottom edge. Default is `0`.
+    func addBottomSeparator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
+        let line = UIView()
+        line.translatesAutoresizingMaskIntoConstraints = false
+        line.backgroundColor = color
+        line.layer.cornerRadius = height / 2
+        self.addSubview(line)
+        NSLayoutConstraint.activate([
+            line.heightAnchor.constraint(equalToConstant: height),
+            line.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            line.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            line.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: spacing)
+        ])
+    }
 }
 
 // MARK: - Constraints
@@ -750,33 +773,5 @@ public extension UIView {
         findConstraint(attribute: .bottom, for: self)
     }
 }
-
-
-
-public extension UIView {
-    /// SwifterSwift: Adds a horizontal separator to the bottom of the view.
-    ///
-    ///     let view = UIView()
-    ///     view.separator(color: .lightGray, height: 1, spacing: 8)
-    ///
-    /// - Parameters:
-    ///   - color: The separator color. Default is `.black`.
-    ///   - height: The height of the separator. Default is `1`.
-    ///   - spacing: Spacing from the bottom edge. Default is `0`.
-    func addBottomSeparator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
-        let line = UIView()
-        line.translatesAutoresizingMaskIntoConstraints = false
-        line.backgroundColor = color
-        line.layer.cornerRadius = height / 2
-        self.addSubview(line)
-        NSLayoutConstraint.activate([
-            line.heightAnchor.constraint(equalToConstant: height),
-            line.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            line.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            line.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: spacing)
-        ])
-    }
-}
-
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -763,7 +763,7 @@ public extension UIView {
     ///   - color: The separator color. Default is `.black`.
     ///   - height: The height of the separator. Default is `1`.
     ///   - spacing: Spacing from the bottom edge. Default is `0`.
-    func addViewSeparator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
+    func addBottomSeparator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
         let line = UIView()
         line.translatesAutoresizingMaskIntoConstraints = false
         line.backgroundColor = color

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -763,11 +763,11 @@ public extension UIView {
     ///   - color: The separator color. Default is `.black`.
     ///   - height: The height of the separator. Default is `1`.
     ///   - spacing: Spacing from the bottom edge. Default is `0`.
-    func separator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
+    func addViewSeparator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
         let line = UIView()
         line.translatesAutoresizingMaskIntoConstraints = false
         line.backgroundColor = color
-        line.layer.cornerRadius = 3
+        line.layer.cornerRadius = height / 2
         self.addSubview(line)
         NSLayoutConstraint.activate([
             line.heightAnchor.constraint(equalToConstant: height),

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -751,4 +751,32 @@ public extension UIView {
     }
 }
 
+
+
+public extension UIView {
+    /// SwifterSwift: Adds a horizontal separator to the bottom of the view.
+    ///
+    ///     let view = UIView()
+    ///     view.separator(color: .lightGray, height: 1, spacing: 8)
+    ///
+    /// - Parameters:
+    ///   - color: The separator color. Default is `.black`.
+    ///   - height: The height of the separator. Default is `1`.
+    ///   - spacing: Spacing from the bottom edge. Default is `0`.
+    func separator(color: UIColor = .black, height: CGFloat = 1, spacing: CGFloat = 0) {
+        let line = UIView()
+        line.translatesAutoresizingMaskIntoConstraints = false
+        line.backgroundColor = color
+        line.layer.cornerRadius = 3
+        self.addSubview(line)
+        NSLayoutConstraint.activate([
+            line.heightAnchor.constraint(equalToConstant: height),
+            line.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            line.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            line.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: spacing)
+        ])
+    }
+}
+
+
 #endif

--- a/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIViewExtensions.swift
@@ -718,9 +718,9 @@ public extension UIView {
         self.addSubview(line)
         NSLayoutConstraint.activate([
             line.heightAnchor.constraint(equalToConstant: height),
-            line.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            line.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            line.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: spacing)
+            line.leadingAnchor.constraint(equalTo: leadingAnchor),
+            line.trailingAnchor.constraint(equalTo: trailingAnchor),
+            line.bottomAnchor.constraint(equalTo: bottomAnchor, constant: spacing)
         ])
     }
 }

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -684,42 +684,23 @@ final class UIViewExtensionsTests: XCTestCase { // swiftlint:disable:this type_b
         XCTAssertFalse(view.subviews.first is UIVisualEffectView)
     }
     
-    func testSeparatorAddsSubview() {
-            let view = UIView()
-            view.separator()
+   
+    func testAddViewSeparator() throws {
+        let view = UIView()
+        let expectedColor: UIColor = .red
+        let expectedHeight: CGFloat = 2.0
 
-            XCTAssertEqual(view.subviews.count, 1)
-        }
+        view.addViewSeparator(color: expectedColor, height: expectedHeight)
 
-        func testSeparatorUsesCorrectColorAndHeight() {
-            let view = UIView()
-            let expectedColor: UIColor = .red
-            let expectedHeight: CGFloat = 2.0
+        let separator = try XCTUnwrap(view.subviews.first, "Separator not found")
+        
+        XCTAssertEqual(view.subviews.count, 1)
+        XCTAssertEqual(separator.backgroundColor, expectedColor)
+        XCTAssertEqual(separator.frame.height, expectedHeight, accuracy: 0.1)
+    }
 
-            view.separator(color: expectedColor, height: expectedHeight)
-
-            guard let separator = view.subviews.first else {
-                XCTFail("Separator not found")
-                return
-            }
-
-            XCTAssertEqual(separator.backgroundColor, expectedColor)
-
-            let heightConstraint = separator.constraints.first { $0.firstAttribute == .height }
-            XCTAssertEqual(heightConstraint?.constant, expectedHeight)
-        }
-
-        func testSeparatorUsesAutoLayout() {
-            let view = UIView()
-            view.separator()
-
-            guard let separator = view.subviews.first else {
-                XCTFail("Separator not found")
-                return
-            }
-
-            XCTAssertFalse(separator.translatesAutoresizingMaskIntoConstraints)
-        }
+    
+    
 }
 
 #endif

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -683,6 +683,43 @@ final class UIViewExtensionsTests: XCTestCase { // swiftlint:disable:this type_b
         view.removeBlur()
         XCTAssertFalse(view.subviews.first is UIVisualEffectView)
     }
+    
+    func testSeparatorAddsSubview() {
+            let view = UIView()
+            view.separator()
+
+            XCTAssertEqual(view.subviews.count, 1)
+        }
+
+        func testSeparatorUsesCorrectColorAndHeight() {
+            let view = UIView()
+            let expectedColor: UIColor = .red
+            let expectedHeight: CGFloat = 2.0
+
+            view.separator(color: expectedColor, height: expectedHeight)
+
+            guard let separator = view.subviews.first else {
+                XCTFail("Separator not found")
+                return
+            }
+
+            XCTAssertEqual(separator.backgroundColor, expectedColor)
+
+            let heightConstraint = separator.constraints.first { $0.firstAttribute == .height }
+            XCTAssertEqual(heightConstraint?.constant, expectedHeight)
+        }
+
+        func testSeparatorUsesAutoLayout() {
+            let view = UIView()
+            view.separator()
+
+            guard let separator = view.subviews.first else {
+                XCTFail("Separator not found")
+                return
+            }
+
+            XCTAssertFalse(separator.translatesAutoresizingMaskIntoConstraints)
+        }
 }
 
 #endif

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -686,7 +686,7 @@ final class UIViewExtensionsTests: XCTestCase { // swiftlint:disable:this type_b
     
     func testAddBottomSeparator() throws {
         let view = UIView()
-        let expectedColor: UIColor = .red
+        let expectedColor = UIColor.red
         let expectedHeight: CGFloat = 2.0
 
         view.addBottomSeparator(color: expectedColor, height: expectedHeight)

--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -684,23 +684,19 @@ final class UIViewExtensionsTests: XCTestCase { // swiftlint:disable:this type_b
         XCTAssertFalse(view.subviews.first is UIVisualEffectView)
     }
     
-   
-    func testAddViewSeparator() throws {
+    func testAddBottomSeparator() throws {
         let view = UIView()
         let expectedColor: UIColor = .red
         let expectedHeight: CGFloat = 2.0
 
-        view.addViewSeparator(color: expectedColor, height: expectedHeight)
+        view.addBottomSeparator(color: expectedColor, height: expectedHeight)
 
         let separator = try XCTUnwrap(view.subviews.first, "Separator not found")
-        
+
         XCTAssertEqual(view.subviews.count, 1)
         XCTAssertEqual(separator.backgroundColor, expectedColor)
-        XCTAssertEqual(separator.frame.height, expectedHeight, accuracy: 0.1)
+        XCTAssertEqual(separator.frame.height, expectedHeight)
     }
-
-    
-    
 }
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.


🚀 This PR adds a new extension to `UIView`:

### ✅ What's added
- `separator(color:height:spacing:)` method, which makes it easy to add a bottom border/separator to any UIView.
- Fully tested with `XCTest` (`UIViewExtensionsTests`)
- `CHANGELOG.md` updated under `[Unreleased]`

### 💡 Usage

```swift
let view = UIView()
view.separator(color: .gray, height: 1, spacing: 4)
```
