### PR TITLE
Add Result extensions

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/ResultExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/ResultExtensions.swift
@@ -1,0 +1,52 @@
+// ResultExtensions.swift - Copyright 2025 SwifterSwift
+
+// MARK: - Properties
+
+public extension Result {
+    /// SwifterSwift: Returns the success value, or `nil` if the result is a failure.
+    ///
+    ///     let success: Result<Int, Error> = .success(42)
+    ///     success.success // Optional(42)
+    ///
+    ///     let failure: Result<Int, Error> = .failure(SomeError())
+    ///     failure.success // nil
+    var success: Success? {
+        guard case let .success(value) = self else { return nil }
+        return value
+    }
+
+    /// SwifterSwift: Returns the failure error, or `nil` if the result is a success.
+    ///
+    ///     let success: Result<Int, Error> = .success(42)
+    ///     success.failure // nil
+    ///
+    ///     let failure: Result<Int, Error> = .failure(SomeError())
+    ///     failure.failure // Optional(SomeError())
+    var failure: Failure? {
+        guard case let .failure(error) = self else { return nil }
+        return error
+    }
+
+    /// SwifterSwift: Returns `true` if the result is a success.
+    ///
+    ///     let success: Result<Int, Error> = .success(42)
+    ///     success.isSuccess // true
+    ///
+    ///     let failure: Result<Int, Error> = .failure(SomeError())
+    ///     failure.isSuccess // false
+    var isSuccess: Bool {
+        guard case .success = self else { return false }
+        return true
+    }
+
+    /// SwifterSwift: Returns `true` if the result is a failure.
+    ///
+    ///     let success: Result<Int, Error> = .success(42)
+    ///     success.isFailure // false
+    ///
+    ///     let failure: Result<Int, Error> = .failure(SomeError())
+    ///     failure.isFailure // true
+    var isFailure: Bool {
+        !isSuccess
+    }
+}

--- a/Tests/SwiftStdlibTests/ResultExtensionsTests.swift
+++ b/Tests/SwiftStdlibTests/ResultExtensionsTests.swift
@@ -1,0 +1,44 @@
+// ResultExtensionsTests.swift - Copyright 2025 SwifterSwift
+
+@testable import SwifterSwift
+import XCTest
+
+private enum TestError: Error, Equatable {
+    case generic
+}
+
+final class ResultExtensionsTests: XCTestCase {
+    // MARK: - Properties
+
+    func testSuccess() {
+        let successResult: Result<Int, TestError> = .success(42)
+        XCTAssertEqual(successResult.success, 42)
+
+        let failureResult: Result<Int, TestError> = .failure(.generic)
+        XCTAssertNil(failureResult.success)
+    }
+
+    func testFailure() {
+        let successResult: Result<Int, TestError> = .success(42)
+        XCTAssertNil(successResult.failure)
+
+        let failureResult: Result<Int, TestError> = .failure(.generic)
+        XCTAssertEqual(failureResult.failure, .generic)
+    }
+
+    func testIsSuccess() {
+        let successResult: Result<Int, TestError> = .success(42)
+        XCTAssertTrue(successResult.isSuccess)
+
+        let failureResult: Result<Int, TestError> = .failure(.generic)
+        XCTAssertFalse(failureResult.isSuccess)
+    }
+
+    func testIsFailure() {
+        let successResult: Result<Int, TestError> = .success(42)
+        XCTAssertFalse(successResult.isFailure)
+
+        let failureResult: Result<Int, TestError> = .failure(.generic)
+        XCTAssertTrue(failureResult.isFailure)
+    }
+}


### PR DESCRIPTION
Adds convenience properties on `Result`: `success`, `failure`, `isSuccess`, `isFailure`. Includes full test coverage and doc comments following SwifterSwift conventions.