### PR TITLE
Add isInCurrentHour, ageInYears, isBirthdayToday to Date extensions

### DIFF
--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -516,7 +516,7 @@ public extension Date {
 
     /// SwifterSwift: Check if the date falls on the same month and day as today (birthday check).
     ///
-    /// // For a person born on March 13:
+    /// // For a person born on March 13, evaluated on March 13:
     /// Date(year: 1990, month: 3, day: 13)!.isBirthdayToday -> true
     ///
     var isBirthdayToday: Bool {

--- a/Sources/SwifterSwift/Foundation/DateExtensions.swift
+++ b/Sources/SwifterSwift/Foundation/DateExtensions.swift
@@ -497,6 +497,36 @@ public extension Date {
     var unixTimestamp: Double {
         return timeIntervalSince1970
     }
+
+        /// SwifterSwift: Check if date is within the current hour.
+    ///
+    /// Date().isInCurrentHour -> true
+    ///
+    var isInCurrentHour: Bool {
+        return calendar.isDate(self, equalTo: Date(), toGranularity: .hour)
+    }
+
+    /// SwifterSwift: The age in years from a given date to today.
+    ///
+    /// Date(year: 1990, month: 1, day: 1)!.ageInYears -> 35
+    ///
+    var ageInYears: Int {
+        return calendar.dateComponents([.year], from: self, to: Date()).year ?? 0
+    }
+
+    /// SwifterSwift: Check if the date falls on the same month and day as today (birthday check).
+    ///
+    /// // For a person born on March 13:
+    /// Date(year: 1990, month: 3, day: 13)!.isBirthdayToday -> true
+    ///
+    var isBirthdayToday: Bool {
+        let today = Date()
+        let components: Set<Calendar.Component> = [.month, .day]
+        let selfComponents = calendar.dateComponents(components, from: self)
+        let todayComponents = calendar.dateComponents(components, from: today)
+        return selfComponents.month == todayComponents.month &&
+            selfComponents.day == todayComponents.day
+    }
 }
 
 // MARK: - Methods


### PR DESCRIPTION
## Summary

Adds 3 new computed properties to `Date` extension that are missing from the current codebase:

- `isInCurrentHour` — Returns `true` if the date falls within the current hour. Follows the existing pattern of `isInCurrentWeek`, `isInCurrentMonth`, `isInCurrentYear`.
- `ageInYears` — Returns the number of full years from the date to today. Extremely common use case for profile/health apps.
- `isBirthdayToday` — Returns `true` if the month and day of the date match today's month and day. Useful for birthday reminder features.

## Checklist
- [x] I checked the Contributing Guidelines before creating this request.
- [x] New extensions are written in Swift 6.0+.
- [x] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+.
- [x] All extensions have a **clear** comments explaining their functionality.
- [x] All extensions are declared as **public**.