### PR TITLE
Feature: CGRect extensions corners and edges + center setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ## Upcoming Release
 ### Breaking Change
 ### Added
+- **CGRect**
+  - Added setter for `center` property for easier modification of the rectangle geometry. [#1245](https://github.com/SwifterSwift/SwifterSwift/pull/1245) by [ihar-shalouski](https://github.com/ihar-shalouski)
+  - Added settable properties `topLeft`, `topCenter`, `topRight`, `centerLeft`, `centerRight`, `bottomLeft`, `bottomCenter`, `bottomRight` for easier modification/aligning of the rectangle geometry. [#1245](https://github.com/SwifterSwift/SwifterSwift/pull/1245) by [ihar-shalouski](https://github.com/ihar-shalouski)
 ### Changed
 ### Fixed
 ### Deprecated

--- a/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
@@ -6,8 +6,21 @@ import CoreGraphics
 // MARK: - Properties
 
 public extension CGRect {
-    /// SwifterSwift: Return center of rect.
-    var center: CGPoint { CGPoint(x: midX, y: midY) }
+    /// SwifterSwift: Center of the rect.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.center) // (25.0, 30.0)
+    ///     rect.center = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (35.0, 40.0, 30.0, 40.0)
+    ///
+    var center: CGPoint {
+        get {
+            CGPoint(x: midX, y: midY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - midX, dy: newValue.y - midY)
+        }
+    }
 }
 
 // MARK: - Initializers

--- a/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
+++ b/Sources/SwifterSwift/CoreGraphics/CGRectExtensions.swift
@@ -21,6 +21,134 @@ public extension CGRect {
             self = offsetBy(dx: newValue.x - midX, dy: newValue.y - midY)
         }
     }
+
+    /// SwifterSwift: Top left corner of the rect.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.topLeft) // (10.0, 20.0)
+    ///     rect.topLeft = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (50.0, 60.0, 30.0, 40.0)
+    ///
+    var topLeft: CGPoint {
+        get {
+            CGPoint(x: minX, y: minY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - minX, dy: newValue.y - minY)
+        }
+    }
+
+    /// SwifterSwift: Center of the top rect edge.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.topCenter) // (25.0, 20.0)
+    ///     rect.topCenter = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (35.0, 60.0, 30.0, 40.0)
+    ///
+    var topCenter: CGPoint {
+        get {
+            CGPoint(x: midX, y: minY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - midX, dy: newValue.y - minY)
+        }
+    }
+
+    /// SwifterSwift: Top right corner of the rect.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.topRight) // (40.0, 20.0)
+    ///     rect.topRight = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (20.0, 60.0, 30.0, 40.0)
+    ///
+    var topRight: CGPoint {
+        get {
+            CGPoint(x: maxX, y: minY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - maxX, dy: newValue.y - minY)
+        }
+    }
+
+    /// SwifterSwift: Center of the left rect edge.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.centerLeft) // (10.0, 40.0)
+    ///     rect.centerLeft = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (50.0, 40.0, 30.0, 40.0)
+    ///
+    var centerLeft: CGPoint {
+        get {
+            CGPoint(x: minX, y: midY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - minX, dy: newValue.y - midY)
+        }
+    }
+
+    /// SwifterSwift: Center of the right rect edge.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.centerRight) // (40.0, 40.0)
+    ///     rect.centerRight = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (20.0, 40.0, 30.0, 40.0)
+    ///
+    var centerRight: CGPoint {
+        get {
+            CGPoint(x: maxX, y: midY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - maxX, dy: newValue.y - midY)
+        }
+    }
+
+    /// SwifterSwift: Bottom left corner of the rect.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.bottomLeft) // (10.0, 60.0)
+    ///     rect.bottomLeft = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (50.0, 20.0, 30.0, 40.0)
+    ///
+    var bottomLeft: CGPoint {
+        get {
+            CGPoint(x: minX, y: maxY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - minX, dy: newValue.y - maxY)
+        }
+    }
+
+    /// SwifterSwift: Center of the top rect edge.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.bottomCenter) // (25.0, 60.0)
+    ///     rect.bottomCenter = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (35.0, 20.0, 30.0, 40.0)
+    ///
+    var bottomCenter: CGPoint {
+        get {
+            CGPoint(x: midX, y: maxY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - midX, dy: newValue.y - maxY)
+        }
+    }
+
+    /// SwifterSwift: Top right corner of the rect.
+    ///
+    ///     var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+    ///     print(rect.bottomRight) // (40.0, 60.0)
+    ///     rect.bottomRight = CGPoint(x: 50, y: 60)
+    ///     print(rect) // (20.0, 20.0, 30.0, 40.0)
+    ///
+    var bottomRight: CGPoint {
+        get {
+            CGPoint(x: maxX, y: maxY)
+        }
+        set {
+            self = offsetBy(dx: newValue.x - maxX, dy: newValue.y - maxY)
+        }
+    }
 }
 
 // MARK: - Initializers

