### PR TITLE
feat: Add safe area insets extensions and key window access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 ### Breaking Change
 ### Added
+- **UIApplication**
+  - Added `topSafeAreaInsets`, `bottomSafeAreaInsets`, `leftSafeAreaInsets`, `rightSafeAreaInsets` properties for easy access to individual safe area insets from the key window.
+  - Added `horizontalSafeAreaInsets`, `verticalSafeAreaInsets` properties for combined safe area insets calculations.
+- **UIWindow**
+  - Added `keyWindow` static property for cross-version key window access, handling both iOS 13+ window scenes and legacy iOS versions.
 ### Changed
 ### Fixed
 ### Deprecated

--- a/Sources/SwifterSwift/UIKit/UIApplicationExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIApplicationExtensions.swift
@@ -63,6 +63,54 @@ public extension UIApplication {
     var version: String? {
         return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
     }
+    
+    /// SwifterSwift: Top safe area insets of the key window.
+    ///
+    /// Returns the top safe area insets from the current key window, or 0 if no key window is available.
+    /// This is useful for adjusting UI elements to account for the status bar, notch, or other system UI elements.
+    var topSafeAreaInsets: CGFloat {
+        UIWindow.keyWindow?.safeAreaInsets.top ?? 0
+    }
+    
+    /// SwifterSwift: Bottom safe area insets of the key window.
+    ///
+    /// Returns the bottom safe area insets from the current key window, or 0 if no key window is available.
+    /// This is useful for adjusting UI elements to account for the home indicator or other system UI elements.
+    var bottomSafeAreaInsets: CGFloat {
+        UIWindow.keyWindow?.safeAreaInsets.bottom ?? 0
+    }
+    
+    /// SwifterSwift: Left safe area insets of the key window.
+    ///
+    /// Returns the left safe area insets from the current key window, or 0 if no key window is available.
+    /// This is useful for adjusting UI elements to account for system UI elements on the left side.
+    var leftSafeAreaInsets: CGFloat {
+        UIWindow.keyWindow?.safeAreaInsets.left ?? 0
+    }
+    
+    /// SwifterSwift: Right safe area insets of the key window.
+    ///
+    /// Returns the right safe area insets from the current key window, or 0 if no key window is available.
+    /// This is useful for adjusting UI elements to account for system UI elements on the right side.
+    var rightSafeAreaInsets: CGFloat {
+        UIWindow.keyWindow?.safeAreaInsets.right ?? 0
+    }
+    
+    /// SwifterSwift: Horizontal safe area insets of the key window.
+    ///
+    /// Returns the combined left and right safe area insets from the current key window, or 0 if no key window is available.
+    /// This is useful for calculating the total horizontal safe area that needs to be accounted for.
+    var horizontalSafeAreaInsets: CGFloat {
+        UIWindow.keyWindow?.safeAreaInsets.horizontal ?? 0
+    }
+    
+    /// SwifterSwift: Vertical safe area insets of the key window.
+    ///
+    /// Returns the combined top and bottom safe area insets from the current key window, or 0 if no key window is available.
+    /// This is useful for calculating the total vertical safe area that needs to be accounted for.
+    var verticalSafeAreaInsets: CGFloat {
+        UIWindow.keyWindow?.safeAreaInsets.vertical ?? 0
+    }
 }
 
 #endif

--- a/Sources/SwifterSwift/UIKit/UIWindowExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIWindowExtensions.swift
@@ -35,6 +35,25 @@ public extension UIWindow {
             completion?()
         })
     }
+    
+    /// SwifterSwift: The current key window of the application.
+    ///
+    /// Returns the key window that is currently receiving keyboard and other non-touch events.
+    /// This property handles both iOS 13+ (using window scenes) and older iOS versions (using the deprecated keyWindow property).
+    ///
+    /// - Note: On iOS 13 and later, this searches through all connected window scenes to find the key window.
+    /// - Note: On iOS 12 and earlier, this uses the deprecated `UIApplication.shared.keyWindow` property.
+    static var keyWindow: UIWindow? {
+        if #available(iOS 13.0, *) {
+            return UIApplication.shared
+                .connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first(where: \.isKeyWindow)
+        } else {
+            return UIApplication.shared.keyWindow
+        }
+    }
 }
 
 #endif

