### PR TITLE
Fix doc for Sequence.any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
 ### Fixed
 - **UIFont**
   - Avoid crash for fonts without bold/italic traits, fallback to self like SwiftUI. [#1246](https://github.com/SwifterSwift/SwifterSwift/pull/1246) by [weihas](https://github.com/weihas)
+- **Sequence**
+  - Fixed documentation for `any`.
 ### Deprecated
 ### Removed
 

--- a/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/SequenceExtensions.swift
@@ -25,11 +25,11 @@ public extension Sequence {
 
     /// SwifterSwift: Check if any element in collection match a condition.
     ///
-    ///        [2, 2, 4].any(matching: {$0 % 2 == 0}) -> false
-    ///        [1, 3, 5, 7].any(matching: {$0 % 2 == 0}) -> true
+    ///        [2, 2, 4].any(matching: {$0 % 2 == 0}) -> true
+    ///        [1, 3, 5, 7].any(matching: {$0 % 2 == 0}) -> false
     ///
     /// - Parameter condition: condition to evaluate each element against.
-    /// - Returns: true when no elements in the array match the specified condition.
+    /// - Returns: true when at least one element in the array match the specified condition.
     func any(matching condition: (Element) throws -> Bool) rethrows -> Bool {
         return try contains { try condition($0) }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the documentation for Sequence's `any`. :rocket:
I think it was copied from `none` and not corrected.
No code changes.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.6.
- [ ] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [x] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