--- a/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
@@ -7,11 +7,16 @@ import XCTest
 import CoreGraphics
 
 final class CGRectExtensionsTests: XCTestCase {
-    func testCenter() {
+    func testCenterGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        let center = rect.center
-        XCTAssertEqual(center.x, 25)
-        XCTAssertEqual(center.y, 40)
+        XCTAssertEqual(rect.center, CGPointMake(25, 40))
+    }
+
+    func testCenterSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.center = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 35, y: 40, width: 30, height: 40))
+        XCTAssertEqual(rect.center, CGPoint(x: 50, y: 60))
     }
 
     func testInitWithCenterAndSize() {

--- a/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
@@ -19,6 +19,102 @@ final class CGRectExtensionsTests: XCTestCase {
         XCTAssertEqual(rect.center, CGPoint(x: 50, y: 60))
     }
 
+    func testTopLeftGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.topLeft, CGPointMake(10, 20))
+    }
+
+    func testTopLeftSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.topLeft = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 50, y: 60, width: 30, height: 40))
+        XCTAssertEqual(rect.topLeft, CGPoint(x: 50, y: 60))
+    }
+
+    func testTopCenterGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.topCenter, CGPointMake(25, 20))
+    }
+
+    func testTopCenterSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.topCenter = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 35, y: 60, width: 30, height: 40))
+        XCTAssertEqual(rect.topCenter, CGPoint(x: 50, y: 60))
+    }
+
+    func testTopRightGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.topRight, CGPointMake(40, 20))
+    }
+
+    func testTopRightSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.topRight = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 20, y: 60, width: 30, height: 40))
+        XCTAssertEqual(rect.topRight, CGPoint(x: 50, y: 60))
+    }
+
+    func testCenterLeftGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.centerLeft, CGPointMake(10, 40))
+    }
+
+    func testCenterLeftSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.centerLeft = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 50, y: 40, width: 30, height: 40))
+        XCTAssertEqual(rect.centerLeft, CGPoint(x: 50, y: 60))
+    }
+
+    func testCenterRightGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.centerRight, CGPointMake(40, 40))
+    }
+
+    func testCenterRightSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.centerRight = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 20, y: 40, width: 30, height: 40))
+        XCTAssertEqual(rect.centerRight, CGPoint(x: 50, y: 60))
+    }
+
+    func testBottomLeftGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.bottomLeft, CGPointMake(10, 60))
+    }
+
+    func testBottomLeftSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.bottomLeft = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 50, y: 20, width: 30, height: 40))
+        XCTAssertEqual(rect.bottomLeft, CGPoint(x: 50, y: 60))
+    }
+
+    func testBottomCenterGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.bottomCenter, CGPointMake(25, 60))
+    }
+
+    func testBottomCenterSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.bottomCenter = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 35, y: 20, width: 30, height: 40))
+        XCTAssertEqual(rect.bottomCenter, CGPoint(x: 50, y: 60))
+    }
+
+    func testBottomRightGet() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        XCTAssertEqual(rect.bottomRight, CGPointMake(40, 60))
+    }
+
+    func testBottomRightSet() {
+        var rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+        rect.bottomRight = CGPoint(x: 50, y: 60)
+        XCTAssertEqual(rect, CGRect(x: 20, y: 20, width: 30, height: 40))
+        XCTAssertEqual(rect.bottomRight, CGPoint(x: 50, y: 60))
+    }
+
     func testInitWithCenterAndSize() {
         let rect = CGRect(center: CGPoint(x: 10, y: 20), size: CGSize(width: 30, height: 40))
         XCTAssertEqual(rect.midX, 10)

--- a/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
+++ b/Tests/CoreGraphicsTests/CGRectExtensionsTests.swift
@@ -9,7 +9,7 @@ import CoreGraphics
 final class CGRectExtensionsTests: XCTestCase {
     func testCenterGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.center, CGPointMake(25, 40))
+        XCTAssertEqual(rect.center, CGPoint(x: 25, y: 40))
     }
 
     func testCenterSet() {
@@ -21,7 +21,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testTopLeftGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.topLeft, CGPointMake(10, 20))
+        XCTAssertEqual(rect.topLeft, CGPoint(x: 10, y: 20))
     }
 
     func testTopLeftSet() {
@@ -33,7 +33,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testTopCenterGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.topCenter, CGPointMake(25, 20))
+        XCTAssertEqual(rect.topCenter, CGPoint(x: 25, y: 20))
     }
 
     func testTopCenterSet() {
@@ -45,7 +45,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testTopRightGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.topRight, CGPointMake(40, 20))
+        XCTAssertEqual(rect.topRight, CGPoint(x: 40, y: 20))
     }
 
     func testTopRightSet() {
@@ -57,7 +57,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testCenterLeftGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.centerLeft, CGPointMake(10, 40))
+        XCTAssertEqual(rect.centerLeft, CGPoint(x: 10, y: 40))
     }
 
     func testCenterLeftSet() {
@@ -69,7 +69,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testCenterRightGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.centerRight, CGPointMake(40, 40))
+        XCTAssertEqual(rect.centerRight, CGPoint(x: 40, y: 40))
     }
 
     func testCenterRightSet() {
@@ -81,7 +81,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testBottomLeftGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.bottomLeft, CGPointMake(10, 60))
+        XCTAssertEqual(rect.bottomLeft, CGPoint(x: 10, y: 60))
     }
 
     func testBottomLeftSet() {
@@ -93,7 +93,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testBottomCenterGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.bottomCenter, CGPointMake(25, 60))
+        XCTAssertEqual(rect.bottomCenter, CGPoint(x: 25, y: 60))
     }
 
     func testBottomCenterSet() {
@@ -105,7 +105,7 @@ final class CGRectExtensionsTests: XCTestCase {
 
     func testBottomRightGet() {
         let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
-        XCTAssertEqual(rect.bottomRight, CGPointMake(40, 60))
+        XCTAssertEqual(rect.bottomRight, CGPoint(x: 40, y: 60))
     }
 
     func testBottomRightSet() {


### PR DESCRIPTION
Added a setter for `CGRect.center`.
Added `CGRect` corners and edges getters/setters. `topLeft`, `topCenter`, `topRight`, `centerLeft`, `centerRight`, `bottomLeft`, `bottomCenter`, `bottomRight`.

## Checklist
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