--- a/Tests/UIKitTests/UIApplicationExtensionsTests.swift
+++ b/Tests/UIKitTests/UIApplicationExtensionsTests.swift
@@ -1,0 +1,118 @@
+// UIApplicationExtensionsTests.swift - Copyright 2025 SwifterSwift
+
+@testable import SwifterSwift
+import XCTest
+
+#if canImport(UIKit) && os(iOS)
+import UIKit
+
+@MainActor
+final class UIApplicationExtensionsTests: XCTestCase {
+    
+    func testTopSafeAreaInsets() {
+        let topInsets = UIApplication.shared.topSafeAreaInsets
+        XCTAssertGreaterThanOrEqual(topInsets, 0)
+        
+        // Test that it returns a reasonable value (should be 0 or positive)
+        // On devices with notch, this should be > 0
+        // On devices without notch, this should be 0 or status bar height
+        XCTAssertLessThanOrEqual(topInsets, 100) // Reasonable upper bound
+    }
+    
+    func testBottomSafeAreaInsets() {
+        let bottomInsets = UIApplication.shared.bottomSafeAreaInsets
+        XCTAssertGreaterThanOrEqual(bottomInsets, 0)
+        
+        // Test that it returns a reasonable value
+        // On devices with home indicator, this should be > 0
+        // On devices without home indicator, this should be 0
+        XCTAssertLessThanOrEqual(bottomInsets, 50) // Reasonable upper bound
+    }
+    
+    func testLeftSafeAreaInsets() {
+        let leftInsets = UIApplication.shared.leftSafeAreaInsets
+        XCTAssertGreaterThanOrEqual(leftInsets, 0)
+        
+        // Test that it returns a reasonable value
+        // Most devices should have 0 left safe area insets
+        XCTAssertLessThanOrEqual(leftInsets, 50) // Reasonable upper bound
+    }
+    
+    func testRightSafeAreaInsets() {
+        let rightInsets = UIApplication.shared.rightSafeAreaInsets
+        XCTAssertGreaterThanOrEqual(rightInsets, 0)
+        
+        // Test that it returns a reasonable value
+        // Most devices should have 0 right safe area insets
+        XCTAssertLessThanOrEqual(rightInsets, 50) // Reasonable upper bound
+    }
+    
+    func testHorizontalSafeAreaInsets() {
+        let horizontalInsets = UIApplication.shared.horizontalSafeAreaInsets
+        XCTAssertGreaterThanOrEqual(horizontalInsets, 0)
+        
+        // Horizontal insets should be the sum of left and right
+        let leftInsets = UIApplication.shared.leftSafeAreaInsets
+        let rightInsets = UIApplication.shared.rightSafeAreaInsets
+        XCTAssertEqual(horizontalInsets, leftInsets + rightInsets)
+        
+        // Test that it returns a reasonable value
+        XCTAssertLessThanOrEqual(horizontalInsets, 100) // Reasonable upper bound
+    }
+    
+    func testVerticalSafeAreaInsets() {
+        let verticalInsets = UIApplication.shared.verticalSafeAreaInsets
+        XCTAssertGreaterThanOrEqual(verticalInsets, 0)
+        
+        // Vertical insets should be the sum of top and bottom
+        let topInsets = UIApplication.shared.topSafeAreaInsets
+        let bottomInsets = UIApplication.shared.bottomSafeAreaInsets
+        XCTAssertEqual(verticalInsets, topInsets + bottomInsets)
+        
+        // Test that it returns a reasonable value
+        XCTAssertLessThanOrEqual(verticalInsets, 150) // Reasonable upper bound
+    }
+    
+    func testSafeAreaInsetsConsistency() {
+        // Test that all safe area insets are consistent with each other
+        let topInsets = UIApplication.shared.topSafeAreaInsets
+        let bottomInsets = UIApplication.shared.bottomSafeAreaInsets
+        let leftInsets = UIApplication.shared.leftSafeAreaInsets
+        let rightInsets = UIApplication.shared.rightSafeAreaInsets
+        let horizontalInsets = UIApplication.shared.horizontalSafeAreaInsets
+        let verticalInsets = UIApplication.shared.verticalSafeAreaInsets
+        
+        // Verify horizontal calculation
+        XCTAssertEqual(horizontalInsets, leftInsets + rightInsets)
+        
+        // Verify vertical calculation
+        XCTAssertEqual(verticalInsets, topInsets + bottomInsets)
+        
+        // All values should be non-negative
+        XCTAssertGreaterThanOrEqual(topInsets, 0)
+        XCTAssertGreaterThanOrEqual(bottomInsets, 0)
+        XCTAssertGreaterThanOrEqual(leftInsets, 0)
+        XCTAssertGreaterThanOrEqual(rightInsets, 0)
+        XCTAssertGreaterThanOrEqual(horizontalInsets, 0)
+        XCTAssertGreaterThanOrEqual(verticalInsets, 0)
+    }
+    
+    func testSafeAreaInsetsWithKeyWindow() {
+        // Test that the safe area insets match what we get from the key window
+        guard let keyWindow = UIWindow.keyWindow else {
+            XCTFail("Key window should be available during tests")
+            return
+        }
+        
+        let windowSafeAreaInsets = keyWindow.safeAreaInsets
+        
+        XCTAssertEqual(UIApplication.shared.topSafeAreaInsets, windowSafeAreaInsets.top)
+        XCTAssertEqual(UIApplication.shared.bottomSafeAreaInsets, windowSafeAreaInsets.bottom)
+        XCTAssertEqual(UIApplication.shared.leftSafeAreaInsets, windowSafeAreaInsets.left)
+        XCTAssertEqual(UIApplication.shared.rightSafeAreaInsets, windowSafeAreaInsets.right)
+        XCTAssertEqual(UIApplication.shared.horizontalSafeAreaInsets, windowSafeAreaInsets.horizontal)
+        XCTAssertEqual(UIApplication.shared.verticalSafeAreaInsets, windowSafeAreaInsets.vertical)
+    }
+}
+
+#endif

--- a/Tests/UIKitTests/UIWindowExtensionsTests.swift
+++ b/Tests/UIKitTests/UIWindowExtensionsTests.swift
@@ -32,6 +32,15 @@ final class UIWindowExtensionsTests: XCTestCase {
 
         waitForExpectations(timeout: 1)
     }
+    
+    func testKeyWindow() {
+        // Test that keyWindow returns a window (should be the test window)
+        let keyWindow = UIWindow.keyWindow
+        XCTAssertNotNil(keyWindow)
+        
+        // Test that the returned window is actually a UIWindow
+        XCTAssertTrue(keyWindow is UIWindow)
+    }
 }
 
 #endif


### PR DESCRIPTION
- Add UIApplication extensions for easy access to safe area insets:
  * topSafeAreaInsets, bottomSafeAreaInsets
  * leftSafeAreaInsets, rightSafeAreaInsets
  * horizontalSafeAreaInsets, verticalSafeAreaInsets
- Add UIWindow.keyWindow static property for cross-version key window access
- Include comprehensive documentation for all new properties
- Handle iOS 13+ window scenes and legacy iOS versions

This provides convenient access to safe area insets for UI layout adjustments and a reliable way to get the current key window across iOS versions.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
