### PR TITLE
fix: Avoid crash for fonts without bold/italic traits, fallback to self like SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Added
 ### Changed
 ### Fixed
+- **UIFont**
+  - Avoid crash for fonts without bold/italic traits, fallback to self like SwiftUI. [#1246](https://github.com/SwifterSwift/SwifterSwift/pull/1246) by [weihas](https://github.com/weihas)
 ### Deprecated
 ### Removed
 

--- a/Sources/SwifterSwift/UIKit/UIFontExtensions.swift
+++ b/Sources/SwifterSwift/UIKit/UIFontExtensions.swift
@@ -8,12 +8,14 @@ import UIKit
 public extension UIFont {
     /// SwifterSwift: Font as bold font.
     var bold: UIFont {
-        return UIFont(descriptor: fontDescriptor.withSymbolicTraits(.traitBold)!, size: 0)
+        guard let descriptor = fontDescriptor.withSymbolicTraits(.traitBold) else { return self }
+        return UIFont(descriptor: descriptor, size: 0)
     }
 
     /// SwifterSwift: Font as italic font.
     var italic: UIFont {
-        return UIFont(descriptor: fontDescriptor.withSymbolicTraits(.traitItalic)!, size: 0)
+        guard let descriptor = fontDescriptor.withSymbolicTraits(.traitItalic) else { return self }
+        return UIFont(descriptor: descriptor, size: 0)
     }
 
     /// SwifterSwift: Font as monospaced font.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.6.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
