### PR TITLE
Add `numberOfDaysInYear` computed property to `Date`

### DIFF
--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -359,6 +359,15 @@ public extension Date {
         return calendar.isDate(self, equalTo: Date(), toGranularity: .year)
     }
 
+    /// SwifterSwift: Number of days in the year of the date.
+    ///
+    ///     Date().numberOfDaysInYear -> 365
+    ///
+    var numberOfDaysInYear: Int {
+        guard let range = calendar.range(of: .day, in: .year, for: self) else { return 365 }
+        return range.count
+    }
+
     /// SwifterSwift: ISO8601 string of format (yyyy-MM-dd'T'HH:mm:ss.SSS) from date.
     ///
     /// 	Date().iso8601String -> "2017-01-12T14:51:29.574Z"

--- a/Tests/FoundationTests/DateExtensionsTests.swift
+++ b/Tests/FoundationTests/DateExtensionsTests.swift
@@ -346,6 +346,16 @@ final class DateExtensionsTests: XCTestCase {
         XCTAssertFalse(dateOneYearFromNow.isInCurrentYear)
     }
 
+    func testNumberOfDaysInYear() {
+        // 2020 is a leap year
+        let leapYearDate = Date(timeIntervalSince1970: 1_577_836_800) // 2020-01-01
+        XCTAssertEqual(leapYearDate.numberOfDaysInYear, 366)
+
+        // 2019 is not a leap year
+        let normalYearDate = Date(timeIntervalSince1970: 1_546_300_800) // 2019-01-01
+        XCTAssertEqual(normalYearDate.numberOfDaysInYear, 365)
+    }
+
     func testIso8601String() {
         let date = Date(timeIntervalSince1970: 512) // 1970-01-01T00:08:32.000Z
         XCTAssertEqual(date.iso8601String, "1970-01-01T00:08:32.000Z")


### PR DESCRIPTION
## Description

Adds a `numberOfDaysInYear` computed property to `Date` that returns the total number of days in the date's year (365 or 366 for leap years).

```swift
let date = Date() // 2026
date.numberOfDaysInYear // 365

let leapDate = ... // 2024-03-15
leapDate.numberOfDaysInYear // 366
```

## Changes
- Added `numberOfDaysInYear` computed property in `DateExtensions.swift`
- Added tests for both leap and non-leap years

Closes #552